### PR TITLE
Update Wallet to Point to Testnet URLs

### DIFF
--- a/src/app/templates/DelegateSettings.tsx
+++ b/src/app/templates/DelegateSettings.tsx
@@ -6,7 +6,7 @@ import { T } from 'lib/i18n/react';
 import { GeneralSettingsSelectors } from './GeneralSettings.selectors';
 
 export const DELEGATE_PROOF_STORAGE_KEY = 'delegate_proof_setting_key';
-export const DEFAULT_DELEGATE_PROOF = false;
+export const DEFAULT_DELEGATE_PROOF = true;
 
 export function setDelegateProofSetting(enabled: boolean) {
   try {

--- a/src/lib/miden-chain/constants.ts
+++ b/src/lib/miden-chain/constants.ts
@@ -8,11 +8,12 @@ export enum MIDEN_NETWORK_NAME {
 
 export const MIDEN_NETWORK_ENDPOINTS = new Map<string, string>([
   [MIDEN_NETWORK_NAME.MAINNET, 'https://api.miden.io'], // Placeholder
-  [MIDEN_NETWORK_NAME.TESTNET, 'https://testnet.miden.io/'],
+  [MIDEN_NETWORK_NAME.TESTNET, 'http://18.203.155.106:57291'],
   [MIDEN_NETWORK_NAME.LOCALNET, 'http://localhost:57291']
 ]);
 
 export const MIDEN_PROVING_ENDPOINTS = new Map<string, string>([
+  [MIDEN_NETWORK_NAME.TESTNET, 'http://18.118.151.210:8082'],
   [MIDEN_NETWORK_NAME.LOCALNET, 'http://localhost:50051']
 ]);
 
@@ -31,5 +32,5 @@ export enum MidenTokens {
 }
 
 export const TOKEN_MAPPING = {
-  [MidenTokens.Miden]: { faucetId: '0x298e0de55702b244' }
+  [MidenTokens.Miden]: { faucetId: '0x29b86f9443ad907a' }
 };

--- a/src/lib/miden/sdk/miden-client-interface.ts
+++ b/src/lib/miden/sdk/miden-client-interface.ts
@@ -19,16 +19,16 @@ export class MidenClientInterface {
     this.webClient = webClient;
   }
 
-  static async create(delegateProving: boolean = false) {
+  static async create(delegateProving: boolean = true) {
     const webClient = new WebClient();
 
     if (delegateProving) {
       await webClient.create_client(
-        MIDEN_NETWORK_ENDPOINTS.get(MIDEN_NETWORK_NAME.LOCALNET)!,
-        MIDEN_PROVING_ENDPOINTS.get(MIDEN_NETWORK_NAME.LOCALNET)!
+        MIDEN_NETWORK_ENDPOINTS.get(MIDEN_NETWORK_NAME.TESTNET)!,
+        MIDEN_PROVING_ENDPOINTS.get(MIDEN_NETWORK_NAME.TESTNET)!
       );
     } else {
-      await webClient.create_client(MIDEN_NETWORK_ENDPOINTS.get(MIDEN_NETWORK_NAME.LOCALNET)!);
+      await webClient.create_client(MIDEN_NETWORK_ENDPOINTS.get(MIDEN_NETWORK_NAME.TESTNET)!);
     }
 
     return new MidenClientInterface(webClient);


### PR DESCRIPTION
# Summary
This PR modifies the endpoints used in the wallet to point to the official Miden Testnet Node, Prover Node, and deployed Faucet. Additionally, it sets the client to use delegated proving by default. 