### PR TITLE
fix onboarding flow to not reopen on popup click.

### DIFF
--- a/src/app/env.ts
+++ b/src/app/env.ts
@@ -59,11 +59,11 @@ export const OpenInFullPage: FC = () => {
   const appEnv = useAppEnv();
 
   useLayoutEffect(() => {
-    const urls = onBoardingUrls();
+    const urls = onboardingUrls();
     browser.tabs.query({}).then(tabs => {
-      const onboardingTab = tabs.find(t => urls.includes(t.url!));
-      if (onboardingTab) {
-        browser.tabs.update(onboardingTab.id!, { active: true });
+      const onboardingTab = tabs.find(t => t.url && urls.includes(t.url));
+      if (onboardingTab?.id) {
+        browser.tabs.update(onboardingTab.id, { active: true });
         if (appEnv.popup) {
           window.close();
         }
@@ -80,7 +80,7 @@ export const OpenInFullPage: FC = () => {
   return null;
 };
 
-export const onBoardingUrls = () => {
+export const onboardingUrls = () => {
   const hashes = [
     '',
     '/',

--- a/src/screens/onboarding/navigator.tsx
+++ b/src/screens/onboarding/navigator.tsx
@@ -142,11 +142,7 @@ export const OnboardingFlow: FC<OnboardingFlowProps> = ({
     const onSelectTransactionTypeSubmit = () =>
       onForwardAction?.({ id: 'select-transaction-type', payload: 'private' });
 
-    const onConfirmSubmit = () => {
-      // onboarding complete
-      console.log('onboarding complete, clearing session storage');
-      onForwardAction?.({ id: 'confirmation' });
-    };
+    const onConfirmSubmit = () => onForwardAction?.({ id: 'confirmation' });
 
     const onImportSeedPhraseSubmit = (seedPhrase: string) =>
       onForwardAction?.({ id: 'import-seed-phrase-submit', payload: seedPhrase });


### PR DESCRIPTION
Currently if the onboarding is in progress and the user opens the extension popup that will open another onboarding tab.

This PR fixes this behaviour by checking if the onboarding tab was already open if yes it redirects to that tab if no it opens the full page