### PR TITLE
ci: add code coverage check workflow for PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,34 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+      - next
+      - 'mw-**'
+      - 'feat/**'
+
+jobs:
+  coverage:
+    name: Coverage Check (80% minimum)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v3
+
+      - name: Use Node 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Run Install
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install
+
+      - name: Run Coverage Check
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: test:coverage

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,14 @@
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
   coverageProvider: 'v8',
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80
+    }
+  },
   moduleNameMapper: {
     '^lib/(.*)$': '<rootDir>/src/lib/$1',
     '^shared/(.*)$': '<rootDir>/src/shared/$1',


### PR DESCRIPTION
Add a separate CI workflow that enforces 80% minimum coverage for all metrics (branches, functions, lines, statements) on pull requests.