### PR TITLE
fix: show custom transactions on activities page

### DIFF
--- a/src/lib/miden/activity/helpers.ts
+++ b/src/lib/miden/activity/helpers.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 
 import { ITransaction } from '../db/types';
 import { getBech32AddressFromAccountId } from '../sdk/helpers';
+import { compareAccountIds } from './utils';
 
 export function tryParseTokenTransfers(
   parameters: any,
@@ -121,8 +122,9 @@ export const interpretTransactionResult = <K extends keyof ITransaction>(
   if (inputFaucetIds.length === 1 && outputFaucetIds.length === 0) {
     type = 'consume';
     const sender = getBech32AddressFromAccountId(inputNotes[0].note().metadata().sender());
-    displayMessage = sender === transaction.accountId ? 'Reclaimed' : 'Received';
-    if (sender !== transaction.accountId) {
+    const isReclaimed = compareAccountIds(sender, transaction.accountId);
+    displayMessage = isReclaimed ? 'Reclaimed' : 'Received';
+    if (!isReclaimed) {
       secondaryAccountId = sender;
     }
 

--- a/src/lib/miden/activity/transactions.ts
+++ b/src/lib/miden/activity/transactions.ts
@@ -174,7 +174,7 @@ export const completeConsumeTransaction = async (id: string, result: Transaction
   const executedTransaction = result.executedTransaction();
 
   const dbTransaction = await Repo.transactions.where({ id }).first();
-  const reclaimed = dbTransaction?.accountId === sender;
+  const reclaimed = compareAccountIds(dbTransaction?.accountId ?? '', sender);
   const displayMessage = reclaimed ? 'Reclaimed' : 'Received';
   const secondaryAccountId = reclaimed ? undefined : sender;
   const asset = note.assets().fungibleAssets()[0];
@@ -392,7 +392,7 @@ export const getCompletedTransactions = async (
     transactions = transactions.concat(failedTransactions);
   }
   transactions.sort((tx1, tx2) => (tx1.completedAt || tx1.initiatedAt) - (tx2.completedAt || tx2.initiatedAt));
-  // transaction may or may not have the note tag
+  // Compare ignoring note tag suffix since stored vs queried account IDs may differ
   transactions = transactions.filter(tx => compareAccountIds(tx.accountId, accountId));
   return transactions.slice(offset, limit);
 };

--- a/src/lib/miden/activity/utils.test.ts
+++ b/src/lib/miden/activity/utils.test.ts
@@ -1,0 +1,52 @@
+import { compareAccountIds } from './utils';
+
+describe('compareAccountIds', () => {
+  it('returns true for identical IDs without tags', () => {
+    expect(compareAccountIds('acc1', 'acc1')).toBe(true);
+  });
+
+  it('returns true for identical IDs with matching tags', () => {
+    expect(compareAccountIds('acc1_tag', 'acc1_tag')).toBe(true);
+  });
+
+  it('returns true for same base ID with different tags', () => {
+    expect(compareAccountIds('acc1_tag1', 'acc1_tag2')).toBe(true);
+  });
+
+  it('returns true when one ID has tag and other does not', () => {
+    expect(compareAccountIds('acc1', 'acc1_tag')).toBe(true);
+    expect(compareAccountIds('acc1_tag', 'acc1')).toBe(true);
+  });
+
+  it('returns false for different base IDs', () => {
+    expect(compareAccountIds('acc1', 'acc2')).toBe(false);
+    expect(compareAccountIds('acc1_tag', 'acc2_tag')).toBe(false);
+  });
+
+  it('returns false when first ID is empty', () => {
+    expect(compareAccountIds('', 'acc1')).toBe(false);
+  });
+
+  it('returns false when second ID is empty', () => {
+    expect(compareAccountIds('acc1', '')).toBe(false);
+  });
+
+  it('returns false when both IDs are empty', () => {
+    expect(compareAccountIds('', '')).toBe(false);
+  });
+
+  it('returns false when first ID is null or undefined', () => {
+    expect(compareAccountIds(null as unknown as string, 'acc1')).toBe(false);
+    expect(compareAccountIds(undefined as unknown as string, 'acc1')).toBe(false);
+  });
+
+  it('returns false when second ID is null or undefined', () => {
+    expect(compareAccountIds('acc1', null as unknown as string)).toBe(false);
+    expect(compareAccountIds('acc1', undefined as unknown as string)).toBe(false);
+  });
+
+  it('handles IDs with multiple underscores correctly', () => {
+    expect(compareAccountIds('acc1_tag_extra', 'acc1_other')).toBe(true);
+    expect(compareAccountIds('acc1_tag_extra', 'acc1')).toBe(true);
+  });
+});

--- a/src/lib/miden/activity/utils.ts
+++ b/src/lib/miden/activity/utils.ts
@@ -1,4 +1,7 @@
-// Compares two AccountIds ingoring if any one of them has a missing note tag
+// Compares two AccountIds ignoring the optional note tag suffix (part after '_')
 export const compareAccountIds = (id1: string, id2: string): boolean => {
+  if (!id1 || !id2) {
+    return false;
+  }
   return id1.split('_')[0] === id2.split('_')[0];
 };


### PR DESCRIPTION
Fixes #57

It seems it was a way simple bug that custom transactions don't have the note tag attached the address. Now we see all the transactions when swapping in zoro attached image for reference 

<img width="613" height="652" alt="image" src="https://github.com/user-attachments/assets/e906ad73-dda9-42b2-a490-a49530e97370" />


