### PR TITLE
fix: disable all animations for Chrome extension

### DIFF
--- a/src/app/a11y/BootAnimation.tsx
+++ b/src/app/a11y/BootAnimation.tsx
@@ -2,6 +2,7 @@ import React, { FC, useLayoutEffect, useState } from 'react';
 
 import CSSTransition from 'react-transition-group/CSSTransition';
 
+import { isExtension } from 'lib/platform';
 import { PropsWithChildren } from 'lib/props-with-children';
 
 const BootAnimation: FC<PropsWithChildren> = ({ children }) => {
@@ -12,7 +13,7 @@ const BootAnimation: FC<PropsWithChildren> = ({ children }) => {
   }, [setBooted]);
 
   return (
-    <CSSTransition in={booted} timeout={200}>
+    <CSSTransition in={booted} timeout={isExtension() ? 0 : 200}>
       {children}
     </CSSTransition>
   );

--- a/src/app/atoms/CustomModal.tsx
+++ b/src/app/atoms/CustomModal.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import classNames from 'clsx';
 import Modal from 'react-modal';
 
+import { isExtension } from 'lib/platform';
 import { PropsWithChildren } from 'lib/props-with-children';
 
 export type CustomModalProps = Modal.Props & Partial<PropsWithChildren>;
@@ -23,7 +24,7 @@ const CustomModal: FC<CustomModalProps> = props => {
       isOpen={isOpen}
       className={classNames('bg-white rounded z-30 shadow-2xl', className)}
       appElement={rootElement}
-      closeTimeoutMS={200}
+      closeTimeoutMS={isExtension() ? 0 : 200}
       overlayClassName={classNames(
         'fixed inset-0 z-30',
         'bg-black bg-opacity-75',

--- a/src/app/layouts/FullScreenPage.tsx
+++ b/src/app/layouts/FullScreenPage.tsx
@@ -1,15 +1,20 @@
 import React, { FC, useEffect, useRef } from 'react';
 
+import { isExtension } from 'lib/platform';
 import { PropsWithChildren } from 'lib/props-with-children';
 
 /**
  * Wrapper for full-screen pages (Send, Receive, etc.) that slides in from the right.
+ * Animation is disabled for the Chrome extension.
  */
 const FullScreenPage: FC<PropsWithChildren> = ({ children }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!containerRef.current) return;
+
+    // Skip animation for Chrome extension
+    if (isExtension()) return;
 
     const el = containerRef.current;
     el.classList.add('mobile-page-enter');

--- a/src/components/Navigator.tsx
+++ b/src/components/Navigator.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, useState, useCallback, ReactNode, use
 
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { isExtension } from 'lib/platform';
+
 export type AnimationDirection = 'forward' | 'backward' | 'up' | 'down';
 export type AnimationIn = 'push' | 'present';
 export type AnimationOut = 'pop' | 'dismiss';
@@ -208,6 +210,9 @@ export const Navigator: React.FC<NavigatorProps> = ({
 }) => {
   const { direction, cardStack, routes, activeRoute, activeIndex, navigateTo } = useNavigator();
 
+  // Disable animations for Chrome extension
+  const effectiveDuration = isExtension() ? 0 : animationDuration;
+
   useEffect(() => {
     // const initialRoute = routes.find(r => r.name === initialRouteName);
     // console.log(initialRoute);
@@ -260,7 +265,7 @@ export const Navigator: React.FC<NavigatorProps> = ({
           exit="exitPosition"
           className="flex-1 flex"
           transition={{
-            duration: animationDuration,
+            duration: effectiveDuration,
             when: 'beforeChildren',
             ease: 'easeOut'
           }}

--- a/src/components/TabPicker.tsx
+++ b/src/components/TabPicker.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
 
 import classNames from 'clsx';
-import { motion, MotionContext } from 'framer-motion';
+import { motion, MotionConfig } from 'framer-motion';
 import { v4 as uuid } from 'uuid';
 
 import { Icon, IconName } from 'app/icons/v2';
+import { isExtension } from 'lib/platform';
 import colors from 'utils/tailwind-colors';
 
 export interface TabPickerItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -75,14 +76,15 @@ export const TabPicker: React.FC<TabPickerProps> = ({ tabs, className, onTabChan
   };
 
   const animationId = useMemo(() => uuid(), []);
+  const skipAnimations = isExtension();
 
   return (
     <div className={classNames('flex', 'rounded-full overflow-hidden p-1', 'bg-grey-50', className)} {...props}>
-      <MotionContext.Provider value={{}}>
+      <MotionConfig transition={skipAnimations ? { duration: 0 } : undefined}>
         {tabs.map((tab, index) => (
           <TabPickerItem key={tab.id} {...tab} onClick={() => handleTabChange(index)} animationId={animationId} />
         ))}
-      </MotionContext.Provider>
+      </MotionConfig>
     </div>
   );
 };

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -4,6 +4,7 @@ import classNames from 'clsx';
 import { motion } from 'framer-motion';
 
 import { hapticMedium } from 'lib/mobile/haptics';
+import { isExtension } from 'lib/platform';
 import colors from 'utils/tailwind-colors';
 
 export interface ToggleProps extends HTMLAttributes<HTMLDivElement> {
@@ -47,13 +48,17 @@ export const Toggle: React.FC<ToggleProps> = ({
           'bg-primary-500': !value
         })}
         animate={{ backgroundColor: value ? '#ffffff' : colors.primary[500] }}
-        layout
-        transition={{
-          type: 'spring',
-          stiffness: 700,
-          damping: 30,
-          backgroundColor: { duration: 0.2 }
-        }}
+        layout={!isExtension()}
+        transition={
+          isExtension()
+            ? { duration: 0 }
+            : {
+                type: 'spring',
+                stiffness: 700,
+                damping: 30,
+                backgroundColor: { duration: 0.2 }
+              }
+        }
       />
     </div>
   );

--- a/src/confirm.tsx
+++ b/src/confirm.tsx
@@ -7,6 +7,9 @@ import { createRoot } from 'react-dom/client';
 import App from 'app/App';
 import { WindowType } from 'app/env';
 
+// Disable animations for extension
+document.documentElement.classList.add('extension-no-animations');
+
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(<App env={{ windowType: WindowType.Popup, confirmWindow: true }} />);

--- a/src/fullpage.tsx
+++ b/src/fullpage.tsx
@@ -7,6 +7,9 @@ import { createRoot } from 'react-dom/client';
 import App from 'app/App';
 import { WindowType } from 'app/env';
 
+// Disable animations for extension
+document.documentElement.classList.add('extension-no-animations');
+
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(<App env={{ windowType: WindowType.FullPage }} />);

--- a/src/lib/platform/index.test.ts
+++ b/src/lib/platform/index.test.ts
@@ -7,18 +7,26 @@ describe('platform detection', () => {
   });
 
   describe('isExtension', () => {
-    it('returns true when browser.runtime.id exists', () => {
+    afterEach(() => {
+      delete (globalThis as any).browser;
+      delete (globalThis as any).chrome;
+    });
+
+    it('returns true when browser.runtime.id exists (Firefox)', () => {
       (globalThis as any).browser = { runtime: { id: 'test-extension-id' } };
 
       const { isExtension } = require('./index');
       expect(isExtension()).toBe(true);
-
-      delete (globalThis as any).browser;
     });
 
-    it('returns false when browser is undefined', () => {
-      delete (globalThis as any).browser;
+    it('returns true when chrome.runtime.id exists (Chrome)', () => {
+      (globalThis as any).chrome = { runtime: { id: 'test-chrome-extension-id' } };
 
+      const { isExtension } = require('./index');
+      expect(isExtension()).toBe(true);
+    });
+
+    it('returns false when neither browser nor chrome is defined', () => {
       const { isExtension } = require('./index');
       expect(isExtension()).toBe(false);
     });
@@ -28,8 +36,6 @@ describe('platform detection', () => {
 
       const { isExtension } = require('./index');
       expect(isExtension()).toBe(false);
-
-      delete (globalThis as any).browser;
     });
 
     it('returns false when browser.runtime.id is undefined', () => {
@@ -37,8 +43,13 @@ describe('platform detection', () => {
 
       const { isExtension } = require('./index');
       expect(isExtension()).toBe(false);
+    });
 
-      delete (globalThis as any).browser;
+    it('returns false when chrome.runtime.id is undefined', () => {
+      (globalThis as any).chrome = { runtime: {} };
+
+      const { isExtension } = require('./index');
+      expect(isExtension()).toBe(false);
     });
   });
 
@@ -87,7 +98,12 @@ describe('platform detection', () => {
   });
 
   describe('getPlatform', () => {
-    it('returns extension when in extension context', () => {
+    afterEach(() => {
+      delete (globalThis as any).browser;
+      delete (globalThis as any).chrome;
+    });
+
+    it('returns extension when in extension context (Firefox)', () => {
       jest.doMock('@capacitor/core', () => {
         throw new Error('Module not found');
       });
@@ -95,15 +111,22 @@ describe('platform detection', () => {
 
       const { getPlatform } = require('./index');
       expect(getPlatform()).toBe('extension');
+    });
 
-      delete (globalThis as any).browser;
+    it('returns extension when in extension context (Chrome)', () => {
+      jest.doMock('@capacitor/core', () => {
+        throw new Error('Module not found');
+      });
+      (globalThis as any).chrome = { runtime: { id: 'test-chrome-id' } };
+
+      const { getPlatform } = require('./index');
+      expect(getPlatform()).toBe('extension');
     });
 
     it('returns web when not in extension or mobile', () => {
       jest.doMock('@capacitor/core', () => {
         throw new Error('Module not found');
       });
-      delete (globalThis as any).browser;
 
       const { getPlatform } = require('./index');
       expect(getPlatform()).toBe('web');

--- a/src/lib/platform/index.ts
+++ b/src/lib/platform/index.ts
@@ -42,8 +42,11 @@ export function isCapacitor(): boolean {
  */
 export function isExtension(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const browserGlobal = (globalThis as any).browser;
-  return typeof browserGlobal !== 'undefined' && !!browserGlobal?.runtime?.id;
+  const g = globalThis as any;
+  // Check for Firefox (browser.runtime.id) or Chrome (chrome.runtime.id)
+  const browserRuntime = g.browser?.runtime?.id;
+  const chromeRuntime = g.chrome?.runtime?.id;
+  return !!(browserRuntime || chromeRuntime);
 }
 
 /**

--- a/src/lib/ui/useTippy.tsx
+++ b/src/lib/ui/useTippy.tsx
@@ -1,21 +1,32 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import tippy, { Props, Instance } from 'tippy.js';
 
+import { isExtension } from 'lib/platform';
+
 export type TippyInstance = Instance<Props>;
 export type TippyProps = Partial<Props>;
+
+// Cache this at module level since it won't change during runtime
+const IS_EXTENSION = isExtension();
 
 export default function useTippy<T extends HTMLElement>(props: Partial<Props>) {
   const targetRef = useRef<T>(null);
   const instanceRef = useRef<Instance<Props>>();
 
+  // Disable animations for extension
+  const effectiveProps = useMemo(
+    () => (IS_EXTENSION ? { ...props, duration: 0, animation: false as const } : props),
+    [props]
+  );
+
   useEffect(() => {
     if (instanceRef.current) {
-      instanceRef.current.setProps(props);
+      instanceRef.current.setProps(effectiveProps);
     } else if (targetRef.current) {
-      instanceRef.current = tippy(targetRef.current, props);
+      instanceRef.current = tippy(targetRef.current, effectiveProps);
     }
-  }, [props]);
+  }, [effectiveProps]);
 
   useEffect(
     () => () => {

--- a/src/main.css
+++ b/src/main.css
@@ -216,3 +216,38 @@ button,
 .mobile-page-enter {
   animation: mobile-slide-in 0.15s ease-out both;
 }
+
+/**
+ * Disable all animations for Chrome extension
+ * This class is added to <html> when isExtension() returns true
+ */
+.extension-no-animations,
+.extension-no-animations *,
+.extension-no-animations *::before,
+.extension-no-animations *::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}
+
+/* Also disable React Modal transitions */
+.extension-no-animations .ReactModal__Overlay {
+  transition: none !important;
+  opacity: 1 !important;
+}
+
+.extension-no-animations .ReactModal__Content {
+  transition: none !important;
+  transform: scale(1) !important;
+}
+
+.extension-no-animations #recall-height-modal.ReactModal__Content {
+  transition: none !important;
+  transform: translateY(0) !important;
+}
+
+/* Disable Tippy animations */
+.extension-no-animations .tippy-box {
+  transition: none !important;
+}

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -15,6 +15,9 @@ import { getMessage } from 'lib/i18n';
 import { clearStorage } from 'lib/miden/reset';
 import { AlertFn, ConfirmFn, DialogsProvider, useAlert, useConfirm } from 'lib/ui/dialog';
 
+// Disable animations for extension
+document.documentElement.classList.add('extension-no-animations');
+
 const OptionsWrapper: FC = () => (
   <DialogsProvider>
     <Options />

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -11,6 +11,9 @@ import App from 'app/App';
 import { WindowType, openInFullPage } from 'app/env';
 import { isPopupModeEnabled } from 'lib/popup-mode';
 
+// Disable animations for extension
+document.documentElement.classList.add('extension-no-animations');
+
 const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(<App env={{ windowType: WindowType.Popup }} />);

--- a/src/screens/onboarding/common/OnboardingView.tsx
+++ b/src/screens/onboarding/common/OnboardingView.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
 
-import { isMobile } from 'lib/platform';
+import { isExtension, isMobile } from 'lib/platform';
 
 interface OnboardingViewProps {
   renderHeader: () => JSX.Element;
@@ -14,6 +14,7 @@ interface OnboardingViewProps {
 
 const OnboardingView: FC<OnboardingViewProps> = ({ renderHeader, renderStep, step, navigationDirection }) => {
   const mobile = isMobile();
+  const skipAnimations = isExtension();
 
   return (
     <div
@@ -29,12 +30,12 @@ const OnboardingView: FC<OnboardingViewProps> = ({ renderHeader, renderStep, ste
         <motion.div
           key={step}
           className="flex-1 flex flex-col"
-          initial="initialState"
+          initial={skipAnimations ? false : 'initialState'}
           animate="animateState"
-          exit="exitState"
+          exit={skipAnimations ? undefined : 'exitState'}
           transition={{
             type: 'tween',
-            duration: 0.2
+            duration: skipAnimations ? 0 : 0.2
           }}
           variants={{
             initialState: {

--- a/src/screens/onboarding/navigator.tsx
+++ b/src/screens/onboarding/navigator.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Icon, IconName } from 'app/icons/v2';
 import { CircleButton } from 'components/CircleButton';
 import { ProgressIndicator } from 'components/ProgressIndicator';
-import { isMobile } from 'lib/platform';
+import { isExtension, isMobile } from 'lib/platform';
 
 import { BiometricSetupScreen } from './common/BiometricSetup';
 import { ConfirmationScreen } from './common/Confirmation';
@@ -225,7 +225,8 @@ export const OnboardingFlow: FC<OnboardingFlowProps> = ({
             exit="exitState"
             transition={{
               type: 'tween',
-              duration: 0.2
+              // Disable animations for Chrome extension
+              duration: isExtension() ? 0 : 0.2
             }}
             variants={{
               initialState: {

--- a/src/screens/send-flow/RecallBlocksModal.tsx
+++ b/src/screens/send-flow/RecallBlocksModal.tsx
@@ -6,6 +6,7 @@ import Modal from 'react-modal';
 
 import { Button, ButtonVariant } from 'components/Button';
 import { Input } from 'components/Input';
+import { isExtension } from 'lib/platform';
 
 export interface RecallBlocksModalProps extends Modal.Props {
   recallBlocksInput?: string;
@@ -27,7 +28,7 @@ export const RecallBlocksModal: FC<RecallBlocksModalProps> = ({
       {...restProps}
       className={classNames('w-full bg-white px-4 py-6 md:rounded-b z-30 shadow-2xl')}
       appElement={document.getElementById('root')!}
-      closeTimeoutMS={200}
+      closeTimeoutMS={isExtension() ? 0 : 200}
       overlayClassName={classNames('absolute inset-0 z-30', 'bg-black bg-opacity-75', 'flex items-end justify-center')}
       onAfterOpen={() => {
         document.body.classList.add('overscroll-y-none');


### PR DESCRIPTION
- Fix isExtension() to check both browser.runtime.id and chrome.runtime.id
- Add global CSS class to disable transitions and animations
- Add extension-no-animations class to all entry points
- Fix Framer Motion animations in TabPicker, Toggle, OnboardingView
- Fix React Modal closeTimeoutMS in CustomModal and RecallBlocksModal
- Fix BootAnimation CSSTransition timeout
- Fix Tippy tooltip animations