### PR TITLE
fix: prevent non-MIDEN tokens from appearing delayed

### DIFF
--- a/src/lib/miden/metadata/defaults.ts
+++ b/src/lib/miden/metadata/defaults.ts
@@ -3,7 +3,7 @@ import { isExtension } from 'lib/platform';
 import { AssetMetadata } from './types';
 
 // Get asset URL that works on extension, mobile, and desktop
-function getAssetUrl(path: string): string {
+export function getAssetUrl(path: string): string {
   if (!isExtension()) {
     // On mobile/desktop, use relative URL from web root
     return `/${path}`;


### PR DESCRIPTION
Move metadata fetching inside the same WASM client lock as getAccount() to prevent AutoSync from grabbing the lock between operations.

Previously, fetchBalances() released the lock after getting the user's account, then tried to acquire it again for each non-MIDEN token's metadata. If AutoSync grabbed the lock in between (which holds it for 30+ seconds during syncState), non-MIDEN tokens would appear delayed.

Now all WASM operations happen in a single lock acquisition.