### PR TITLE
fix: note consume issues: batch consume, mutex contention, stuck transactions

### DIFF
--- a/src/lib/miden/db/types.ts
+++ b/src/lib/miden/db/types.ts
@@ -143,6 +143,7 @@ export class ConsumeTransaction implements ITransaction {
   accountId: string;
   amount?: bigint;
   noteId: string;
+  noteIds: string[];
   secondaryAccountId?: string;
   faucetId: string;
   transactionId?: string;
@@ -154,18 +155,24 @@ export class ConsumeTransaction implements ITransaction {
   displayIcon: ITransactionIcon;
   delegateTransaction?: boolean;
 
-  constructor(accountId: string, note: ConsumableNote, delegateTransaction?: boolean) {
+  constructor(accountId: string, notes: ConsumableNote | ConsumableNote[], delegateTransaction?: boolean) {
+    const noteArray = Array.isArray(notes) ? notes : [notes];
+    const firstNote = noteArray[0];
     this.id = uuid();
     this.type = 'consume';
     this.accountId = accountId;
-    this.noteId = note.id;
-    this.faucetId = note.faucetId;
-    this.secondaryAccountId = note.senderAddress;
-    this.amount = note.amount !== '' ? BigInt(note.amount) : undefined;
+    this.noteId = firstNote.id;
+    this.noteIds = noteArray.map(n => n.id);
+    this.faucetId = firstNote.faucetId;
+    this.secondaryAccountId = firstNote.senderAddress;
+    this.amount = noteArray.reduce((sum, n) => {
+      const noteAmount = n.amount !== '' ? BigInt(n.amount) : 0n;
+      return sum + noteAmount;
+    }, 0n);
     this.status = ITransactionStatus.Queued;
     this.initiatedAt = Date.now();
     this.displayIcon = 'RECEIVE';
-    this.displayMessage = 'Consuming';
+    this.displayMessage = noteArray.length > 1 ? `Consuming ${noteArray.length} notes` : 'Consuming';
     this.delegateTransaction = delegateTransaction;
   }
 }

--- a/src/lib/miden/front/autoSync.ts
+++ b/src/lib/miden/front/autoSync.ts
@@ -1,4 +1,3 @@
-import { isMobile } from 'lib/platform';
 import { WalletState, WalletStatus } from 'lib/shared/types';
 import { useWalletStore } from 'lib/store';
 
@@ -75,8 +74,8 @@ export class Sync {
       return;
     }
 
-    // On mobile, don't sync while transaction modal is open to avoid lock contention
-    if (isMobile() && storeState.isTransactionModalOpen) {
+    // Don't sync while transaction modal is open to avoid WASM mutex contention with consume
+    if (storeState.isTransactionModalOpen) {
       console.log('[AutoSync] Skipping sync while transaction modal is open');
       await sleep(3000);
       await this.sync();

--- a/src/lib/miden/sdk/miden-client-interface.ts
+++ b/src/lib/miden/sdk/miden-client-interface.ts
@@ -148,9 +148,10 @@ export class MidenClientInterface {
   }
 
   async consumeNoteId(transaction: ConsumeTransaction): Promise<Uint8Array> {
-    const { accountId, noteId } = transaction;
+    const { accountId } = transaction;
+    const noteIds = transaction.noteIds ?? [transaction.noteId];
 
-    const notes = await this.getNotesByIds([noteId]);
+    const notes = await this.getNotesByIds(noteIds);
     const consumeTransactionRequest = this.webClient.newConsumeTransactionRequest(notes);
     let consumeTransactionResult = await this.webClient.executeTransaction(
       accountIdStringToSdk(accountId),


### PR DESCRIPTION
## Summary

This PR fixes three critical note consume issues in the Miden Wallet Chrome extension:

1. **Notes from faucet fail to consume or consume very late** - AutoSync (3s polling) and claimable notes polling (5s) compete with consume transactions for the single WASM AsyncMutex, starving consume operations
2. **Multiple incoming notes pile up in the queue** - Each note creates a separate ConsumeTransaction, processing sequentially through the mutex bottleneck  
3. **Stuck transactions block the entire queue** - A transaction stuck in `GeneratingTransaction` state blocks all subsequent transactions indefinitely (30min timeout on desktop)

## Changes

### Fix 1: Pause AutoSync during consume on all platforms
- Removed the `isMobile()` guard so AutoSync pauses on desktop too when transaction modal is open

### Fix 2: Pause claimable notes polling during consume
- Set SWR `refreshInterval` to 0 when `isTransactionModalOpen` is true
- Updated `notesBeingClaimed` filter to support batch `noteIds`

### Fix 3: Batch consume - multiple notes in a single transaction
- `ConsumeTransaction` now accepts `ConsumableNote[]` and stores `noteIds: string[]`
- SDK interface uses full `noteIds` array (SDK already supports `Note[]`)
- Added `initiateBatchConsumeTransaction()` for single batch transaction
- "Claim All" creates one transaction instead of N separate ones

### Fix 4: Auto-cancel stuck transactions in processing loop
- Detects transactions stuck in `GeneratingTransaction` state and auto-cancels them

### Fix 5: Reduce desktop stuck transaction timeout (30min → 5min)

## Test plan

- [x] Request tokens from faucet → verify note is consumed quickly
- [x] Multiple notes → "Claim All" creates a single batch transaction
- [x] Verify AutoSync pauses during consume (console log)
- [x] Stuck transaction auto-cancels after ~1 minute
- [x] Build succeeds: `yarn build:extension`