### PR TITLE
Wrap getMidenClient in withWasmClientLock in MidenProvider

### DIFF
--- a/src/lib/miden/front/provider.tsx
+++ b/src/lib/miden/front/provider.tsx
@@ -7,7 +7,7 @@ import { MidenContextProvider, useMidenContext } from 'lib/miden/front/client';
 import { PropsWithChildren } from 'lib/props-with-children';
 import { WalletStoreProvider } from 'lib/store/WalletStoreProvider';
 
-import { getMidenClient } from '../sdk/miden-client';
+import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 import { TokensMetadataProvider } from './assets';
 
 // Pre-create the modal container to avoid flash when first opening
@@ -38,7 +38,9 @@ export const MidenProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     const initializeClient = async () => {
       try {
-        await getMidenClient();
+        await withWasmClientLock(async () => {
+          await getMidenClient();
+        });
       } catch (err) {
         console.error('Failed to initialize Miden client singleton:', err);
       }


### PR DESCRIPTION
Wraped the eager `getMidenClient()` initialization in MidenProvider with `withWasmClientLock` and added the corresponding `import from ../sdk/miden-client`.

According to [CLAUDE.md](https://github.com/nikolaysamoil0ff/miden-wallet/blob/main/CLAUDE.md#wasm-client-concurrency), the Miden WASM client cannot handle concurrent access, and all interactions with it must be wrapped in `withWasmClientLock`. Direct calls to `getMidenClient()` without the lock can lead to concurrency issues, including the documented Rust error:

`recursive use of an object detected which would lead to unsafe aliasing in rust`

Since MidenProvider performs eager initialization on app startup, this could overlap with other WASM operations (e.g. workers, AutoSync, frontend hooks) and cause race conditions.