### PR TITLE
fix: address PSM integration review findings

### DIFF
--- a/src/lib/miden/activity/transactions.ts
+++ b/src/lib/miden/activity/transactions.ts
@@ -577,7 +577,11 @@ export const generateTransaction = async (
   });
   // Route PSM accounts through PSM service
   if (isPsmAccount(transaction.accountId)) {
-    await generatePsmTransaction(transaction, signCallback);
+    try {
+      await generatePsmTransaction(transaction, signCallback);
+    } catch (error) {
+      await cancelTransaction(transaction, error);
+    }
     return;
   }
 

--- a/src/lib/miden/back/vault.ts
+++ b/src/lib/miden/back/vault.ts
@@ -518,12 +518,10 @@ export class Vault {
 
   async getPublicKeyForCommitment(pkc: string): Promise<string> {
     try {
-      console.log('Getting public key for commitment', pkc);
       const sk = await fetchAndDecryptOneWithLegacyFallBack<string>(accAuthSecretKeyStrgKey(pkc), this.vaultKey);
-      console.log('Got secret key for commitment', { pkc, sk });
       let secretKeyBytes = new Uint8Array(Buffer.from(sk, 'hex'));
       const wasmSecretKey = AuthSecretKey.deserialize(secretKeyBytes);
-      console.log(wasmSecretKey.publicKey().serialize());
+      // Skip first byte (type prefix) from serialized public key
       return Buffer.from(wasmSecretKey.publicKey().serialize().slice(1)).toString('hex');
     } catch (e) {
       console.error('Error in getPublicKeyForCommitment', e);

--- a/src/lib/miden/db/types.ts
+++ b/src/lib/miden/db/types.ts
@@ -1,4 +1,3 @@
-import { ProposalMetadata } from '@openzeppelin/psm-client';
 import { v4 as uuid } from 'uuid';
 
 import { ConsumableNote, NoteType } from '../types';

--- a/src/lib/miden/front/autoSync.ts
+++ b/src/lib/miden/front/autoSync.ts
@@ -1,6 +1,3 @@
-import { PsmHttpClient } from '@openzeppelin/psm-client';
-
-import { DEFAULT_PSM_ENDPOINT } from 'lib/miden-chain/constants';
 import { isMobile } from 'lib/platform';
 import { WalletState, WalletStatus } from 'lib/shared/types';
 import { useWalletStore } from 'lib/store';
@@ -100,12 +97,11 @@ export class Sync {
         return syncSummary.blockNum();
       });
 
-      if (useWalletStore.getState())
-        if (blockNum !== null) {
-          this.lastHeight = blockNum;
-          syncDebugInfo.lastBlockNum = blockNum;
-          syncDebugInfo.lastError = undefined;
-        }
+      if (blockNum !== null) {
+        this.lastHeight = blockNum;
+        syncDebugInfo.lastBlockNum = blockNum;
+        syncDebugInfo.lastError = undefined;
+      }
       syncDebugInfo.syncCount++;
       syncDebugInfo.lastSyncTime = new Date().toLocaleTimeString();
     } catch (error) {

--- a/src/lib/miden/front/psm-manager.ts
+++ b/src/lib/miden/front/psm-manager.ts
@@ -5,8 +5,7 @@ import { WalletType } from 'screens/onboarding/types';
 import { MULTISIG_SLOT_NAMES } from '../psm/account';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 /**
- * Get or create a MultisigService for the given account (lazy initialization).
- * Services are cached in memory and reused for subsequent calls.
+ * Create a MultisigService for the given PSM account.
  */
 export async function getOrCreateMultisigService(
   accountPublicKey: string,
@@ -50,8 +49,7 @@ export async function getOrCreateMultisigService(
 }
 
 /**
- * Check if an account is a PSM account and has completed at least one transaction.
- * PSM routing only applies after the first transaction.
+ * Check if an account is a PSM account.
  */
 export function isPsmAccount(accountPublicKey: string): boolean {
   const accounts = useWalletStore.getState().accounts;

--- a/src/lib/miden/psm/index.ts
+++ b/src/lib/miden/psm/index.ts
@@ -1,6 +1,5 @@
-import { Account, WebClient } from '@miden-sdk/miden-sdk';
+import { Account } from '@miden-sdk/miden-sdk';
 import {
-  AccountInspector,
   Multisig,
   MultisigClient,
   MultisigConfig,
@@ -129,6 +128,7 @@ export class MultisigService {
     if (!account) {
       throw new Error('Account not found in MultisigService');
     }
+    // +2 accounts for the current nonce plus the proposal execution incrementing nonce
     const nonce = Number(account.nonce().asInt()) + 2;
 
     // Create metadata for unknown/custom proposal type
@@ -164,7 +164,7 @@ export class MultisigService {
           await new Promise(resolve => setTimeout(resolve, 3000)); // Wait before retrying
           await this.sync();
         } else {
-          console.error('Max sync retries reached. Please check your account state and try again.');
+          throw new Error('Max sync retries reached: local state is ahead of on-chain state');
         }
       } else {
         throw error; // Rethrow if it's a different error


### PR DESCRIPTION
## Summary

- **Remove secret key logging** from `vault.getPublicKeyForCommitment` — decrypted key material was being logged to console
- **Fix broken autoSync conditional** — dangling `if (useWalletStore.getState())` was a no-op that changed scoping of sync counter updates
- **Add error handling to `generatePsmTransaction`** — failures now properly cancel the transaction instead of leaving it stuck in `GeneratingTransaction` status
- **Throw on max sync retries** — `MultisigService.sync()` now throws after exhausting retries instead of silently returning (which caused the caller to mark the tx as completed)
- **Remove unused imports** — `PsmHttpClient`, `ProposalMetadata`, `AccountInspector`, `WebClient`
- **Fix misleading comments** — removed stale "cached" and "after first transaction" claims from psm-manager
- **Document nonce offset** — added comment explaining the `+ 2` in `createCustomProposal`

## Test plan

- [ ] Verify PSM account creation still works
- [ ] Verify PSM send transaction completes successfully
- [ ] Verify PSM consume note completes successfully
- [ ] Verify failed PSM transactions are properly cancelled (not stuck in generating)
- [ ] Verify autoSync continues to update block number correctly