### PR TITLE
feat: Chrome side panel mode with popup toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
 
 ### Features
 
+* [FEATURE][extension] Chrome Side Panel mode with popup toggle. Users can switch between popup (default) and side panel via the maximize/minimize icon in the header. Preference persists across sessions. (#176)
+* [FEATURE][extension] Pin extension prompt shown once after fresh install, guiding users to pin the extension to the toolbar. (#176)
+* [FEATURE][all] Color-coded Send (blue) and Receive (green) action buttons on the home page, matching the token detail page. (#176)
+
+### Fixes
+
+* [FIX][extension] Fixed `onInstalled` event handler not firing on Chrome MV3 due to webpack async module loading delaying listener registration. Handler moved to `sw.js` for synchronous registration. (#176)
+* [FIX][all] Fixed `ConsumingNote` page using raw UA sniffing instead of `isMobile()` platform detection. (#176)
 * [FIX][all] Fixed transaction recovery after network outages. Private accounts could enter a permanently broken state where all transactions fail with "initial state commitment does not match". Root causes: AutoSync loop died on the generating-transaction page, transactions were built against stale local state, and the transaction modal blocked on stale tx failures. Now syncs state before executing transactions, keeps AutoSync alive during transaction generation, cancels crashed/stale transactions properly, and shows correct "Failed" status instead of misleading "Executing". (#150)
 * [FIX][all] Removed stale "Download Generated Files" button and output notes storage. The `useExportNotes` hook, `registerOutputNote`, and related storage key were unused dead code. Simplifies the transaction completion screen and its auto-close logic. (#160)
 * [FIX][all] Removed the "Upload File" button and drag-and-drop note import from the Receive page. The freed space is now used by the notes list, making it taller. (#161)

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -2611,5 +2611,17 @@
   "advancedOptions": {
     "message": "Erweiterte Optionen",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Pin Miden-Geldbörse",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Klicken Sie auf das Puzzle-Symbol und heften Sie Miden Wallet an, um über Ihre Symbolleiste schnell darauf zugreifen zu können.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Habe es",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/en/en.json
+++ b/public/_locales/en/en.json
@@ -609,5 +609,8 @@
   "date": "Date",
   "details": "Details",
   "addANote": "Add a note",
-  "advancedOptions": "Advanced Options"
+  "advancedOptions": "Advanced Options",
+  "pinExtensionTitle": "Pin Miden Wallet",
+  "pinExtensionDescription": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar.",
+  "gotIt": "Got it"
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -2575,5 +2575,17 @@
   "advancedOptions": {
     "message": "Advanced Options",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Pin Miden Wallet",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Got it",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -2639,5 +2639,17 @@
   "advancedOptions": {
     "message": "Advanced Options",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Pin Miden Wallet",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Got it",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -2536,5 +2536,17 @@
   "advancedOptions": {
     "message": "Opciones avanzadas",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Cartera Pin Miden",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Haga clic en el ícono del rompecabezas y fije Miden Wallet para acceder rápidamente desde su barra de herramientas.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Entiendo",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -2598,5 +2598,17 @@
   "advancedOptions": {
     "message": "Options avancées",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Portefeuille Pin Miden",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Cliquez sur l'icône du puzzle et épinglez Miden Wallet pour un accès rapide depuis votre barre d'outils.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "J'ai compris",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -2611,5 +2611,17 @@
   "advancedOptions": {
     "message": "詳細オプション",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "ピンミデンウォレット",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "パズル アイコンをクリックして Miden Wallet を固定すると、ツールバーから簡単にアクセスできます。",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "わかった",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -2611,5 +2611,17 @@
   "advancedOptions": {
     "message": "고급 옵션",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "핀 미덴 지갑",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "도구 모음에서 빠르게 액세스하려면 퍼즐 아이콘을 클릭하고 Miden Wallet을 고정하세요.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "알았어요",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -2536,5 +2536,17 @@
   "advancedOptions": {
     "message": "Opcje zaawansowane",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Przypnij portfel Miden",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Kliknij ikonę puzzli i przypnij portfel Miden, aby uzyskać szybki dostęp z paska narzędzi.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Rozumiem",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -2597,5 +2597,17 @@
   "advancedOptions": {
     "message": "Opções Avançadas",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Carteira Miden Pin",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Clique no ícone do quebra-cabeça e fixe a Carteira Miden para acesso rápido na barra de ferramentas.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Entendi",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -2612,5 +2612,17 @@
   "advancedOptions": {
     "message": "Дополнительные параметры",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "кошелек Miden с булавками",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Нажмите на значок головоломки и закрепите Miden Wallet для быстрого доступа с панели инструментов.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Понятно",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -2599,5 +2599,17 @@
   "advancedOptions": {
     "message": "Gelişmiş Seçenekler",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Miden Cüzdanını Pinle",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Araç çubuğunuzdan hızlı erişim için bulmaca simgesine tıklayın ve Miden Cüzdanını sabitleyin.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "Anladım",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -2612,5 +2612,17 @@
   "advancedOptions": {
     "message": "Додаткові параметри",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Pin Miden Wallet",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "Клацніть піктограму головоломки та закріпіть Miden Wallet для швидкого доступу з панелі інструментів.",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "зрозумів",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -2611,5 +2611,17 @@
   "advancedOptions": {
     "message": "高级选项",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Pin Miden 钱包",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "单击拼图图标并固定 Miden Wallet，以便从工具栏快速访问。",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "知道了",
+    "englishSource": "Got it"
   }
 }

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -2611,5 +2611,17 @@
   "advancedOptions": {
     "message": "高级选项",
     "englishSource": "Advanced Options"
+  },
+  "pinExtensionTitle": {
+    "message": "Pin Miden 钱包",
+    "englishSource": "Pin Miden Wallet"
+  },
+  "pinExtensionDescription": {
+    "message": "单击拼图图标并固定 Miden Wallet，以便从工具栏快速访问。",
+    "englishSource": "Click the puzzle icon and pin Miden Wallet for quick access from your toolbar."
+  },
+  "gotIt": {
+    "message": "知道了",
+    "englishSource": "Got it"
   }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -13,7 +13,7 @@
   "__chrome|firefox|opera__homepage_url": "https://miden.fi",
   "short_name": "Miden Wallet",
 
-  "permissions": ["storage", "clipboardWrite", "unlimitedStorage", "activeTab", "tabs", "notifications", "alarms"],
+  "permissions": ["storage", "clipboardWrite", "unlimitedStorage", "activeTab", "tabs", "notifications", "alarms", "sidePanel"],
   "host_permissions": [
     "http://localhost/*",
     "https://*.miden.fi/*"
@@ -40,10 +40,14 @@
     }
   },
 
-  "__chrome__minimum_chrome_version": "88",
+  "__chrome__minimum_chrome_version": "114",
   "__opera__minimum_opera_version": "36",
 
   "default_locale": "en",
+
+  "__chrome__side_panel": {
+    "default_path": "sidepanel.html"
+  },
 
   "action": {
     "__chrome|firefox|opera__default_popup": "popup.html",

--- a/public/sidepanel.html
+++ b/public/sidepanel.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="" class="no-scrollbar" style="width: 100%; height: 100%; min-width: 360px;">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
+    <title>Miden Wallet</title>
+  </head>
+  <body style="width: 100%; height: 100%; overflow: hidden; margin: 0;">
+    <div id="root" style="height: 100%"></div>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,15 @@
 /* eslint-disable */
 
+// IMPORTANT: Register onInstalled BEFORE importScripts so it fires synchronously.
+// Webpack's async module loading in background.js can delay listener registration,
+// causing Chrome MV3 to miss the install event.
+chrome.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === 'install') {
+    chrome.storage.local.set({ 'fresh_install': true });
+    chrome.tabs.create({ url: chrome.runtime.getURL('fullpage.html') });
+  }
+});
+
 try {
   const window = globalThis;
   // This is the file produced by webpack

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,6 +12,7 @@ import ErrorBoundary from 'app/ErrorBoundary';
 import Dialogs from 'app/layouts/Dialogs';
 import { MobileBackBridge } from 'app/MobileBackBridge';
 import PageRouter from 'app/PageRouter';
+import { PinExtensionPrompt } from 'app/templates/PinExtensionPrompt';
 import { ExtensionMessageListener } from 'components/ConnectivityIssueBanner';
 import { MidenProvider } from 'lib/miden/front';
 import { isDesktop as checkIsDesktop, isExtension, isMobile as checkIsMobile } from 'lib/platform';
@@ -66,6 +67,7 @@ const AppProvider: FC<AppProps> = ({ children, env }) => {
     <AppEnvProvider {...env}>
       <Woozie.Provider>
         <ExtensionMessageListener />
+        {isExtension() && <PinExtensionPrompt />}
         {checkIsMobile() && <MobileBackBridge />}
         {checkIsDesktop() && (
           <Suspense fallback={null}>

--- a/src/app/atoms/SeedPhraseInput.tsx
+++ b/src/app/atoms/SeedPhraseInput.tsx
@@ -36,7 +36,7 @@ export const SeedPhraseInput: FC<SeedPhraseInputProps> = ({
   reset
 }) => {
   const { t } = useTranslation();
-  const { popup } = useAppEnv();
+  const { compact } = useAppEnv();
 
   const [pasteFailed, setPasteFailed] = useState(false);
   const [draftSeed, setDraftSeed] = useState(new Array(defaultNumberOfWords).fill(''));
@@ -122,7 +122,7 @@ export const SeedPhraseInput: FC<SeedPhraseInputProps> = ({
     <div>
       <div className={classNames('flex justify-between', 'mb-6')}>
         <h1 className={classNames('flex text-base self-center text-black', 'font-medium')}>{label}</h1>
-        <div className={classNames('relative w-64 h-10')} style={{ width: popup ? 220 : undefined }}>
+        <div className={classNames('relative w-64 h-10')} style={{ width: compact ? 220 : undefined }}>
           <SeedLengthSelect
             options={numberOfWordsOptions}
             currentOption={draftSeed.length.toString()}

--- a/src/app/env.ts
+++ b/src/app/env.ts
@@ -28,7 +28,8 @@ export type AppEnvironment = {
 
 export enum WindowType {
   Popup,
-  FullPage
+  FullPage,
+  SidePanel
 }
 
 export type BackHandler = () => void;
@@ -36,6 +37,8 @@ export type BackHandler = () => void;
 export const [AppEnvProvider, useAppEnv] = constate((env: AppEnvironment) => {
   const fullPage = env.windowType === WindowType.FullPage;
   const popup = env.windowType === WindowType.Popup;
+  const sidePanel = env.windowType === WindowType.SidePanel;
+  const compact = popup || sidePanel;
   const confirmWindow = env.confirmWindow ?? false;
 
   const handlerRef = useRef<BackHandler>();
@@ -63,6 +66,8 @@ export const [AppEnvProvider, useAppEnv] = constate((env: AppEnvironment) => {
   return {
     fullPage,
     popup,
+    sidePanel,
+    compact,
     confirmWindow,
     onBack,
     registerBackHandler
@@ -86,13 +91,13 @@ export const OpenInFullPage: FC = () => {
         const onboardingTab = tabs.find((t: Tabs.Tab) => t.url && urls.includes(t.url));
         if (onboardingTab?.id) {
           browser.tabs.update(onboardingTab.id, { active: true });
-          if (appEnv.popup) {
+          if (appEnv.compact) {
             window.close();
           }
         } else {
           // unable to find existing onboarding tab, open a new one
           await openInFullPage();
-          if (appEnv.popup) {
+          if (appEnv.compact) {
             window.close();
           }
         }
@@ -100,7 +105,7 @@ export const OpenInFullPage: FC = () => {
         console.error('OpenInFullPage error:', err);
       }
     })();
-  }, [appEnv.popup]);
+  }, [appEnv.compact]);
 
   return null;
 };

--- a/src/app/hooks/useAppEnvStyle.ts
+++ b/src/app/hooks/useAppEnvStyle.ts
@@ -1,7 +1,7 @@
 import { useAppEnv } from '../env';
 
 export const useAppEnvStyle = () => {
-  const { popup } = useAppEnv();
+  const { compact } = useAppEnv();
 
-  return { dropdownWidth: popup ? 328 : 382 };
+  return { dropdownWidth: compact ? 328 : 382 };
 };

--- a/src/app/icons/minimise.svg
+++ b/src/app/icons/minimise.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-minimize2-icon lucide-minimize-2"><path d="M4 14h6v6"/><path d="m10 14-7 7"/><path d="M20 10h-6V4"/><path d="m14 10 7-7"/></svg>

--- a/src/app/layouts/PageLayout.tsx
+++ b/src/app/layouts/PageLayout.tsx
@@ -31,7 +31,7 @@ const PageLayout: FC<PageLayoutProps> = ({
   showBottomBorder = true,
   ...toolbarProps
 }) => {
-  const { fullPage } = useAppEnv();
+  const { fullPage, sidePanel } = useAppEnv();
 
   // Platform-specific sizing:
   // - Mobile: 100% to inherit from parent chain (body has safe area padding)
@@ -41,9 +41,11 @@ const PageLayout: FC<PageLayoutProps> = ({
     ? { height: '100%', width: '100%' }
     : isDesktop()
       ? { height: '100%', width: '100%', maxWidth: '600px' }
-      : fullPage
-        ? { height: '640px', width: '600px' }
-        : { height: '600px', width: '360px' };
+      : sidePanel
+        ? { height: '100%', width: '100%' }
+        : fullPage
+          ? { height: '640px', width: '600px' }
+          : { height: '600px', width: '360px' };
 
   return (
     <>

--- a/src/app/layouts/PageLayout/ChangelogOverlay/ChangelogOverlay.tsx
+++ b/src/app/layouts/PageLayout/ChangelogOverlay/ChangelogOverlay.tsx
@@ -16,7 +16,7 @@ const currentVersion = process.env.VERSION;
 
 export const ChangelogOverlay: FC = () => {
   const { t } = useTranslation();
-  const { popup } = useAppEnv();
+  const { compact } = useAppEnv();
   const [lastShownVersion, setLastShownVersion] = useStorage<string | undefined | null>(
     `last_shown_changelog_version`,
     '1.14.8'
@@ -25,7 +25,7 @@ export const ChangelogOverlay: FC = () => {
   const handleContinue = () => {
     setLastShownVersion(currentVersion);
   };
-  const popupClassName = popup ? 'inset-0' : 'top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 p-12';
+  const compactClassName = compact ? 'inset-0' : 'top-1/2 left-1/2 transform -translate-y-1/2 -translate-x-1/2 p-12';
 
   const isNewerVersion = changelogData.find(e => e.version === currentVersion);
   if (!isNewerVersion) {
@@ -38,18 +38,18 @@ export const ChangelogOverlay: FC = () => {
       <div
         className={'fixed inset-0 bg-pure-white/10 dark:bg-pure-black/50 backdrop-blur-xl backdrop-saturate-150 z-50'}
       ></div>
-      <ContentContainer className={classNames('fixed z-50', 'max-h-full', popupClassName)} padding={!popup}>
+      <ContentContainer className={classNames('fixed z-50', 'max-h-full', compactClassName)} padding={!compact}>
         <div
           className={classNames(
             'bg-white shadow-lg relative',
             s.overlay_scrollbar,
-            popup ? 'pt-12 px-8' : 'pt-16 rounded-md'
+            compact ? 'pt-12 px-8' : 'pt-16 rounded-md'
           )}
           style={{
             backgroundColor: `#ffe6ff`,
-            minHeight: popup ? '100vh' : 200,
-            maxHeight: popup ? '100vh' : 'calc(100vh - 96px)',
-            paddingBottom: popup ? 104 : 160
+            minHeight: compact ? '100vh' : 200,
+            maxHeight: compact ? '100vh' : 'calc(100vh - 96px)',
+            paddingBottom: compact ? 104 : 160
           }}
         >
           <div className={classNames('flex flex-col max-w-sm mx-auto w-full')}>
@@ -73,10 +73,10 @@ export const ChangelogOverlay: FC = () => {
             <div
               className={classNames(s.overlay_ok_container)}
               style={{
-                height: popup ? 104 : 90,
-                bottom: popup ? 0 : 48,
-                left: popup ? 16 : 32,
-                right: popup ? 16 : 32
+                height: compact ? 104 : 90,
+                bottom: compact ? 0 : 48,
+                left: compact ? 16 : 32,
+                right: compact ? 16 : 32
               }}
             >
               <Button
@@ -89,7 +89,7 @@ export const ChangelogOverlay: FC = () => {
                 onClick={handleContinue}
                 testID={ChangelogOverlaySelectors.Continue}
                 style={{
-                  width: popup ? 270 : 384
+                  width: compact ? 270 : 384
                 }}
               >
                 {t('okGotIt')}

--- a/src/app/layouts/PageLayout/Footer.tsx
+++ b/src/app/layouts/PageLayout/Footer.tsx
@@ -47,7 +47,7 @@ const FooterNavButton: FC<FooterNavButtonProps> = ({ Icon, linkTo, onClick, badg
         {active && (
           <motion.div
             layoutId={PILL_LAYOUT_ID}
-            className="absolute inset-0 rounded-full bg-pill-active/18"
+            className="absolute inset-0 rounded-full bg-pill-active/18 dark:bg-pill-active/10"
             transition={{ type: 'spring', bounce: 0.15, duration: 0.4 }}
           />
         )}
@@ -95,14 +95,7 @@ const Footer: FC<FooterProps> = ({ historyBadge }) => {
 
   return (
     <footer className="w-full px-4 pb-3 pt-2 md:px-6" style={mobileBottomPadding}>
-      <div
-        className="flex items-center rounded-[26px] px-2 py-2 shadow-[0px_4px_20px_0px_rgba(0,0,0,0.08)]"
-        style={{
-          backgroundColor: 'rgba(255, 255, 255, 0.6)',
-          backdropFilter: 'blur(6px)',
-          WebkitBackdropFilter: 'blur(6px)'
-        }}
-      >
+      <div className="flex items-center rounded-[26px] px-2 py-2 shadow-[0px_4px_20px_0px_rgba(0,0,0,0.08)] bg-pure-white/60 dark:bg-[#1e1e1e] backdrop-blur-md dark:backdrop-blur-none">
         <FooterNavButton Icon={HomeIcon} linkTo={'/'} onClick={onHomeClick} name={t('home')} />
         <FooterNavButton
           Icon={ActivityIcon}

--- a/src/app/layouts/PageLayout/Header.tsx
+++ b/src/app/layouts/PageLayout/Header.tsx
@@ -8,6 +8,8 @@ import Name from 'app/atoms/Name';
 import { openInFullPage, useAppEnv } from 'app/env';
 import { ReactComponent as ChevronDownIcon } from 'app/icons/chevron-down.svg';
 import { ReactComponent as MaximiseIcon } from 'app/icons/maximise.svg';
+import { ReactComponent as MinimiseIcon } from 'app/icons/minimise.svg';
+import { isExtension } from 'lib/platform';
 import { Icon, IconName } from 'app/icons/v2';
 import ContentContainer from 'app/layouts/ContentContainer';
 import AddressChip from 'app/templates/AddressChip';
@@ -53,7 +55,7 @@ const SyncSpinner: FC<{ visible: boolean }> = ({ visible }) => (
 
 const Control: FC = () => {
   const account = useAccount();
-  const { popup } = useAppEnv();
+  const { popup, sidePanel, compact } = useAppEnv();
   const allTokensBaseMetadata = useAllTokensBaseMetadata();
   const { isLoading: isLoadingBalances } = useAllBalances(account.publicKey, allTokensBaseMetadata);
   const hasCompletedInitialSync = useWalletStore(s => s.hasCompletedInitialSync);
@@ -70,9 +72,34 @@ const Control: FC = () => {
     return () => clearTimeout(hideTimeout);
   }, [isSyncing]);
 
-  const handleMaximiseViewClick = () => {
+  const handleMaximiseViewClick = async () => {
+    const chrome = (globalThis as any).chrome;
+    const hasSidePanel = isExtension() && chrome?.sidePanel?.open;
+
+    if (sidePanel && hasSidePanel) {
+      // Switch back to popup mode
+      chrome.storage.local.set({ sidepanel_mode: false });
+      chrome.action.setPopup({ popup: 'popup.html' });
+      chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
+      window.close();
+      return;
+    }
+    if (popup && hasSidePanel) {
+      // Switch to side panel mode
+      try {
+        chrome.storage.local.set({ sidepanel_mode: true });
+        chrome.action.setPopup({ popup: '' });
+        chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+        const win = await chrome.windows.getLastFocused();
+        await chrome.sidePanel.open({ windowId: win.id });
+        window.close();
+        return;
+      } catch {
+        // Fall through to fullpage
+      }
+    }
     openInFullPage();
-    if (popup) {
+    if (compact) {
       window.close();
     }
   };
@@ -103,7 +130,7 @@ const Control: FC = () => {
         </div>
         <div className="flex items-center gap-1">
           {showSpinner && <SyncSpinner visible={isSyncing} />}
-          {popup && (
+          {compact && (
             <Button
               className={classNames(
                 'flex items-center justify-center',
@@ -111,21 +138,29 @@ const Control: FC = () => {
                 'transition ease-in-out duration-200',
                 'cursor-pointer',
                 'opacity-90 hover:opacity-100',
-                'h-6 w-6'
+                'h-7 w-7'
               )}
               onClick={handleMaximiseViewClick}
             >
-              <MaximiseIcon className="w-4 h-4 stroke-black" />
+              {sidePanel ? (
+                <MinimiseIcon className="w-5 h-5 stroke-heading-gray" />
+              ) : (
+                <MaximiseIcon className="w-5 h-5 stroke-heading-gray" />
+              )}
             </Button>
           )}
           <Button
-            className="flex items-center justify-center cursor-pointer h-5 w-5"
+            className="flex items-center justify-center cursor-pointer h-7 w-7"
             onClick={() => {
               hapticLight();
               navigate('/settings');
             }}
           >
-            <Icon name={IconName.SettingsNew} className="w-5 h-5 stroke-black fill-black" fill="currentColor" />
+            <Icon
+              name={IconName.SettingsNew}
+              className="w-6 h-6 stroke-heading-gray fill-heading-gray"
+              fill="currentColor"
+            />
           </Button>
         </div>
       </div>

--- a/src/app/layouts/PageLayout/Header.tsx
+++ b/src/app/layouts/PageLayout/Header.tsx
@@ -73,29 +73,35 @@ const Control: FC = () => {
   }, [isSyncing]);
 
   const handleMaximiseViewClick = async () => {
-    const chrome = (globalThis as any).chrome;
-    const hasSidePanel = isExtension() && chrome?.sidePanel?.open;
+    const chromeApi = (globalThis as any).chrome;
+    const hasSidePanel = isExtension() && chromeApi?.sidePanel?.open;
 
     if (sidePanel && hasSidePanel) {
       // Switch back to popup mode
-      chrome.storage.local.set({ sidepanel_mode: false });
-      chrome.action.setPopup({ popup: 'popup.html' });
-      chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
+      chromeApi.storage.local.set({ sidepanel_mode: false });
+      chromeApi.action.setPopup({ popup: 'popup.html' });
+      chromeApi.sidePanel
+        .setPanelBehavior({ openPanelOnActionClick: false })
+        .catch((err: Error) => console.warn('[Header] setPanelBehavior error:', err));
       window.close();
       return;
     }
     if (popup && hasSidePanel) {
       // Switch to side panel mode
       try {
-        chrome.storage.local.set({ sidepanel_mode: true });
-        chrome.action.setPopup({ popup: '' });
-        chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
-        const win = await chrome.windows.getLastFocused();
-        await chrome.sidePanel.open({ windowId: win.id });
+        await chromeApi.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+        chromeApi.action.setPopup({ popup: '' });
+        chromeApi.storage.local.set({ sidepanel_mode: true });
+        const win = await chromeApi.windows.getLastFocused();
+        await chromeApi.sidePanel.open({ windowId: win.id });
         window.close();
         return;
-      } catch {
-        // Fall through to fullpage
+      } catch (err) {
+        // Restore popup mode on failure
+        chromeApi.action.setPopup({ popup: 'popup.html' });
+        chromeApi.storage.local.set({ sidepanel_mode: false });
+        chromeApi.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => {});
+        console.warn('[Header] Side panel open failed, falling back to fullpage:', err);
       }
     }
     openInFullPage();

--- a/src/app/layouts/SimplePageLayout.tsx
+++ b/src/app/layouts/SimplePageLayout.tsx
@@ -14,7 +14,7 @@ interface SimplePageLayoutProps extends PropsWithChildren {
 }
 
 const SimplePageLayout: FC<SimplePageLayoutProps> = ({ title, icon, children }) => {
-  const { fullPage } = useAppEnv();
+  const { fullPage, sidePanel } = useAppEnv();
   // Platform-specific sizing:
   // - Mobile: 100% height/width to fill viewport (body has safe area padding)
   // - Desktop: responsive sizing (100% height, maxWidth: 600px, centered)
@@ -25,6 +25,8 @@ const SimplePageLayout: FC<SimplePageLayoutProps> = ({ title, icon, children }) 
     containerStyle = { height: '100%', width: '100%', overflow: 'hidden' };
   } else if (isDesktop()) {
     containerStyle = { height: '100%', width: '100%', maxWidth: '600px', margin: '0 auto', overflow: 'hidden' };
+  } else if (sidePanel) {
+    containerStyle = { height: '100%', width: '100%', overflow: 'hidden' };
   } else if (fullPage) {
     containerStyle = { height: '600px', width: '360px', margin: 'auto', overflow: 'hidden' };
   } else {

--- a/src/app/layouts/TabLayout.tsx
+++ b/src/app/layouts/TabLayout.tsx
@@ -16,7 +16,7 @@ import { useLocation } from 'lib/woozie';
  */
 const TabLayout: FC<PropsWithChildren> = ({ children }) => {
   const historyBadge = useHistoryBadge();
-  const { fullPage } = useAppEnv();
+  const { fullPage, sidePanel } = useAppEnv();
   const { pathname } = useLocation();
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -54,9 +54,11 @@ const TabLayout: FC<PropsWithChildren> = ({ children }) => {
     ? { height: '100%', width: '100%' }
     : isDesktop()
       ? { height: '100%', width: '100%', maxWidth: '600px' }
-      : fullPage
-        ? { height: '640px', width: '600px' }
-        : { height: '600px', width: '360px' };
+      : sidePanel
+        ? { height: '100%', width: '100%' }
+        : fullPage
+          ? { height: '640px', width: '600px' }
+          : { height: '600px', width: '360px' };
 
   return (
     <div

--- a/src/app/pages/Explore/MainBanner.tsx
+++ b/src/app/pages/Explore/MainBanner.tsx
@@ -27,10 +27,10 @@ const BalanceBanner: FC<{ balance: BigNumber }> = ({ balance }) => {
 };
 
 const AssetBanner: FC = () => {
-  const { popup } = useAppEnv();
+  const { compact } = useAppEnv();
 
   return (
-    <BannerLayout name={<Name style={{ maxWidth: popup ? '11rem' : '13rem' }}>{'Miden'}</Name>}>
+    <BannerLayout name={<Name style={{ maxWidth: compact ? '11rem' : '13rem' }}>{'Miden'}</Name>}>
       <Balance>{balance => <BalanceBanner balance={balance} />}</Balance>
     </BannerLayout>
   );

--- a/src/app/pages/Explore/SyncBanner.tsx
+++ b/src/app/pages/Explore/SyncBanner.tsx
@@ -16,7 +16,7 @@ const SyncBanner = memo<SyncBannerProps>(({ syncText, fullPage }: SyncBannerProp
   const appEnv = useAppEnv();
   const maximizeClick = () => {
     openInFullPage();
-    if (appEnv.popup) {
+    if (appEnv.compact) {
       window.close();
     }
   };

--- a/src/app/pages/Receive.tsx
+++ b/src/app/pages/Receive.tsx
@@ -57,7 +57,7 @@ export const Receive: React.FC<ReceiveProps> = () => {
   const { fieldRef, copy, copied } = useCopyToClipboard();
   const { data: claimableNotes, mutate: mutateClaimableNotes } = useClaimableNotes(address);
   const isDelegatedProvingEnabled = isDelegateProofEnabled();
-  const { fullPage } = useAppEnv();
+  const { fullPage, sidePanel } = useAppEnv();
   const safeClaimableNotes = useMemo(
     () => (claimableNotes ?? []).filter((n): n is NonNullable<typeof n> => n != null),
     [claimableNotes]
@@ -326,11 +326,12 @@ export const Receive: React.FC<ReceiveProps> = () => {
   ]);
 
   // Match SendManager's container sizing - use h-full to inherit from parent (body has safe area padding)
-  const containerClass = isMobile()
-    ? 'h-full w-full'
-    : fullPage
-      ? 'h-[640px] max-h-[640px] w-[600px] max-w-[600px] border rounded-3xl'
-      : 'h-[600px] max-h-[600px] w-[360px] max-w-[360px]';
+  const containerClass =
+    isMobile() || sidePanel
+      ? 'h-full w-full'
+      : fullPage
+        ? 'h-[640px] max-h-[640px] w-[600px] max-w-[600px] border rounded-3xl'
+        : 'h-[600px] max-h-[600px] w-[360px] max-w-[360px]';
 
   const [isQRSheetOpen, setIsQRSheetOpen] = useState(false);
 

--- a/src/app/pages/TokenDetail.tsx
+++ b/src/app/pages/TokenDetail.tsx
@@ -40,7 +40,7 @@ type TokenDetailProps = {
 
 const TokenDetail: FC<TokenDetailProps> = ({ tokenId }) => {
   const { t } = useTranslation();
-  const { fullPage } = useAppEnv();
+  const { fullPage, sidePanel } = useAppEnv();
   const account = useAccount();
   const scrollParentRef = useRef<HTMLDivElement>(null);
   const allTokensMetadata = useAllTokensBaseMetadata();
@@ -56,11 +56,12 @@ const TokenDetail: FC<TokenDetailProps> = ({ tokenId }) => {
 
   const handleBack = () => goBack();
 
-  const containerClass = isMobile()
-    ? 'h-full w-full'
-    : fullPage
-      ? 'h-[640px] max-h-[640px] w-[600px] max-w-[600px]'
-      : 'h-[600px] max-h-[600px] w-[360px] max-w-[360px]';
+  const containerClass =
+    isMobile() || sidePanel
+      ? 'h-full w-full'
+      : fullPage
+        ? 'h-[640px] max-h-[640px] w-[600px] max-w-[600px]'
+        : 'h-[600px] max-h-[600px] w-[360px] max-w-[360px]';
 
   return (
     <div className={classNames(containerClass, 'mx-auto overflow-hidden flex flex-col bg-app-bg')}>

--- a/src/app/pages/Unlock.tsx
+++ b/src/app/pages/Unlock.tsx
@@ -42,7 +42,7 @@ const Unlock: FC<UnlockProps> = ({ openForgotPasswordInFullPage = false }) => {
   const { t } = useTranslation();
   const { unlock } = useMidenContext();
   const formAnalytics = useFormAnalytics('UnlockWallet');
-  const { popup } = useAppEnv();
+  const { compact } = useAppEnv();
 
   const [attempt, setAttempt] = useLocalStorage<number>(MidenSharedStorageKey.PasswordAttempts, 1);
   const [timelock, setTimeLock] = useLocalStorage<number>(MidenSharedStorageKey.TimeLock, 0);
@@ -182,13 +182,13 @@ const Unlock: FC<UnlockProps> = ({ openForgotPasswordInFullPage = false }) => {
     if (openForgotPasswordInFullPage) {
       navigate('/forgot-password-info');
       openInFullPage();
-      if (popup) {
+      if (compact) {
         window.close();
       }
     } else {
       navigate('/forgot-password-info');
     }
-  }, [openForgotPasswordInFullPage, popup]);
+  }, [openForgotPasswordInFullPage, compact]);
 
   // Retry hardware unlock for hardware-only wallets
   const onRetryHardwareUnlock = useCallback(async () => {

--- a/src/app/templates/ModalWithTitle.tsx
+++ b/src/app/templates/ModalWithTitle.tsx
@@ -10,12 +10,12 @@ export type ModalWithTitleProps = CustomModalProps & {
 };
 
 const ModalWithTitle: FC<ModalWithTitleProps> = ({ title, children, className, ...restProps }) => {
-  const { popup } = useAppEnv();
+  const { compact } = useAppEnv();
 
   return (
     <CustomModal
       {...restProps}
-      className={classNames('w-full max-w-md', popup ? 'px-4' : 'px-6', 'pb-4 pt-5', className)}
+      className={classNames('w-full max-w-md', compact ? 'px-4' : 'px-6', 'pb-4 pt-5', className)}
     >
       <>
         {title ? <h1 className={classNames('mb-6 text-lg font-medium', 'text-black text-left')}>{title}</h1> : null}

--- a/src/app/templates/PinExtensionPrompt.tsx
+++ b/src/app/templates/PinExtensionPrompt.tsx
@@ -1,0 +1,83 @@
+import React, { FC, useCallback, useEffect, useState } from 'react';
+
+import classNames from 'clsx';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from 'components/Button';
+import { isExtension } from 'lib/platform';
+
+/**
+ * Shows a floating prompt asking users to pin the extension to the toolbar.
+ * Only displays once after fresh install, then auto-dismisses.
+ */
+export const PinExtensionPrompt: FC = () => {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isExtension()) return;
+
+    chrome.storage.local.get('fresh_install', result => {
+      if (result.fresh_install) {
+        setVisible(true);
+        chrome.storage.local.remove('fresh_install');
+      }
+    });
+  }, []);
+
+  const dismiss = useCallback(() => setVisible(false), []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed z-[9999] pointer-events-none" style={{ top: 8, right: 60 }}>
+      {/* Arrow pointing up */}
+      <div
+        style={{
+          width: 0,
+          height: 0,
+          borderLeft: '10px solid transparent',
+          borderRight: '10px solid transparent',
+          borderBottom: '10px solid #1a1a2e',
+          marginLeft: 'auto',
+          marginRight: 24
+        }}
+      />
+      {/* Tooltip body */}
+      <div
+        className={classNames(
+          'rounded-xl shadow-2xl px-5 py-4',
+          'flex flex-col items-center gap-3',
+          'text-pure-white pointer-events-auto'
+        )}
+        style={{
+          backgroundColor: '#1a1a2e',
+          maxWidth: 280
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <PuzzleIcon />
+          <p className="text-sm font-semibold">{t('pinExtensionTitle')}</p>
+        </div>
+        <p className="text-xs text-center opacity-80">{t('pinExtensionDescription')}</p>
+        <Button
+          className={classNames(
+            'px-4 py-1.5 rounded-lg text-xs font-semibold',
+            'bg-pure-white/20 hover:bg-pure-white/30',
+            'text-pure-white transition-colors'
+          )}
+          onClick={dismiss}
+        >
+          {t('gotIt')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+/** Puzzle piece icon matching Chrome's extensions icon */
+const PuzzleIcon: FC = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M20.5 11H19V7c0-1.1-.9-2-2-2h-4V3.5a2.5 2.5 0 0 0-5 0V5H4c-1.1 0-2 .9-2 2v3.8h1.5c1.4 0 2.5 1.1 2.5 2.5s-1.1 2.5-2.5 2.5H2V19c0 1.1.9 2 2 2h3.8v-1.5c0-1.4 1.1-2.5 2.5-2.5s2.5 1.1 2.5 2.5V21H17c1.1 0 2-.9 2-2v-4h1.5a2.5 2.5 0 0 0 0-5z" />
+  </svg>
+);

--- a/src/app/templates/history/HistoryItem.tsx
+++ b/src/app/templates/history/HistoryItem.tsx
@@ -24,7 +24,7 @@ type HistoryItemProps = {
 
 const HistoryContent: FC<HistoryItemProps> = ({ fullHistory, entry, lastEntry }) => {
   const { t } = useTranslation();
-  const { popup } = useAppEnv();
+  const { compact } = useAppEnv();
   const isReceive = entry.transactionIcon === 'RECEIVE' || entry.message === 'Consuming';
   const isFaucet = isFaucetRequest(entry);
 
@@ -61,7 +61,7 @@ const HistoryContent: FC<HistoryItemProps> = ({ fullHistory, entry, lastEntry })
         {entry.secondaryAddress && (
           <span className="text-xs text-grey-500 truncate flex gap-0.5">
             <p className="font-medium">{`${isReceive ? t('from') : t('to')}: `}</p>
-            <AddressShortView address={entry.secondaryAddress} trim={isMobile() || popup} />
+            <AddressShortView address={entry.secondaryAddress} trim={isMobile() || compact} />
           </span>
         )}
       </div>

--- a/src/background.ts
+++ b/src/background.ts
@@ -11,11 +11,16 @@ import { setupTransactionProcessor } from 'lib/miden/back/transaction-processor'
 
 // Chrome: restore side panel preference on startup
 if (process.env.TARGET_BROWSER === 'chrome') {
-  const chrome = (globalThis as any).chrome;
-  chrome.storage.local.get('sidepanel_mode', (result: { sidepanel_mode?: boolean }) => {
+  const chromeApi = (globalThis as any).chrome;
+  chromeApi.storage.local.get('sidepanel_mode', (result: { sidepanel_mode?: boolean }) => {
     if (result.sidepanel_mode) {
-      chrome.action.setPopup({ popup: '' });
-      chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+      chromeApi.action.setPopup({ popup: '' });
+      chromeApi.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch((err: Error) => {
+        // Restore popup if side panel setup fails
+        chromeApi.action.setPopup({ popup: 'popup.html' });
+        chromeApi.storage.local.set({ sidepanel_mode: false });
+        console.warn('[Background] Side panel restore failed, reverting to popup:', err);
+      });
     }
   });
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -7,7 +7,18 @@ import { start } from 'lib/miden/back/main';
 import { doSync, setupSyncManager } from 'lib/miden/back/sync-manager';
 import { setupTransactionProcessor } from 'lib/miden/back/transaction-processor';
 
-runtime.onInstalled.addListener(({ reason }) => (reason === 'install' ? openFullPage() : null));
+// NOTE: onInstalled is handled in sw.js (must be synchronous for MV3)
+
+// Chrome: restore side panel preference on startup
+if (process.env.TARGET_BROWSER === 'chrome') {
+  const chrome = (globalThis as any).chrome;
+  chrome.storage.local.get('sidepanel_mode', (result: { sidepanel_mode?: boolean }) => {
+    if (result.sidepanel_mode) {
+      chrome.action.setPopup({ popup: '' });
+      chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+    }
+  });
+}
 
 runtime.onUpdateAvailable.addListener(details => {
   // Swaps in the new version immediately

--- a/src/components/explore/ActionButtons.tsx
+++ b/src/components/explore/ActionButtons.tsx
@@ -28,8 +28,15 @@ interface ActionButtonProps extends TestIDProps {
   isActive?: boolean;
 }
 
-function getActionBgColor(_type: 'send' | 'receive' | 'faucet') {
-  return 'bg-[#777487]';
+function getActionBgColor(type: 'send' | 'receive' | 'faucet') {
+  switch (type) {
+    case 'send':
+      return 'bg-send-blue';
+    case 'receive':
+      return 'bg-receive-green';
+    default:
+      return 'bg-[#777487]';
+  }
 }
 
 const ActionButton: FC<ActionButtonProps> = ({

--- a/src/screens/consuming-note/ConsumingNote.tsx
+++ b/src/screens/consuming-note/ConsumingNote.tsx
@@ -5,10 +5,12 @@ import classNames from 'clsx';
 import { useTranslation } from 'react-i18next';
 
 import CircularProgress from 'app/atoms/CircularProgress';
+import { useAppEnv } from 'app/env';
 import { Icon, IconName } from 'app/icons/v2';
 import { Alert, AlertVariant } from 'components/Alert';
 import { Button, ButtonVariant } from 'components/Button';
 import { useAccount } from 'lib/miden/front';
+import { isMobile } from 'lib/platform';
 import { useWalletStore } from 'lib/store';
 import { truncateHash } from 'utils/string';
 
@@ -81,11 +83,9 @@ export const ConsumingNotePage: FC<ConsumingNotePageProps> = ({ noteId }) => {
     return undefined;
   }, [status, onClose]);
 
-  // On mobile, use h-full to inherit from parent chain (body has safe area padding)
-  const isMobileDevice = typeof window !== 'undefined' && /Android|iPhone|iPad/i.test(navigator.userAgent);
-  const containerClass = isMobileDevice
-    ? 'h-full w-full'
-    : 'h-[640px] max-h-[640px] w-[600px] max-w-[600px] border rounded-3xl';
+  const { sidePanel } = useAppEnv();
+  const containerClass =
+    isMobile() || sidePanel ? 'h-full w-full' : 'h-[640px] max-h-[640px] w-[600px] max-w-[600px] border rounded-3xl';
 
   return (
     <div

--- a/src/screens/onboarding/navigator.tsx
+++ b/src/screens/onboarding/navigator.tsx
@@ -213,7 +213,10 @@ export const OnboardingFlow: FC<OnboardingFlowProps> = ({
   };
 
   return (
-    <div className={classNames('flex flex-col', 'bg-app-bg', 'overflow-hidden', 'w-full h-full mx-auto')}>
+    <div
+      className={classNames('flex flex-col', 'bg-app-bg', 'overflow-hidden', 'w-full h-full mx-auto')}
+      style={{ maxWidth: 420 }}
+    >
       <div className="flex flex-col flex-1 min-h-0">
         <AnimatePresence mode={'wait'} initial={false}>
           {step !== OnboardingStep.Welcome && (

--- a/src/screens/send-flow/SendManager.tsx
+++ b/src/screens/send-flow/SendManager.tsx
@@ -79,7 +79,7 @@ export const SendManager: React.FC<SendManagerProps> = ({ isLoading, preselected
   const { navigateTo, goBack, cardStack } = useNavigator();
   const allAccounts = useAllAccounts();
   const { publicKey } = useAccount();
-  const { fullPage } = useAppEnv();
+  const { fullPage, sidePanel } = useAppEnv();
   const delegateEnabled = isDelegateProofEnabled();
   const [recallDate, setRecallDate] = useState<Date | undefined>(undefined);
   const [recallTime, setRecallTime] = useState('12:00');
@@ -459,11 +459,12 @@ export const SendManager: React.FC<SendManagerProps> = ({ isLoading, preselected
 
   // On mobile, use h-full to inherit from parent chain (body has safe area padding)
   const isMobileDevice = isMobile();
-  const containerClass = isMobileDevice
-    ? 'h-full w-full'
-    : fullPage
-      ? 'h-[640px] max-h-[640px] w-[600px] max-w-[600px]'
-      : 'h-[600px] max-h-[600px] w-[360px] max-w-[360px]';
+  const containerClass =
+    isMobileDevice || sidePanel
+      ? 'h-full w-full'
+      : fullPage
+        ? 'h-[640px] max-h-[640px] w-[600px] max-w-[600px]'
+        : 'h-[600px] max-h-[600px] w-[360px] max-w-[360px]';
 
   return (
     <div

--- a/src/sidepanel.tsx
+++ b/src/sidepanel.tsx
@@ -1,0 +1,17 @@
+import './main.css';
+
+import React from 'react';
+
+import { createRoot } from 'react-dom/client';
+
+import 'lib/lock-up/run-checks';
+
+import App from 'app/App';
+import { WindowType } from 'app/env';
+import { initTheme } from 'lib/settings/theme';
+
+initTheme();
+
+const container = document.getElementById('root');
+const root = createRoot(container!);
+root.render(<App env={{ windowType: WindowType.SidePanel }} />);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,7 @@ const appConfig = {
     fullpage: './src/fullpage.tsx',
     options: './src/options.tsx',
     popup: './src/popup.tsx',
+    sidepanel: './src/sidepanel.tsx',
     contentScript: './src/contentScript.ts',
     addToWindow: './src/addToWindow.ts'
   },
@@ -94,6 +95,7 @@ const appConfig = {
     new Dotenv(),
     new webpack.EnvironmentPlugin({
       VERSION: pkg.version,
+      TARGET_BROWSER: TARGET_BROWSER,
       MIDEN_USE_MOCK_CLIENT: MIDEN_USE_MOCK_CLIENT || 'false'
     }),
 
@@ -288,6 +290,7 @@ const backgroundConfig = {
     new Dotenv(),
     new webpack.EnvironmentPlugin({
       VERSION: pkg.version,
+      TARGET_BROWSER: TARGET_BROWSER,
       MIDEN_USE_MOCK_CLIENT: MIDEN_USE_MOCK_CLIENT || 'false'
     }),
 
@@ -466,6 +469,7 @@ const workerConfig = {
     new Dotenv(),
     new webpack.EnvironmentPlugin({
       VERSION: pkg.version,
+      TARGET_BROWSER: TARGET_BROWSER,
       MIDEN_USE_MOCK_CLIENT: MIDEN_USE_MOCK_CLIENT || 'false'
     }),
 

--- a/webpack.html.config.js
+++ b/webpack.html.config.js
@@ -29,7 +29,8 @@ module.exports = publicPath => {
     getTemplateEntry(publicPath, 'popup'),
     getTemplateEntry(publicPath, 'fullpage'),
     getTemplateEntry(publicPath, 'confirm'),
-    getTemplateEntry(publicPath, 'options')
+    getTemplateEntry(publicPath, 'options'),
+    getTemplateEntry(publicPath, 'sidepanel')
   ];
 
   return htmlTemplates.map(

--- a/yarn.lock
+++ b/yarn.lock
@@ -13236,9 +13236,9 @@ zlib@^1.0.5:
   integrity sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==
 
 zustand@^5.0.0:
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.11.tgz#99f912e590de1ca9ce6c6d1cab6cdb1f034ab494"
-  integrity sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.12.tgz#ed36f647aa89965c4019b671dfc23ef6c6e3af8c"
+  integrity sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==
 
 zustand@^5.0.9:
   version "5.0.10"


### PR DESCRIPTION
## Summary

- Add Chrome Side Panel as an alternative display mode (popup remains the default)
- Users can toggle between popup and side panel via the maximize/minimize icon in the header
- Preference is persisted across sessions via `chrome.storage.local`
- Add pin extension prompt on first install
- Color-coded Send (blue) and Receive (green) action buttons on home page
- Update `@miden-sdk/miden-sdk` to 0.13.3

## Details

**Side panel infrastructure:**
- New `WindowType.SidePanel` enum variant and `compact` boolean (`popup || sidePanel`) in `useAppEnv()`
- New `sidepanel.html` (full-height layout) and `sidepanel.tsx` entry point
- Manifest: `side_panel` config, `sidePanel` permission, Chrome min version bumped to 114
- Webpack: sidepanel entry point and HTML template added

**Mode toggle:**
- Maximize icon in popup → opens side panel, disables popup on icon click
- Minimize icon in side panel → closes panel, restores popup on icon click
- Background script restores preference on startup via `chrome.action.setPopup()` and `chrome.sidePanel.setPanelBehavior()`

**Layout updates:**
- Side panel uses `height: 100%; width: 100%` (not fixed 360×600px)
- All container sizing components updated: PageLayout, TabLayout, SimplePageLayout, Receive, TokenDetail, SendManager, ConsumingNote

**Other:**
- `popup` checks migrated to `compact` across 10+ components for shared narrow-width behavior
- Pin extension prompt shown once after fresh install
- Onboarding flow constrained to 420px max-width

## Test plan

- [ ] Click extension icon → popup opens (default)
- [ ] Click maximize icon in popup → side panel opens, popup closes
- [ ] Click extension icon while in side panel mode → side panel opens (not popup)
- [ ] Click minimize icon in side panel → panel closes
- [ ] Click extension icon after minimizing → popup opens
- [ ] Reload extension → mode preference persists
- [ ] Fresh install → fullpage tab opens with pin prompt
- [ ] Send/Receive buttons on home page show blue/green colors
- [ ] All screens render correctly in side panel (full height, no overflow)