### PR TITLE
fix: dedup consume transactions across Completed state (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [FEATURE][all] Migrated backend from `WasmWebClient` to the new `MidenClient` TypeScript API. All service-worker WASM access now goes through `MidenClientInterface` wrapping the high-level `MidenClient` surface.
 * [FEATURE][all] Migrated frontend to `@miden-sdk/react` hooks (`useMiden`, `useSyncState`, `useAccount`, etc.), replacing manual sync and balance-polling logic.
 
+### Fixes
+
+* [FIX][all] Fixed duplicate consume-transaction entries in wallet history when receiving a single note. `initiateConsumeTransaction` now dedups against all non-`Failed` consume txs for the same note (including `Completed`), preventing auto-consume from re-enqueueing while `getConsumableNotes` is still returning the note during chain-sync lag. Also replaced the sync poll's blanket clear of `extensionClaimingNoteIds` with a surgical remove so Explore's `isBeingClaimed` gate works correctly. (#184)
+
 ---
 
 ## 1.13.3 (2026-03-19)

--- a/src/lib/miden/activity/transactions.extended.test.ts
+++ b/src/lib/miden/activity/transactions.extended.test.ts
@@ -45,13 +45,27 @@ jest.mock('lib/miden/repo', () => ({
     filter: jest.fn((fn: (tx: any) => boolean) => ({
       toArray: jest.fn(async () => txStore.filter(fn))
     })),
-    where: jest.fn((query: any) => ({
-      first: jest.fn(async () => txStore.find(t => t.id === query.id)),
-      modify: jest.fn(async (fn: (tx: any) => void) => {
-        const tx = txStore.find(t => t.id === query.id);
-        if (tx) fn(tx);
-      })
-    }))
+    where: jest.fn((arg: any) => {
+      // Indexed lookup path: where('fieldName').equals(value).filter(fn).toArray()
+      if (typeof arg === 'string') {
+        const field = arg;
+        return {
+          equals: (val: any) => ({
+            filter: (fn: (tx: any) => boolean) => ({
+              toArray: async () => txStore.filter(t => t[field] === val).filter(fn)
+            })
+          })
+        };
+      }
+      // Primary-key path: where({ id }).first() / .modify()
+      return {
+        first: jest.fn(async () => txStore.find(t => t.id === arg.id)),
+        modify: jest.fn(async (fn: (tx: any) => void) => {
+          const tx = txStore.find(t => t.id === arg.id);
+          if (tx) fn(tx);
+        })
+      };
+    })
   }
 }));
 
@@ -598,6 +612,16 @@ describe('initiateConsumeTransactionFromId', () => {
 });
 
 describe('initiateConsumeTransaction reuse path', () => {
+  const buildNote = (overrides: Partial<any> = {}) => ({
+    id: 'note-1',
+    faucetId: 'f',
+    amount: '1',
+    senderAddress: 'sender',
+    isBeingClaimed: false,
+    type: NoteTypeEnum.Public,
+    ...overrides
+  });
+
   it('does not duplicate when an in-flight consume already exists for the same note', async () => {
     txStore.push({
       id: 'existing',
@@ -607,16 +631,54 @@ describe('initiateConsumeTransaction reuse path', () => {
       status: ITransactionStatus.GeneratingTransaction,
       initiatedAt: 100
     });
-    const note = {
-      id: 'note-1',
-      faucetId: 'f',
-      amount: '1',
-      senderAddress: 'sender',
-      isBeingClaimed: false,
-      type: NoteTypeEnum.Public
-    };
-    const result = await initiateConsumeTransaction('acc-1', note);
+    const result = await initiateConsumeTransaction('acc-1', buildNote());
     expect(result).toBe('existing');
     expect(txStore.filter(t => t.type === 'consume')).toHaveLength(1);
+  });
+
+  it('does not duplicate when a Completed consume already exists for the same note', async () => {
+    // Regression test for issue #171: after a consume completes, getConsumableNotes()
+    // may still return the same note briefly. Auto-consume must not enqueue another tx.
+    txStore.push({
+      id: 'completed',
+      type: 'consume',
+      noteId: 'note-1',
+      accountId: 'acc-1',
+      status: ITransactionStatus.Completed,
+      initiatedAt: 100,
+      completedAt: 200
+    });
+    const result = await initiateConsumeTransaction('acc-1', buildNote());
+    expect(result).toBe('completed');
+    expect(txStore.filter(t => t.type === 'consume')).toHaveLength(1);
+  });
+
+  it('allows retry when only a Failed consume exists for the same note', async () => {
+    txStore.push({
+      id: 'failed',
+      type: 'consume',
+      noteId: 'note-1',
+      accountId: 'acc-1',
+      status: ITransactionStatus.Failed,
+      initiatedAt: 100,
+      completedAt: 200
+    });
+    const result = await initiateConsumeTransaction('acc-1', buildNote());
+    expect(result).not.toBe('failed');
+    expect(txStore.filter(t => t.type === 'consume')).toHaveLength(2);
+  });
+
+  it('does not dedup a consume from a different account with the same noteId', async () => {
+    txStore.push({
+      id: 'other-account',
+      type: 'consume',
+      noteId: 'note-1',
+      accountId: 'acc-2',
+      status: ITransactionStatus.Completed,
+      initiatedAt: 100
+    });
+    const result = await initiateConsumeTransaction('acc-1', buildNote());
+    expect(result).not.toBe('other-account');
+    expect(txStore.filter(t => t.type === 'consume')).toHaveLength(2);
   });
 });

--- a/src/lib/miden/activity/transactions.test.ts
+++ b/src/lib/miden/activity/transactions.test.ts
@@ -288,20 +288,28 @@ describe('transactions utilities', () => {
   });
 
   describe('initiateConsumeTransaction', () => {
-    it('creates consume transaction when none exists', async () => {
-      mockTransactionsFilter.mockReturnValueOnce({
-        toArray: jest.fn().mockResolvedValueOnce([])
-      });
-      mockTransactionsAdd.mockResolvedValueOnce(undefined);
+    const note = {
+      id: 'note-123',
+      faucetId: 'faucet',
+      amount: '100',
+      senderAddress: 'sender',
+      isBeingClaimed: false,
+      type: NoteTypeEnum.Private
+    };
 
-      const note = {
-        id: 'note-123',
-        faucetId: 'faucet',
-        amount: '100',
-        senderAddress: 'sender',
-        isBeingClaimed: false,
-        type: NoteTypeEnum.Private
-      };
+    const mockDedupQuery = (rows: any[]) => {
+      mockTransactionsWhere.mockReturnValueOnce({
+        equals: jest.fn().mockReturnValueOnce({
+          filter: jest.fn().mockReturnValueOnce({
+            toArray: jest.fn().mockResolvedValueOnce(rows)
+          })
+        })
+      });
+    };
+
+    it('creates consume transaction when none exists', async () => {
+      mockDedupQuery([]);
+      mockTransactionsAdd.mockResolvedValueOnce(undefined);
 
       const result = await initiateConsumeTransaction('account-1', note);
 
@@ -309,7 +317,7 @@ describe('transactions utilities', () => {
       expect(typeof result).toBe('string');
     });
 
-    it('returns existing transaction id if consume for same note exists', async () => {
+    it('returns existing transaction id when a Queued consume exists for same note', async () => {
       const existingTx = {
         id: 'existing-tx',
         type: 'consume',
@@ -318,23 +326,64 @@ describe('transactions utilities', () => {
         status: ITransactionStatus.Queued,
         initiatedAt: 100
       };
-      mockTransactionsFilter.mockReturnValueOnce({
-        toArray: jest.fn().mockResolvedValueOnce([existingTx])
-      });
-
-      const note = {
-        id: 'note-123',
-        faucetId: 'faucet',
-        amount: '100',
-        senderAddress: 'sender',
-        isBeingClaimed: false,
-        type: NoteTypeEnum.Private
-      };
+      mockDedupQuery([existingTx]);
 
       const result = await initiateConsumeTransaction('account-1', note);
 
       expect(result).toBe('existing-tx');
       expect(mockTransactionsAdd).not.toHaveBeenCalled();
+    });
+
+    it('returns existing transaction id when a Completed consume exists for same note', async () => {
+      // This is the bug from issue #171: after a consume completes, getConsumableNotes()
+      // can still return the note briefly. Without Completed dedup, auto-consume would
+      // re-enqueue a fresh tx every SWR poll.
+      const existingTx = {
+        id: 'completed-tx',
+        type: 'consume',
+        noteId: 'note-123',
+        accountId: 'account-1',
+        status: ITransactionStatus.Completed,
+        initiatedAt: 100,
+        completedAt: 200
+      };
+      mockDedupQuery([existingTx]);
+
+      const result = await initiateConsumeTransaction('account-1', note);
+
+      expect(result).toBe('completed-tx');
+      expect(mockTransactionsAdd).not.toHaveBeenCalled();
+    });
+
+    it('creates a new transaction when only a Failed consume exists (retry allowed)', async () => {
+      // Failed txs are excluded from the dedup filter, so the user can retry a consume
+      // that previously failed. The Dexie query filter drops Failed rows, so we simulate
+      // that here by returning [] from the filtered query.
+      mockDedupQuery([]);
+      mockTransactionsAdd.mockResolvedValueOnce(undefined);
+
+      const result = await initiateConsumeTransaction('account-1', note);
+
+      expect(mockTransactionsAdd).toHaveBeenCalled();
+      expect(typeof result).toBe('string');
+    });
+
+    it('does not dedup across different accounts', async () => {
+      const otherAccountTx = {
+        id: 'other-account-tx',
+        type: 'consume',
+        noteId: 'note-123',
+        accountId: 'account-2',
+        status: ITransactionStatus.Completed,
+        initiatedAt: 100
+      };
+      mockDedupQuery([otherAccountTx]);
+      mockTransactionsAdd.mockResolvedValueOnce(undefined);
+
+      const result = await initiateConsumeTransaction('account-1', note);
+
+      expect(result).not.toBe('other-account-tx');
+      expect(mockTransactionsAdd).toHaveBeenCalled();
     });
   });
 
@@ -343,8 +392,12 @@ describe('transactions utilities', () => {
       mockGetInputNote.mockReturnValueOnce({
         metadata: () => ({ noteType: () => 'public' })
       });
-      mockTransactionsFilter.mockReturnValueOnce({
-        toArray: jest.fn().mockResolvedValueOnce([])
+      mockTransactionsWhere.mockReturnValueOnce({
+        equals: jest.fn().mockReturnValueOnce({
+          filter: jest.fn().mockReturnValueOnce({
+            toArray: jest.fn().mockResolvedValueOnce([])
+          })
+        })
       });
       mockTransactionsAdd.mockResolvedValueOnce(undefined);
 

--- a/src/lib/miden/activity/transactions.ts
+++ b/src/lib/miden/activity/transactions.ts
@@ -145,8 +145,16 @@ export const initiateConsumeTransaction = async (
   delegateTransaction?: boolean
 ): Promise<string> => {
   const dbTransaction = new ConsumeTransaction(accountId, note, delegateTransaction);
-  const uncompletedTransactions = await getUncompletedTransactions(accountId);
-  const existingTransaction = uncompletedTransactions.find(tx => tx.type === 'consume' && tx.noteId === note.id);
+  // Dedup against all non-Failed consume txs for this noteId, including Completed ones.
+  // Reason: getConsumableNotes() can still return a note for a short window after a local
+  // consume completes (chain-sync lag). Without this, auto-consume polling creates a new
+  // tx every 5s until the sync catches up. Failed txs are excluded so retries still work.
+  const existingByNote = await Repo.transactions
+    .where('noteId')
+    .equals(note.id)
+    .filter(tx => tx.type === 'consume' && tx.status !== ITransactionStatus.Failed)
+    .toArray();
+  const existingTransaction = existingByNote.find(tx => compareAccountIds(tx.accountId, accountId));
   if (existingTransaction) {
     return existingTransaction.id;
   }

--- a/src/lib/miden/repo.ts
+++ b/src/lib/miden/repo.ts
@@ -26,6 +26,10 @@ db.version(1.1)
     await tx.db.table<ITransaction, string>(Table.Transactions).clear();
   });
 
+db.version(1.2).stores({
+  [Table.Transactions]: indexes('id', 'accountId', 'transactionId', 'initiatedAt', 'completedAt', 'noteId')
+});
+
 export const transactions = db.table<ITransaction, string>(Table.Transactions);
 
 function indexes(...items: string[]) {

--- a/src/lib/store/hooks/useIntercomSync.ts
+++ b/src/lib/store/hooks/useIntercomSync.ts
@@ -96,10 +96,22 @@ export function useIntercomSync() {
         if (!syncData) return;
         if (syncData.accountPublicKey !== accountPublicKey) return;
 
-        // Clear stale claiming IDs (sync data is authoritative)
-        store().clearExtensionClaimingNoteIds();
-        // Trigger note toast check (so popup shows toast for new notes)
         const noteIds = syncData.notes.map(n => n.id);
+
+        // Drop claiming IDs for notes that are no longer consumable (the SW has
+        // confirmed the consume). A blanket reset here would defeat the
+        // isBeingClaimed gate used by Explore's auto-consume, because
+        // NoteClaimStarted broadcasts fire once while this poll ticks every 3s.
+        const consumableIds = new Set(noteIds);
+        const staleClaimingIds: string[] = [];
+        for (const id of store().extensionClaimingNoteIds) {
+          if (!consumableIds.has(id)) staleClaimingIds.push(id);
+        }
+        if (staleClaimingIds.length > 0) {
+          store().removeExtensionClaimingNoteIds(staleClaimingIds);
+        }
+
+        // Trigger note toast check (so popup shows toast for new notes)
         store().checkForNewNotes(noteIds);
         // Convert vault assets → balances, update Zustand
         updateBalancesFromSyncData(syncData.accountPublicKey, syncData.vaultAssets).catch(err =>

--- a/src/lib/store/index.test.ts
+++ b/src/lib/store/index.test.ts
@@ -1017,6 +1017,25 @@ describe('useWalletStore', () => {
       useWalletStore.getState().clearExtensionClaimingNoteIds();
       expect(useWalletStore.getState().extensionClaimingNoteIds.size).toBe(0);
     });
+
+    it('removeExtensionClaimingNoteIds removes only the specified ids', () => {
+      useWalletStore.getState().addExtensionClaimingNoteId('n1');
+      useWalletStore.getState().addExtensionClaimingNoteId('n2');
+      useWalletStore.getState().addExtensionClaimingNoteId('n3');
+      useWalletStore.getState().removeExtensionClaimingNoteIds(['n1', 'n3']);
+      const ids = useWalletStore.getState().extensionClaimingNoteIds;
+      expect(ids.has('n1')).toBe(false);
+      expect(ids.has('n2')).toBe(true);
+      expect(ids.has('n3')).toBe(false);
+    });
+
+    it('removeExtensionClaimingNoteIds is a no-op for empty input and unknown ids', () => {
+      useWalletStore.getState().addExtensionClaimingNoteId('n1');
+      const before = useWalletStore.getState().extensionClaimingNoteIds;
+      useWalletStore.getState().removeExtensionClaimingNoteIds([]);
+      useWalletStore.getState().removeExtensionClaimingNoteIds(['unknown']);
+      expect(useWalletStore.getState().extensionClaimingNoteIds).toBe(before);
+    });
   });
 
   describe('fetchBalances action (skip guard)', () => {

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -558,6 +558,18 @@ export const useWalletStore = create<WalletStore>()(
       }));
     },
 
+    removeExtensionClaimingNoteIds: noteIds => {
+      if (noteIds.length === 0) return;
+      set(state => {
+        const next = new Set(state.extensionClaimingNoteIds);
+        let changed = false;
+        for (const id of noteIds) {
+          if (next.delete(id)) changed = true;
+        }
+        return changed ? { extensionClaimingNoteIds: next } : {};
+      });
+    },
+
     clearExtensionClaimingNoteIds: () => {
       set({ extensionClaimingNoteIds: new Set<string>() });
     }

--- a/src/lib/store/types.ts
+++ b/src/lib/store/types.ts
@@ -215,6 +215,8 @@ export interface ExtensionSyncSlice {
 export interface ExtensionSyncActions {
   setExtensionClaimableNotes: (notes: SerializedConsumableNote[]) => void;
   addExtensionClaimingNoteId: (noteId: string) => void;
+  /** Remove specific note IDs from the claiming set (e.g. those no longer consumable). */
+  removeExtensionClaimingNoteIds: (noteIds: string[]) => void;
   clearExtensionClaimingNoteIds: () => void;
 }
 


### PR DESCRIPTION
Closes #171.

## Summary
- Auto-consume was creating a fresh consume transaction every 5s SWR poll, producing up to 150 duplicate `Completed` rows for a single received note.
- Root cause: `initiateConsumeTransaction` deduped only against `Queued` / `GeneratingTransaction` transactions. After the first consume completed, the WASM client's `getConsumableNotes()` briefly kept returning the note (chain-sync lag), so each poll inserted a new row.

## Changes
- **`src/lib/miden/activity/transactions.ts`** — dedup now checks all non-`Failed` consume txs for the same `(noteId, accountId)`, including `Completed`. `Failed` is excluded so retries still work.
- **`src/lib/miden/repo.ts`** — Dexie schema bumped to `1.2` with a new `noteId` index so the dedup lookup is O(log n) instead of a full-table scan. Dexie reindexes existing rows automatically on open — no data migration.
- **`src/lib/store/hooks/useIntercomSync.ts`** — the 3s sync poll no longer blanket-clears `extensionClaimingNoteIds`, which was defeating Explore's `isBeingClaimed` gate. It now removes only IDs whose notes are no longer consumable in the SW's sync data.
- **`src/lib/store/{index,types}.ts`** — new `removeExtensionClaimingNoteIds(ids)` action backing the surgical removal above.

## Tests
- Regression cases in `transactions.test.ts` and `transactions.extended.test.ts`: Completed dedup, Failed retry, cross-account non-dedup.
- `store/index.test.ts`: coverage for `removeExtensionClaimingNoteIds` (partial removal + no-op paths).
- Full suite: **1647 passing, 121 suites**. Lint, prettier, and tsc clean.

## Test plan
- [x] `yarn test` — all suites pass
- [x] `yarn lint` — no warnings
- [x] `yarn format` — clean
- [x] `yarn tsc --noEmit` — clean
- [ ] Manual verification on an account with an unconsumed note: confirm the wallet produces exactly one `Consumed` history entry after receive.

## Notes for reviewers
- I traced the Rust-side question of *why* the SDK's `getConsumableNotes` re-returns a locally-consumed note (filter is correct, `apply_transaction` correctly flips `Committed` → `ProcessingAuthenticated`, and a repeat consume should `Err(NoteNotConsumable)`). The 150 `Completed` rows observed in the bug report can't be explained by that state machine alone — something is either resetting state back to `Committed` or the wallet is marking Completed despite a Rust failure. Without a live repro I can't pin that down; the JS dedup here is a defensive fix that works regardless of the root cause and is worth landing on its own.