### PR TITLE
ci: use mock Miden client for Playwright E2E on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         uses: borales/actions-yarn@v4
         with:
           cmd: build:chrome
+        env:
+          MIDEN_USE_MOCK_CLIENT: 'true'
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

CI on main has been failing since PR #151 because `ci.yml` builds the Chrome extension for Playwright without `MIDEN_USE_MOCK_CLIENT=true`. The production build bundles the real Miden WASM client, which attempts a gRPC call on the CI runner and fails with `invalid content type: application/grpc`. `registerWallet` in `Welcome.tsx` throws, the Explore page never renders, and `popup-smoke.spec.ts:80` times out.

`pr.yml:103` has always set this env var on the build step — this change mirrors that in `ci.yml`.

## Test plan

- [x] Reproduced locally: `yarn build:chrome` (no env) + `yarn test:e2e` → fails with the same gRPC error on onboarding create flow
- [x] Rebuilt with `MIDEN_USE_MOCK_CLIENT=true yarn build:chrome` + `SKIP_EXTENSION_BUILD=true yarn test:e2e` → 7/7 tests pass in 22s
- [ ] CI green on this PR