### PR TITLE
fix: gate page-side SDK WASM init; preserve live Dexie handles on clearStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.14.2 (TBD)
+
+### Fixes
+
+* [FIX][all] Gated page-side SDK WASM init. `fetchTokenMetadata` and `SendDetails` used to race the SDK's lazy wasm-bindgen load when constructing `Endpoint`/`RpcClient` directly on the page thread, hitting `Cannot read properties of undefined (reading '__wbindgen_malloc')` and blacklisting the token via `autoFetchMetadataFails` for the rest of the session. New `ensureSdkWasmReady()` helper actively triggers the SDK's `loadWasm()` via a Vite-aliased deep import and probes readiness, wired up before any page-side RPC construction. (#187)
+* [FIX][all] `clearStorage` no longer tears down live Dexie handles. The spawn-time reset used to call `Repo.db.delete() + db.open()`, which fired a `versionchange` event to every other open handle (notably the page's), forced them closed, and triggered `DatabaseClosedError` on subsequent page-side reads. Now clears only the transactions table; a new `resetStorageDestructive()` preserves the full-wipe semantics for the options-page "Reset Wallet" button that actually wants it. (#187)
+
+---
+
 ## 1.14.0 (TBD)
 
 ### Features

--- a/src/lib/miden-chain/constants.test.ts
+++ b/src/lib/miden-chain/constants.test.ts
@@ -1,14 +1,123 @@
 /**
  * Coverage tests for `lib/miden-chain/constants.ts`.
- *
- * Covers the getNetworkId function.
  */
 
-import { getNetworkId } from './constants';
+// Mock the virtual Vite alias — jest doesn't resolve it otherwise.
+jest.mock('sdk-wasm-loader', () => ({ __esModule: true, default: jest.fn(async () => undefined) }), { virtual: true });
+
+const mockEndpoint = jest.fn();
+jest.mock('@miden-sdk/miden-sdk', () => ({
+  Endpoint: function (url: string) {
+    return mockEndpoint(url);
+  },
+  NetworkId: {
+    mainnet: () => ({ kind: 'mainnet' }),
+    devnet: () => ({ kind: 'devnet' }),
+    testnet: () => ({ kind: 'testnet' })
+  }
+}));
 
 describe('miden-chain/constants', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockEndpoint.mockReset();
+  });
+
   it('getNetworkId returns a NetworkId', () => {
-    const id = getNetworkId();
-    expect(id).toBeDefined();
+    jest.isolateModules(() => {
+      const { getNetworkId } = require('./constants');
+      const id = getNetworkId();
+      expect(id).toBeDefined();
+    });
+  });
+
+  it('getRpcEndpoint constructs an Endpoint for the current network', () => {
+    mockEndpoint.mockReturnValue({ ok: true });
+    jest.isolateModules(() => {
+      const { getRpcEndpoint } = require('./constants');
+      getRpcEndpoint();
+    });
+    expect(mockEndpoint).toHaveBeenCalledTimes(1);
+    expect(mockEndpoint.mock.calls[0][0]).toMatch(/^https?:\/\//);
+  });
+
+  describe('ensureSdkWasmReady', () => {
+    it('resolves when deep loadWasm import + probe both succeed', async () => {
+      mockEndpoint.mockReturnValue({ ok: true });
+      await jest.isolateModulesAsync(async () => {
+        const { ensureSdkWasmReady } = require('./constants');
+        await expect(ensureSdkWasmReady()).resolves.toBeUndefined();
+      });
+    });
+
+    it('returns the cached promise on repeated calls', async () => {
+      mockEndpoint.mockReturnValue({ ok: true });
+      await jest.isolateModulesAsync(async () => {
+        const { ensureSdkWasmReady } = require('./constants');
+        const p1 = ensureSdkWasmReady();
+        const p2 = ensureSdkWasmReady();
+        expect(p1).toBe(p2);
+        await p1;
+      });
+    });
+
+    it('falls back to probe when loadWasm is not a function', async () => {
+      jest.doMock('sdk-wasm-loader', () => ({ __esModule: true, default: 'not-a-function' }), { virtual: true });
+      mockEndpoint.mockReturnValue({ ok: true });
+      await jest.isolateModulesAsync(async () => {
+        const { ensureSdkWasmReady } = require('./constants');
+        await expect(ensureSdkWasmReady()).resolves.toBeUndefined();
+      });
+    });
+
+    it('warns and falls through when deep import throws', async () => {
+      jest.doMock(
+        'sdk-wasm-loader',
+        () => {
+          throw new Error('module not found');
+        },
+        { virtual: true }
+      );
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockEndpoint.mockReturnValue({ ok: true });
+      await jest.isolateModulesAsync(async () => {
+        const { ensureSdkWasmReady } = require('./constants');
+        await expect(ensureSdkWasmReady()).resolves.toBeUndefined();
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('deep loadWasm import unavailable'),
+        expect.any(Error)
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('returns early on unrelated probe error (WASM is loaded, arg rejected)', async () => {
+      mockEndpoint.mockImplementation(() => {
+        throw new Error('invalid URL');
+      });
+      await jest.isolateModulesAsync(async () => {
+        const { ensureSdkWasmReady } = require('./constants');
+        await expect(ensureSdkWasmReady()).resolves.toBeUndefined();
+      });
+      // Only probed once — returned early on the unrelated error
+      expect(mockEndpoint).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when probe keeps hitting __wbindgen_malloc across all retries', async () => {
+      mockEndpoint.mockImplementation(() => {
+        throw new Error("Cannot read properties of undefined (reading '__wbindgen_malloc')");
+      });
+      await jest.isolateModulesAsync(async () => {
+        const { ensureSdkWasmReady } = require('./constants');
+        await expect(ensureSdkWasmReady()).rejects.toThrow(/SDK WASM not loaded/);
+        // After throw, a subsequent call should retry (promise was reset).
+        // Make the next probe succeed so the retry resolves.
+        mockEndpoint.mockReset();
+        mockEndpoint.mockReturnValue({ ok: true });
+        await expect(ensureSdkWasmReady()).resolves.toBeUndefined();
+      });
+      // 4 delays × failed + 1 success on retry
+      expect(mockEndpoint.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/src/lib/miden-chain/constants.ts
+++ b/src/lib/miden-chain/constants.ts
@@ -93,8 +93,81 @@ export function getNetworkId(): NetworkId {
 
 /**
  * Returns the SDK Endpoint for the current DEFAULT_NETWORK.
+ *
+ * NOTE: this constructs a wasm-bindgen-backed `Endpoint` instance and
+ * therefore requires the SDK's WASM module to be loaded on this thread.
+ * Page-side callers should `await ensureSdkWasmReady()` first; otherwise
+ * the constructor throws `TypeError: Cannot read properties of undefined
+ * (reading '__wbindgen_malloc')` whenever it races SDK init.
  */
 export function getRpcEndpoint(): Endpoint {
   const url = MIDEN_NETWORK_ENDPOINTS.get(DEFAULT_NETWORK)!;
   return new Endpoint(url);
+}
+
+/**
+ * Resolves once the SDK's WASM module is loaded on the current thread, so
+ * subsequent `new Endpoint(...)` / `new RpcClient(...)` calls are safe.
+ *
+ * On the extension page the SDK's WASM is loaded lazily — the first
+ * `WebClient`-backed call (e.g. via `useSyncTrigger`) triggers it. Code that
+ * reaches for `Endpoint` / `RpcClient` directly (currently
+ * `fetchTokenMetadata` and `SendDetails`) doesn't go through that path and
+ * fires before the chunk is ready, hitting `Cannot read properties of
+ * undefined (reading '__wbindgen_malloc')`.
+ *
+ * We can't just probe-retry: nothing else triggers a load on the page side,
+ * so the bindings stay undefined indefinitely. We have to actively call the
+ * SDK's loadWasm. It isn't re-exported from the main entry, so we deep-import
+ * it; the path is stable across the SDK versions we ship against, and the
+ * probe at the end catches any future mismatch.
+ */
+let _sdkWasmReady: Promise<void> | null = null;
+export function ensureSdkWasmReady(): Promise<void> {
+  if (_sdkWasmReady) return _sdkWasmReady;
+  _sdkWasmReady = (async () => {
+    try {
+      // Trigger the SDK's wasm-bindgen init. The SDK's package.json exports
+      // map doesn't list the wasm-loader file directly; we import via a
+      // Vite alias (`sdk-wasm-loader` → `node_modules/@miden-sdk/miden-sdk/
+      // dist/wasm.js`) configured per build target.
+      // @ts-expect-error -- virtual specifier resolved via Vite alias
+      // eslint-disable-next-line import/no-unresolved
+      const wasmModule = await import('sdk-wasm-loader');
+      const loadWasm = wasmModule.default ?? wasmModule;
+      if (typeof loadWasm === 'function') {
+        await loadWasm();
+      }
+    } catch (err) {
+      // Deep import unavailable (SDK refactor, unusual bundler) — fall through
+      // to the probe loop below, which will at least surface a clear error
+      // and let `_sdkWasmReady` retry next call.
+      console.warn('ensureSdkWasmReady: deep loadWasm import unavailable, falling back to probe', err);
+    }
+
+    // Verify by probing — handles both the "loadWasm worked" happy path and
+    // the "deep import failed but something else happens to have loaded WASM"
+    // edge case. If neither, we throw and reset so the next caller retries.
+    const delays = [0, 50, 150, 300];
+    let lastErr: unknown;
+    for (const delay of delays) {
+      if (delay > 0) await new Promise(r => setTimeout(r, delay));
+      try {
+        new Endpoint('https://probe.invalid');
+        return;
+      } catch (err) {
+        const msg = (err as { message?: string } | null)?.message ?? '';
+        if (msg.includes('__wbindgen_malloc') || msg.includes('Cannot read properties of undefined')) {
+          lastErr = err;
+          continue;
+        }
+        return; // unrelated error — WASM is loaded, probe arg was just rejected
+      }
+    }
+    _sdkWasmReady = null;
+    throw new Error(
+      `ensureSdkWasmReady: SDK WASM not loaded — ${(lastErr as { message?: string } | null)?.message ?? 'unknown'}`
+    );
+  })();
+  return _sdkWasmReady;
 }

--- a/src/lib/miden/metadata/fetch.test.ts
+++ b/src/lib/miden/metadata/fetch.test.ts
@@ -38,7 +38,8 @@ jest.mock('@miden-sdk/miden-sdk', () => ({
 }));
 
 jest.mock('lib/miden-chain/constants', () => ({
-  getRpcEndpoint: jest.fn(() => 'mock-endpoint')
+  getRpcEndpoint: jest.fn(() => 'mock-endpoint'),
+  ensureSdkWasmReady: jest.fn(() => Promise.resolve())
 }));
 
 const mockFetchFromStorage = jest.fn();

--- a/src/lib/miden/metadata/fetch.ts
+++ b/src/lib/miden/metadata/fetch.ts
@@ -1,6 +1,6 @@
 import { Address, BasicFungibleFaucetComponent, RpcClient } from '@miden-sdk/miden-sdk';
 
-import { getRpcEndpoint } from 'lib/miden-chain/constants';
+import { ensureSdkWasmReady, getRpcEndpoint } from 'lib/miden-chain/constants';
 import { isMidenAsset } from 'lib/miden/assets';
 import { fetchFromStorage } from 'lib/miden/front/storage';
 
@@ -27,6 +27,13 @@ export async function fetchTokenMetadata(
   }
 
   try {
+    // Page-side: gate on SDK WASM readiness so the wasm-bindgen `Endpoint`
+    // constructor doesn't fire before the SDK chunk has hydrated. Without
+    // this, the first faucet metadata fetch on a freshly-loaded page reliably
+    // hits "Cannot read properties of undefined (reading '__wbindgen_malloc')",
+    // gets blacklisted via `autoFetchMetadataFails`, and the token displays
+    // with default metadata for the rest of the session.
+    await ensureSdkWasmReady();
     const endpoint = getRpcEndpoint();
     const rpcClient = new RpcClient(endpoint);
     const account = await rpcClient.getAccountDetails(Address.fromBech32(assetId).accountId());

--- a/src/lib/miden/reset.test.ts
+++ b/src/lib/miden/reset.test.ts
@@ -7,10 +7,14 @@ _g.__resetTest = {
 
 const mockDbDelete = jest.fn();
 const mockDbOpen = jest.fn();
+const mockTransactionsClear = jest.fn();
 jest.mock('lib/miden/repo', () => ({
   db: {
     delete: () => mockDbDelete(),
     open: () => mockDbOpen()
+  },
+  transactions: {
+    clear: () => mockTransactionsClear()
   }
 }));
 
@@ -42,7 +46,7 @@ jest.mock(
 
 import { isDesktop, isExtension, isMobile } from 'lib/platform';
 
-import { clearClientStorage, clearStorage } from './reset';
+import { clearClientStorage, clearStorage, resetStorageDestructive } from './reset';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -52,14 +56,18 @@ beforeEach(() => {
 });
 
 describe('clearStorage', () => {
-  it('drops and reopens the IndexedDB by default', async () => {
+  it('clears the transactions table by default and never deletes the DB', async () => {
     await clearStorage();
-    expect(mockDbDelete).toHaveBeenCalled();
-    expect(mockDbOpen).toHaveBeenCalled();
+    expect(mockTransactionsClear).toHaveBeenCalled();
+    // db.delete() would force every other open handle closed and leave the
+    // page Dexie connection unrecoverable — see commit message.
+    expect(mockDbDelete).not.toHaveBeenCalled();
+    expect(mockDbOpen).not.toHaveBeenCalled();
   });
 
-  it('skips DB drop when clearDb=false', async () => {
+  it('skips the table clear when clearDb=false', async () => {
     await clearStorage(false);
+    expect(mockTransactionsClear).not.toHaveBeenCalled();
     expect(mockDbDelete).not.toHaveBeenCalled();
   });
 
@@ -81,6 +89,16 @@ describe('clearStorage', () => {
   it('clears browser.storage.local on extension', async () => {
     (isExtension as jest.Mock).mockReturnValue(true);
     await clearStorage();
+    expect(mockBrowserStorageClear).toHaveBeenCalled();
+  });
+});
+
+describe('resetStorageDestructive', () => {
+  it('drops and reopens the IndexedDB and clears platform storage', async () => {
+    (isExtension as jest.Mock).mockReturnValue(true);
+    await resetStorageDestructive();
+    expect(mockDbDelete).toHaveBeenCalled();
+    expect(mockDbOpen).toHaveBeenCalled();
     expect(mockBrowserStorageClear).toHaveBeenCalled();
   });
 });

--- a/src/lib/miden/reset.ts
+++ b/src/lib/miden/reset.ts
@@ -1,12 +1,7 @@
 import * as Repo from 'lib/miden/repo';
 import { isDesktop, isExtension, isMobile } from 'lib/platform';
 
-export async function clearStorage(clearDb: boolean = true) {
-  if (clearDb) {
-    await Repo.db.delete();
-    await Repo.db.open();
-  }
-
+async function clearPlatformKeyValueStorage(): Promise<void> {
   if (isMobile()) {
     // On mobile, use native Capacitor Preferences.clear()
     const { Preferences } = await import('@capacitor/preferences');
@@ -19,6 +14,41 @@ export async function clearStorage(clearDb: boolean = true) {
     const browser = await import('webextension-polyfill');
     await browser.default.storage.local.clear();
   }
+}
+
+/**
+ * Soft storage reset called during wallet creation / spawn.
+ *
+ * Empties the `transactions` table and wipes the platform key-value store,
+ * but deliberately keeps the TridentMain Dexie connection alive. Using
+ * `db.delete()` here would fire a `versionchange` event to every other open
+ * handle (notably the page's, which was opened lazily by the onboarding UI),
+ * force them closed, and leave no path to reopen them short of a page reload
+ * — which is how we end up with `DatabaseClosedError` on every subsequent
+ * page-side Dexie read and custom-faucet `fetchTokenMetadata` calls racing
+ * against a partially-loaded SDK.
+ *
+ * If you need the full "throw away everything, including live connections
+ * from other tabs/contexts" semantic, call `resetStorageDestructive` below.
+ */
+export async function clearStorage(clearDb: boolean = true) {
+  if (clearDb) {
+    await Repo.transactions.clear();
+  }
+  await clearPlatformKeyValueStorage();
+}
+
+/**
+ * Hard reset — explicitly what the options-page "Reset Wallet" button wants.
+ * Deletes the Dexie database (forcing every live handle closed) AND clears
+ * the platform key-value store. Callers should only use this when the user
+ * has explicitly opted into a full wipe; for wallet creation flows use
+ * `clearStorage` above instead.
+ */
+export async function resetStorageDestructive() {
+  await Repo.db.delete();
+  await Repo.db.open();
+  await clearPlatformKeyValueStorage();
 }
 
 export function clearClientStorage() {

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -17,7 +17,7 @@ import 'lib/lock-up/run-checks';
 import DisableOutlinesForClick from 'app/a11y/DisableOutlinesForClick';
 import Dialogs from 'app/layouts/Dialogs';
 import { getMessage } from 'lib/i18n';
-import { clearStorage } from 'lib/miden/reset';
+import { resetStorageDestructive } from 'lib/miden/reset';
 import { AlertFn, ConfirmFn, DialogsProvider, useAlert, useConfirm } from 'lib/ui/dialog';
 
 // Disable animations for extension
@@ -87,7 +87,7 @@ async function handleReset(customAlert: AlertFn, confirm: ConfirmFn) {
   if (confirmed) {
     (async () => {
       try {
-        await clearStorage();
+        await resetStorageDestructive();
         browser.runtime.reload();
       } catch (err: any) {
         await customAlert({

--- a/src/screens/send-flow/SendDetails.tsx
+++ b/src/screens/send-flow/SendDetails.tsx
@@ -11,7 +11,7 @@ import { Button, ButtonVariant } from 'components/Button';
 import { InputAmount } from 'components/InputAmount';
 import { NavigationHeader } from 'components/NavigationHeader';
 import { useNativeNavbarAction } from 'lib/dapp-browser';
-import { getRpcEndpoint } from 'lib/miden-chain/constants';
+import { ensureSdkWasmReady, getRpcEndpoint } from 'lib/miden-chain/constants';
 import { hapticError, hapticLight, hapticSuccess } from 'lib/mobile/haptics';
 import { isMobile } from 'lib/platform';
 import { isScanAvailable, scanQRCode } from 'lib/qr';
@@ -94,11 +94,20 @@ export const SendDetails: React.FC<SendDetailsProps> = ({
   const showScanButton = isScanAvailable();
 
   useEffect(() => {
-    const rpc = new RpcClient(getRpcEndpoint());
-    rpc
-      .getBlockHeaderByNumber()
-      .then(header => setSyncHeight(header.blockNum()))
+    let cancelled = false;
+    // Page-side SDK calls need WASM loaded — see ensureSdkWasmReady comment.
+    ensureSdkWasmReady()
+      .then(() => {
+        if (cancelled) return;
+        const rpc = new RpcClient(getRpcEndpoint());
+        return rpc.getBlockHeaderByNumber().then(header => {
+          if (!cancelled) setSyncHeight(header.blockNum());
+        });
+      })
       .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const computeAndSetRecallBlocks = useCallback(

--- a/vite.background.config.ts
+++ b/vite.background.config.ts
@@ -244,6 +244,12 @@ export default defineConfig({
       components: resolve(__dirname, 'src/components'),
       screens: resolve(__dirname, 'src/screens'),
       utils: resolve(__dirname, 'src/utils'),
+      // See lib/miden-chain/constants.ts — virtual specifier resolved here to
+      // reach the SDK's wasm-loader file that isn't listed in its exports map.
+      'sdk-wasm-loader': resolve(
+        __dirname,
+        'node_modules/@miden-sdk/miden-sdk/dist/wasm.js'
+      ),
     },
   },
 

--- a/vite.desktop.config.ts
+++ b/vite.desktop.config.ts
@@ -70,6 +70,12 @@ export default defineConfig({
       screens: resolve(__dirname, 'src/screens'),
       utils: resolve(__dirname, 'src/utils'),
       stories: resolve(__dirname, 'src/stories'),
+      // See lib/miden-chain/constants.ts — virtual specifier resolved here to
+      // reach the SDK's wasm-loader file that isn't listed in its exports map.
+      'sdk-wasm-loader': resolve(
+        __dirname,
+        'node_modules/@miden-sdk/miden-sdk/dist/wasm.js'
+      ),
     },
   },
 

--- a/vite.extension.config.ts
+++ b/vite.extension.config.ts
@@ -324,6 +324,14 @@ export default defineConfig({
       buffer: 'buffer',
       stream: 'stream-browserify',
       assert: 'assert',
+      // The SDK's package.json exports field only lists "."; alias a
+      // virtual specifier through to the wasm-loader file directly so
+      // `ensureSdkWasmReady` can call it without tripping Rolldown's
+      // exports-map enforcement. See lib/miden-chain/constants.ts.
+      'sdk-wasm-loader': resolve(
+        __dirname,
+        'node_modules/@miden-sdk/miden-sdk/dist/wasm.js'
+      ),
     },
   },
 

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -149,6 +149,12 @@ export default defineConfig({
       stories: resolve(__dirname, 'src/stories'),
       // Mock webextension-polyfill for mobile
       'webextension-polyfill': resolve(__dirname, 'src/lib/webextension-polyfill-mock.js'),
+      // See lib/miden-chain/constants.ts — virtual specifier resolved here to
+      // reach the SDK's wasm-loader file that isn't listed in its exports map.
+      'sdk-wasm-loader': resolve(
+        __dirname,
+        'node_modules/@miden-sdk/miden-sdk/dist/wasm.js'
+      ),
     },
   },
 


### PR DESCRIPTION
## Summary

Two independent wallet fixes surfaced while analyzing anomalies in the E2E test harness after the MMR-peaks client fix (PR #2039 on miden-client). Both are page-side regressions that have been silently degrading the Chrome extension experience.

### 1. Page-side SDK WASM init race (`__wbindgen_malloc undefined`)

`fetchTokenMetadata` (called from `useLocalClaimableNotes` SWR polling) and `SendDetails` construct `new Endpoint(...)` / `new RpcClient(...)` directly on the page thread. On a freshly-loaded extension page the SDK's wasm-bindgen module is lazy-loaded by the first `WebClient`-backed call — code that reaches for `Endpoint` directly fires before the chunk has hydrated and hits `TypeError: Cannot read properties of undefined (reading '__wbindgen_malloc')`. The token then gets blacklisted via `autoFetchMetadataFails` and displays with default metadata for the rest of the session.

**Fix:** new `ensureSdkWasmReady()` in `lib/miden-chain/constants.ts` actively triggers the SDK's `loadWasm()` via a deep import, with a probe-retry fallback for bundler edge cases. `fetchTokenMetadata` and `SendDetails` await it before constructing Endpoint/RpcClient. The SDK doesn't re-export the wasm-loader file in its `exports` map, so the deep import is wired through a Vite alias (`sdk-wasm-loader` → `node_modules/@miden-sdk/miden-sdk/dist/wasm.js`) in all four Vite configs (extension, background, mobile, desktop).

### 2. `clearStorage` tearing down live Dexie handles (DatabaseClosedError)

`Vault.spawn` calls `clearStorage(true)` during wallet creation, which previously did `Repo.db.delete() + db.open()`. The `db.delete()` fires a `versionchange` event to every other open handle (notably the page's, opened lazily by onboarding), forces them closed, and leaves no path to reopen them short of a page reload. Result: `DatabaseClosedError` on every subsequent page-side Dexie read. The symptom is subtle — wallet works but background page reads fail quietly.

**Fix:** `clearStorage` now calls `Repo.transactions.clear()` instead, which is what the spawn-time reset actually wants (wipe the transactions table, keep the connection alive). A new `resetStorageDestructive()` provides the old "nuke everything including live handles" semantic for the one caller that actually needs it — the options page's "Reset Wallet" button. `options.tsx` migrated to the destructive variant.

## Verification

- `yarn test`: 121 suites, 1649 tests, all passing
- `yarn lint` clean, `yarn format` clean
- `yarn test:e2e:blockchain:devnet` run 3× end-to-end on devnet: 21/21 specs pass, ~6.5m each
- Full anomaly scan across all 3 run timelines: **zero** hits on `__wbindgen_malloc`, `DatabaseClosedError`, `recursive use of an object`, or `inconsistent partial mmr`. Only surviving errors are the known `MonitorServiceClient.healthCheck` DNS failures (pre-existing, unrelated) and two benign `ERR_ABORTED` RPC retries from the WASM client lock machinery (request superseded by a newer call within 35ms; test passes normally).

## Test plan

- [ ] Onboard a fresh wallet on Chrome extension — vault created without `DatabaseClosedError` in console
- [ ] Claim a note from a custom faucet — token shows correct symbol/decimals on first paint (not fallback)
- [ ] Reset Wallet from options page — full wipe still works, wallet returns to welcome
- [ ] Mobile + desktop builds: `yarn build:mobile`, `yarn build:desktop` succeed