### PR TITLE
chore: bump @miden-sdk packages to 0.14.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "private": true,
   "engines": {
     "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
     "@dicebear/avatars-jdenticon-sprites": "4.2.5",
     "@floating-ui/react": "^0.27.16",
     "@hookform/resolvers": "^3.9.0",
-    "@miden-sdk/miden-sdk": "0.14.2",
-    "@miden-sdk/react": "0.14.2",
+    "@miden-sdk/miden-sdk": "0.14.3",
+    "@miden-sdk/react": "0.14.3",
     "@miden/dapp-browser": "link:./packages/dapp-browser",
     "@newhighsco/storybook-addon-svgr": "^2.0.7",
     "@noble/hashes": "^1.4.0",
@@ -197,7 +197,7 @@
   "devDependencies": {
     "@capacitor/cli": "^8.0.1",
     "@chromatic-com/storybook": "^1.5.0",
-    "@miden-sdk/vite-plugin": "0.14.2",
+    "@miden-sdk/vite-plugin": "0.14.3",
     "@playwright/test": "^1.48.2",
     "@resvg/resvg-js": "^2.6.2",
     "@serh11p/jest-webextension-mock": "4.0.0",
@@ -310,7 +310,7 @@
     "**/axios": "^1.13.0",
     "**/cross-spawn": "^7.0.5",
     "**/nth-check": "^2.1.1",
-    "**/@miden-sdk/miden-sdk": "0.14.2"
+    "**/@miden-sdk/miden-sdk": "0.14.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:e2e:blockchain:devnet": "cross-env E2E_NETWORK=devnet yarn test:e2e:blockchain",
     "test:e2e:blockchain:localhost": "cross-env E2E_NETWORK=localhost yarn test:e2e:blockchain",
     "test:e2e:blockchain:agentic": "cross-env E2E_AGENTIC=true yarn test:e2e:blockchain",
-    "test:e2e:stress:build": "yarn test:e2e:blockchain:build",
+    "test:e2e:stress:build": "yarn install && yarn test:e2e:blockchain:build",
     "test:e2e:stress": "yarn test:e2e:stress:build && playwright test --config playwright.stress.config.ts",
     "test:e2e:stress:run": "yarn test:e2e:stress:build && playwright test --config playwright.stress.config.ts",
     "test:e2e:stress:run-only": "playwright test --config playwright.stress.config.ts",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Miden Wallet",
-  "version": "1.14.2",
+  "version": "1.14.3",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",

--- a/public/manifest.v2.json
+++ b/public/manifest.v2.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Miden Wallet",
-  "version": "1.14.2",
+  "version": "1.14.3",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,26 +2272,26 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@miden-sdk/miden-sdk@0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.14.2.tgz#181b4997ee70020d5a91600f74fcd23116ec050d"
-  integrity sha512-GpdsywPJJs1+p3O3h6gqW5se/c3dicYhOqudkDWdC5XTg+oIafD+sx76zf/FCDRZvHfFZWmgov4oRHervwV01Q==
+"@miden-sdk/miden-sdk@0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.14.3.tgz#9b3e1466309b92a957eb92628e28141d0b773696"
+  integrity sha512-b/dY0qn9/crxjkotpkPjf+Mm5Gl04+8EYgm0c4M2Iz4A+IQWDDka9lWUt/pV7fLx+UeZCfeFMuphkHP9vqLzUg==
   dependencies:
     "@rollup/plugin-typescript" "^12.3.0"
     dexie "^4.0.1"
     glob "^11.0.0"
 
-"@miden-sdk/react@0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.14.2.tgz#8adfc5ea4d56d69245efb6c43eca35d75f0430f8"
-  integrity sha512-b1rUMtKEw3KtZA5F6P0x3R4w1+GR6djolWPHlxhieZShC3djGeO1T1gRe8OugzOh/B63+So884LI0WW+k55PzA==
+"@miden-sdk/react@0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.14.3.tgz#ad3604d461039e594480ef592307c9b886f6d5bb"
+  integrity sha512-NEGrHs5qJVdbkXNZ9NfqqpoJwSj7fiYMpFEpC6c3vTjvZACzkdsFJMlijbqR8qpaGsuuOJb2/wyvPvu7rNQpTA==
   dependencies:
     zustand "^5.0.0"
 
-"@miden-sdk/vite-plugin@0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/vite-plugin/-/vite-plugin-0.14.2.tgz#d8e210a94430b2dc79295d57d452085b97a9bc0a"
-  integrity sha512-KU01Wp00c9QRICe0D84jG68CEXf2mA1KAbyBbLghZbwOOKTrbBj25emp3rn9QjiMo7i/7Nanp8YwUNEQD/DSGg==
+"@miden-sdk/vite-plugin@0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/vite-plugin/-/vite-plugin-0.14.3.tgz#7e00f89c3708da2105e037f30f37c92a13b669e2"
+  integrity sha512-ydv+5x5xmH8RJsGDbWZ5wyaIbBymGaN3XdYkEsdlhaipLst1okNSF7wRNVwRKJxyd5M+KH6xQ4i5munVkL+uFw==
 
 "@miden/dapp-browser@link:./packages/dapp-browser":
   version "0.0.0"


### PR DESCRIPTION
## Summary
- Bumps `@miden-sdk/miden-sdk`, `@miden-sdk/react`, and `@miden-sdk/vite-plugin` from `0.14.2` → `0.14.3`
- Updates the `**/@miden-sdk/miden-sdk` resolution pin to match

## Test plan
- [ ] `yarn build:chrome` (devnet) succeeds locally
- [ ] Smoke-test the loaded extension against devnet (create wallet, sync, send/receive)