### PR TITLE
fix: self-heal popup init race on MV3 SW cold-start (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [FIX][all] Encrypted-wallet-file import now restores secret keys for every imported account, not just the first. The decrypted wallet payload carries the full `WalletAccount[]` (with `hdIndex` and `type` per account), and `Vault.spawnFromMidenClient` re-derives each auth key from the mnemonic and inserts it into the new keystore via `client.keystore.insert`. Previously the imported miden-client DB came over without keystore entries, so signing broke for any non-default account.
 * [FIX][all] Encrypted wallet file export now includes wallet account metadata alongside the miden-client/wallet DB dumps, so import can preserve account names and HD indices instead of falling back to generic "Miden Account N" labels.
 * [FIX][all] Encrypted-file password screen consolidates the hardware-vs-password branching around a single `hasHardwareProtector` check — hardware-only vaults skip password entry entirely, password-protected vaults keep the attempt/lockout flow.
+* [FIX][extension] Popup no longer white-screens after an MV3 service-worker cold-start. `WalletStoreProvider` stopped gating the app tree on a racy single `GetStateRequest`, and `useIntercomSync` replaced its fixed 15 s retry budget + one-shot latch with a cancellable unbounded retry loop (250 ms → 3 s exponential backoff). The backend's existing post-init `StateUpdated` broadcast still hydrates the store as soon as the SW is ready; the popup now self-heals from a missed broadcast or slow port setup instead of staying blank until fully reopened. (#196, closes #113)
 
 ---
 

--- a/src/app/pages/Welcome.tsx
+++ b/src/app/pages/Welcome.tsx
@@ -49,7 +49,7 @@ async function waitForReadyState(syncFromBackend: (state: any) => void, maxAttem
   for (let i = 0; i < maxAttempts; i++) {
     try {
       console.log('[waitForReadyState] Attempt', i + 1);
-      const state = await fetchStateFromBackend(0);
+      const state = await fetchStateFromBackend();
       console.log('[waitForReadyState] Got state:', { status: state.status, hasAccounts: !!state.accounts?.length });
       syncFromBackend(state);
       if (state.status === WalletStatus.Ready) {

--- a/src/lib/intercom/client.test.ts
+++ b/src/lib/intercom/client.test.ts
@@ -146,6 +146,21 @@ describe('IntercomClient', () => {
     await expect(client.request({ action: 'x' }, { signal: controller.signal })).rejects.toThrow('Aborted');
   });
 
+  it('abort after port replacement does not throw (cleanup swallows dead-port removeListener)', async () => {
+    await flushPromises();
+    const controller = new AbortController();
+    const requestPromise = client.request({ action: 'x' }, { signal: controller.signal });
+    await flushPromises();
+
+    // Simulate the port being torn down after request started — e.g. SW evicted it.
+    mockRemoveListener.mockImplementationOnce(() => {
+      throw new Error('port disconnected');
+    });
+
+    expect(() => controller.abort()).not.toThrow();
+    await expect(requestPromise).rejects.toThrow('Aborted');
+  });
+
   it('ignores messages with different reqId', async () => {
     // Wait for port initialization
     await flushPromises();

--- a/src/lib/intercom/client.test.ts
+++ b/src/lib/intercom/client.test.ts
@@ -123,6 +123,29 @@ describe('IntercomClient', () => {
     });
   });
 
+  it('abort via AbortSignal rejects and removes the port listener', async () => {
+    await flushPromises();
+
+    const controller = new AbortController();
+    const requestPromise = client.request({ action: 'x' }, { signal: controller.signal });
+    await flushPromises();
+
+    expect(mockAddListener).toHaveBeenCalledTimes(1);
+    const listener = mockAddListener.mock.calls[0][0];
+
+    controller.abort();
+
+    await expect(requestPromise).rejects.toThrow('Aborted');
+    expect(mockRemoveListener).toHaveBeenCalledWith(listener);
+  });
+
+  it('rejects immediately if the signal is already aborted', async () => {
+    await flushPromises();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(client.request({ action: 'x' }, { signal: controller.signal })).rejects.toThrow('Aborted');
+  });
+
   it('ignores messages with different reqId', async () => {
     // Wait for port initialization
     await flushPromises();
@@ -353,7 +376,7 @@ describe('MobileIntercomClientWrapper', () => {
     mockMobileAdapter.request.mockResolvedValueOnce({ ok: true });
     const client = createIntercomClient();
     const result = await client.request({ payload: 'p' });
-    expect(mockMobileAdapter.request).toHaveBeenCalledWith({ payload: 'p' });
+    expect(mockMobileAdapter.request).toHaveBeenCalledWith({ payload: 'p' }, undefined);
     expect(result).toEqual({ ok: true });
   });
 
@@ -400,7 +423,7 @@ describe('DesktopIntercomClientWrapper', () => {
     mockDesktopAdapter.request.mockResolvedValueOnce({ from: 'desktop' });
     const client = createIntercomClient();
     const result = await client.request({ x: 1 });
-    expect(mockDesktopAdapter.request).toHaveBeenCalledWith({ x: 1 });
+    expect(mockDesktopAdapter.request).toHaveBeenCalledWith({ x: 1 }, undefined);
     expect(result).toEqual({ from: 'desktop' });
   });
 

--- a/src/lib/intercom/client.ts
+++ b/src/lib/intercom/client.ts
@@ -160,8 +160,17 @@ export class IntercomClient implements IIntercomClient {
     this.send({ type: MessageType.Req, data: payload, reqId });
 
     return new Promise((resolve, reject) => {
+      let done = false;
       const cleanup = () => {
-        port.onMessage.removeListener(listener);
+        if (done) return;
+        done = true;
+        // port may already be disconnected & replaced by onDisconnect — don't
+        // let its onMessage throw through cleanup.
+        try {
+          port.onMessage.removeListener(listener);
+        } catch {
+          /* noop */
+        }
         if (options?.signal) options.signal.removeEventListener('abort', onAbort);
       };
       const listener = (msg: any) => {

--- a/src/lib/intercom/client.ts
+++ b/src/lib/intercom/client.ts
@@ -9,7 +9,7 @@ import { MessageType, RequestMessage } from './types';
  * Interface for intercom clients (extension, mobile, and desktop)
  */
 export interface IIntercomClient {
-  request(payload: any): Promise<any>;
+  request(payload: any, options?: { signal?: AbortSignal }): Promise<any>;
   subscribe(callback: (data: any) => void): () => void;
 }
 
@@ -77,9 +77,9 @@ class MobileIntercomClientWrapper implements IIntercomClient {
     return this.adapterPromise;
   }
 
-  async request(payload: any): Promise<any> {
+  async request(payload: any, options?: { signal?: AbortSignal }): Promise<any> {
     const adapter = await this.getAdapter();
-    return adapter.request(payload);
+    return adapter.request(payload, options);
   }
 
   subscribe(callback: (data: any) => void): () => void {
@@ -108,9 +108,9 @@ class DesktopIntercomClientWrapper implements IIntercomClient {
     return this.adapterPromise;
   }
 
-  async request(payload: any): Promise<any> {
+  async request(payload: any, options?: { signal?: AbortSignal }): Promise<any> {
     const adapter = await this.getAdapter();
-    return adapter.request(payload);
+    return adapter.request(payload, options);
   }
 
   subscribe(callback: (data: any) => void): () => void {
@@ -152,31 +152,37 @@ export class IntercomClient implements IIntercomClient {
   /**
    * Makes a request to background process and returns a response promise
    */
-  async request(payload: any): Promise<any> {
+  async request(payload: any, options?: { signal?: AbortSignal }): Promise<any> {
     await this.portReady;
     const reqId = this.reqId++;
+    const port = this.port;
 
     this.send({ type: MessageType.Req, data: payload, reqId });
 
     return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        port.onMessage.removeListener(listener);
+        if (options?.signal) options.signal.removeEventListener('abort', onAbort);
+      };
       const listener = (msg: any) => {
-        switch (true) {
-          case msg?.reqId !== reqId:
-            return;
-
-          case msg?.type === MessageType.Res:
-            resolve(msg.data);
-            break;
-
-          case msg?.type === MessageType.Err:
-            reject(deserializeError(msg.data));
-            break;
-        }
-
-        this.port.onMessage.removeListener(listener);
+        if (msg?.reqId !== reqId) return;
+        if (msg?.type === MessageType.Res) resolve(msg.data);
+        else if (msg?.type === MessageType.Err) reject(deserializeError(msg.data));
+        cleanup();
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(new Error('Aborted'));
       };
 
-      this.port.onMessage.addListener(listener);
+      port.onMessage.addListener(listener);
+      if (options?.signal) {
+        if (options.signal.aborted) {
+          onAbort();
+          return;
+        }
+        options.signal.addEventListener('abort', onAbort);
+      }
     });
   }
 

--- a/src/lib/intercom/desktop-adapter.ts
+++ b/src/lib/intercom/desktop-adapter.ts
@@ -43,7 +43,7 @@ export class DesktopIntercomAdapter {
   /**
    * Makes a request directly to the backend handlers
    */
-  async request(payload: WalletRequest): Promise<WalletResponse | void> {
+  async request(payload: WalletRequest, _options?: { signal?: AbortSignal }): Promise<WalletResponse | void> {
     // Ensure backend is initialized
     if (!this.initialized) {
       await this.init();

--- a/src/lib/intercom/mobile-adapter.ts
+++ b/src/lib/intercom/mobile-adapter.ts
@@ -35,7 +35,7 @@ export class MobileIntercomAdapter {
   /**
    * Makes a request directly to the backend handlers
    */
-  async request(payload: WalletRequest): Promise<WalletResponse | void> {
+  async request(payload: WalletRequest, _options?: { signal?: AbortSignal }): Promise<WalletResponse | void> {
     // Ensure backend is initialized
     if (!this.initialized) {
       await this.init();

--- a/src/lib/store/WalletStoreProvider.tsx
+++ b/src/lib/store/WalletStoreProvider.tsx
@@ -5,33 +5,25 @@ import { useIntercomSync } from './hooks/useIntercomSync';
 /**
  * Provider component that sets up the Zustand store synchronization with the backend.
  * This should wrap the main app to ensure the store stays in sync.
+ *
+ * We intentionally do NOT gate children on the initial fetch completing:
+ * `getFrontState()` on the backend short-circuits to Idle while the SW is
+ * still initializing, and the Zustand defaults match that shape. Gating the
+ * tree on a racy single GetStateRequest was the root cause of #113 (MV3 SW
+ * cold-start + WASM init could outrun the popup's fetch budget, leaving a
+ * blank popup with no recovery path).
  */
 export const WalletStoreProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <Suspense fallback={<WalletStoreLoading />}>
+    <Suspense fallback={null}>
       <WalletStoreSyncSetup>{children}</WalletStoreSyncSetup>
     </Suspense>
   );
 };
 
-/**
- * Inner component that sets up sync and renders children when ready
- */
 const WalletStoreSyncSetup: FC<PropsWithChildren> = ({ children }) => {
-  const isInitialized = useIntercomSync();
-
-  if (!isInitialized) {
-    return <WalletStoreLoading />;
-  }
-
+  useIntercomSync();
   return <>{children}</>;
-};
-
-/**
- * Loading fallback component
- */
-const WalletStoreLoading: FC = () => {
-  return null; // The app already has loading UI via Suspense boundaries
 };
 
 export default WalletStoreProvider;

--- a/src/lib/store/hooks/useIntercomSync.test.ts
+++ b/src/lib/store/hooks/useIntercomSync.test.ts
@@ -38,21 +38,18 @@ describe('fetchStateFromBackend', () => {
       type: WalletMessageType.GetStateResponse,
       state: { status: 'Ready', accounts: [] }
     });
-    const state = await fetchStateFromBackend(0);
+    const state = await fetchStateFromBackend();
     expect(state).toEqual({ status: 'Ready', accounts: [] });
   });
 
   it('throws when the response type is wrong', async () => {
     intercom.request.mockResolvedValue({ type: 'WrongType' });
-    await expect(fetchStateFromBackend(0)).rejects.toThrow('Invalid response type');
+    await expect(fetchStateFromBackend()).rejects.toThrow('Invalid response type');
   });
 
-  it('retries when configured and eventually succeeds', async () => {
-    intercom.request.mockResolvedValueOnce({ type: 'WrongType' }).mockResolvedValueOnce({
-      type: WalletMessageType.GetStateResponse,
-      state: { status: 'Locked' }
-    });
-    const state = await fetchStateFromBackend(2);
-    expect(state).toEqual({ status: 'Locked' });
+  it('is a single attempt — the caller owns any retry loop', async () => {
+    intercom.request.mockResolvedValueOnce({ type: 'WrongType' });
+    await expect(fetchStateFromBackend()).rejects.toThrow('Invalid response type');
+    expect(intercom.request).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/store/hooks/useIntercomSync.test.ts
+++ b/src/lib/store/hooks/useIntercomSync.test.ts
@@ -23,9 +23,14 @@ jest.mock('lib/platform', () => ({
 
 import { WalletMessageType } from 'lib/shared/types';
 
-import { fetchStateFromBackend } from './useIntercomSync';
+import { fetchStateFromBackend, retryFetchState } from './useIntercomSync';
 
 const intercom = _g.__intSyncTest.intercomMock;
+
+const readyResponse = {
+  type: WalletMessageType.GetStateResponse,
+  state: { status: 'Ready', accounts: [] }
+};
 
 beforeEach(() => {
   intercom.request.mockReset();
@@ -34,10 +39,7 @@ beforeEach(() => {
 
 describe('fetchStateFromBackend', () => {
   it('returns the state field of a successful response', async () => {
-    intercom.request.mockResolvedValueOnce({
-      type: WalletMessageType.GetStateResponse,
-      state: { status: 'Ready', accounts: [] }
-    });
+    intercom.request.mockResolvedValueOnce(readyResponse);
     const state = await fetchStateFromBackend();
     expect(state).toEqual({ status: 'Ready', accounts: [] });
   });
@@ -51,5 +53,60 @@ describe('fetchStateFromBackend', () => {
     intercom.request.mockResolvedValueOnce({ type: 'WrongType' });
     await expect(fetchStateFromBackend()).rejects.toThrow('Invalid response type');
     expect(intercom.request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('retryFetchState', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('retries until fetchStateFromBackend resolves, then returns state', async () => {
+    intercom.request
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(readyResponse);
+
+    const promise = retryFetchState(() => false);
+    // Advance past two backoff windows (250ms + 500ms) to unblock retries.
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    expect(await promise).toEqual({ status: 'Ready', accounts: [] });
+    expect(intercom.request).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns null when cancelled between attempts', async () => {
+    let cancelled = false;
+    intercom.request.mockRejectedValue(new Error('boom'));
+
+    const promise = retryFetchState(() => cancelled);
+    // Let the first failure land, then cancel during the backoff wait.
+    await jest.advanceTimersByTimeAsync(0);
+    cancelled = true;
+    await jest.advanceTimersByTimeAsync(5_000);
+
+    expect(await promise).toBeNull();
+  });
+
+  it('warns exactly once after 20 failed attempts', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    intercom.request.mockRejectedValue(new Error('boom'));
+    let cancelled = false;
+
+    const promise = retryFetchState(() => cancelled);
+    // Run >20 attempts: backoff saturates at 3s, so 20 rounds ≈ plenty of slack.
+    await jest.advanceTimersByTimeAsync(120_000);
+    cancelled = true;
+    await jest.advanceTimersByTimeAsync(5_000);
+    await promise;
+
+    const wedgedWarns = warn.mock.calls.filter(
+      args => typeof args[0] === 'string' && args[0].includes('backend unresponsive after 20 attempts')
+    );
+    expect(wedgedWarns).toHaveLength(1);
+    warn.mockRestore();
   });
 });

--- a/src/lib/store/hooks/useIntercomSync.ts
+++ b/src/lib/store/hooks/useIntercomSync.ts
@@ -1,6 +1,4 @@
-import { useEffect, useRef } from 'react';
-
-import retry from 'async-retry';
+import { useEffect } from 'react';
 
 import { MidenState } from 'lib/miden/types';
 import { isExtension } from 'lib/platform';
@@ -16,6 +14,15 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
   return Promise.race([promise, timeoutPromise]);
 }
+
+/**
+ * Unbounded exponential backoff, capped at `maxDelayMs`.
+ * The MV3 service worker's cold-start (WASM init + initial chain sync) can take
+ * tens of seconds on slow machines; keeping the UI bound to a fixed retry
+ * budget was the cause of #113 (popup white-screens with no recovery).
+ */
+const INITIAL_BACKOFF_MS = 250;
+const MAX_BACKOFF_MS = 3_000;
 
 /**
  * Read the SW's last-broadcast sync snapshot from chrome.storage.local and
@@ -60,36 +67,50 @@ async function rehydrateBalancesFromStorage(accountPublicKey: string): Promise<v
 export function useIntercomSync() {
   const syncFromBackend = useWalletStore(s => s.syncFromBackend);
   const isInitialized = useWalletStore(s => s.isInitialized);
-  const initialFetchDone = useRef(false);
 
   useEffect(() => {
-    // Fetch initial state
+    let cancelled = false;
+
+    // Retry the initial GetStateRequest indefinitely with exponential backoff.
+    // The backend broadcasts `StateUpdated` once SW init completes (see
+    // main.ts:start), which is caught by the subscriber below — either path
+    // hydrates the store. Using an unbounded loop here is a belt-and-braces
+    // guarantee that a missed broadcast or slow port setup never leaves the
+    // popup permanently stuck (the failure mode in #113).
     const fetchInitialState = async () => {
-      /* c8 ignore next -- ref guard for double-mount in StrictMode */
-      if (initialFetchDone.current) return;
-      initialFetchDone.current = true;
+      let backoffMs = INITIAL_BACKOFF_MS;
+      while (!cancelled) {
+        try {
+          const state = await fetchStateFromBackend();
+          if (cancelled) return;
+          syncFromBackend(state);
 
-      try {
-        const state = await fetchStateFromBackend(5);
-        syncFromBackend(state);
-
-        // Rehydrate balances from the last SW sync snapshot BEFORE the app
-        // renders. Without this, any non-MIDEN token (e.g. a custom faucet)
-        // is missing from `useAllBalances` until the 3s poll ticks below,
-        // so Send's token list shows only the MIDEN fallback for the first
-        // few seconds after any page (re)load. Surfaced by the E2E stress
-        // suite — receivers that claim mid-run would render Send as
-        // MIDEN-only until the next poll cycle.
-        if (isExtension() && state.currentAccount) {
-          await rehydrateBalancesFromStorage(state.currentAccount.publicKey);
+          // Rehydrate balances from the last SW sync snapshot BEFORE the app
+          // renders. Without this, any non-MIDEN token (e.g. a custom faucet)
+          // is missing from `useAllBalances` until the 3s poll ticks below,
+          // so Send's token list shows only the MIDEN fallback for the first
+          // few seconds after any page (re)load. Surfaced by the E2E stress
+          // suite — receivers that claim mid-run would render Send as
+          // MIDEN-only until the next poll cycle.
+          if (isExtension() && state.currentAccount) {
+            await rehydrateBalancesFromStorage(state.currentAccount.publicKey);
+          }
+          return;
+        } /* c8 ignore next 8 -- retry path, requires backend error simulation */ catch (error) {
+          if (cancelled) return;
+          console.warn('[useIntercomSync] initial fetch failed, retrying:', error);
+          const wait = backoffMs;
+          await new Promise(resolve => setTimeout(resolve, wait));
+          backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
         }
-      } /* c8 ignore next 3 -- retry path, requires backend error simulation */ catch (error) {
-        console.error('Failed to fetch initial state:', error);
-        initialFetchDone.current = false; // Allow retry
       }
     };
 
     fetchInitialState();
+
+    return () => {
+      cancelled = true;
+    };
   }, [syncFromBackend]);
 
   useEffect(() => {
@@ -103,7 +124,7 @@ export function useIntercomSync() {
     const unsubscribe = intercom.subscribe((msg: WalletNotification) => {
       if (msg?.type === WalletMessageType.StateUpdated) {
         // Refetch state when backend notifies of changes
-        fetchStateFromBackend(0)
+        fetchStateFromBackend()
           .then(syncFromBackend)
           .catch(error => console.error('Failed to sync state:', error));
       } else if (msg?.type === WalletMessageType.SyncCompleted) {
@@ -177,25 +198,24 @@ export function useIntercomSync() {
 }
 
 /**
- * Fetch state from backend with retry logic
+ * Fetch state from backend (single attempt, 3s timeout).
+ *
+ * Callers that want to keep trying until the SW is ready should wrap this in
+ * a retry loop (see `fetchInitialState` above). The 3s per-attempt timeout
+ * guards against the intercom port hanging indefinitely on cold-start.
  */
-async function fetchStateFromBackend(maxRetries: number = 0): Promise<MidenState> {
+async function fetchStateFromBackend(): Promise<MidenState> {
   const intercom = getIntercom();
 
-  const res = await retry(
-    async () => {
-      return withTimeout(
-        (async () => {
-          const res = await intercom.request({ type: WalletMessageType.GetStateRequest });
-          if (res?.type !== WalletMessageType.GetStateResponse) {
-            throw new Error('Invalid response type');
-          }
-          return res;
-        })(),
-        3_000
-      );
-    },
-    { retries: maxRetries, minTimeout: 0, maxTimeout: 0 } as Parameters<typeof retry>[1]
+  const res = await withTimeout(
+    (async () => {
+      const res = await intercom.request({ type: WalletMessageType.GetStateRequest });
+      if (res?.type !== WalletMessageType.GetStateResponse) {
+        throw new Error('Invalid response type');
+      }
+      return res;
+    })(),
+    3_000
   );
 
   return res.state;

--- a/src/lib/store/hooks/useIntercomSync.ts
+++ b/src/lib/store/hooks/useIntercomSync.ts
@@ -7,22 +7,44 @@ import { NoteClaimStarted, SyncData, WalletMessageType, WalletNotification } fro
 import { getIntercom, useWalletStore } from '../index';
 import { updateBalancesFromSyncData } from '../utils/updateBalancesFromSyncData';
 
-/** Wraps a promise with a timeout */
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error('Timeout')), ms);
-  });
-  return Promise.race([promise, timeoutPromise]);
-}
-
 /**
- * Unbounded exponential backoff, capped at `maxDelayMs`.
- * The MV3 service worker's cold-start (WASM init + initial chain sync) can take
- * tens of seconds on slow machines; keeping the UI bound to a fixed retry
- * budget was the cause of #113 (popup white-screens with no recovery).
+ * Retry config for GetStateRequest. The MV3 service worker's cold-start
+ * (WASM init + initial chain sync) can take tens of seconds on slow machines;
+ * a fixed budget was the cause of #113 (popup white-screens with no recovery).
  */
 const INITIAL_BACKOFF_MS = 250;
-const MAX_BACKOFF_MS = 3_000;
+const MAX_BACKOFF_MS = 3_000; // cap of the exponential growth
+const PER_ATTEMPT_TIMEOUT_MS = 3_000;
+const WARN_AFTER_ATTEMPTS = 20; // ~1 min of failed retries — indicates a wedged SW
+
+/**
+ * Keep trying `fetchStateFromBackend` until it succeeds or `isCancelled`
+ * returns true. Emits a single `console.warn` once `WARN_AFTER_ATTEMPTS` is
+ * crossed so a permanently-wedged SW surfaces in logs / analytics instead of
+ * spinning invisibly.
+ */
+async function retryFetchState(isCancelled: () => boolean): Promise<MidenState | null> {
+  let backoffMs = INITIAL_BACKOFF_MS;
+  let attempt = 0;
+  while (!isCancelled()) {
+    try {
+      return await fetchStateFromBackend();
+    } /* c8 ignore next 10 -- retry path exercised by fake-timers test */ catch (error) {
+      if (isCancelled()) return null;
+      attempt += 1;
+      if (attempt === WARN_AFTER_ATTEMPTS) {
+        console.warn(
+          `[useIntercomSync] backend unresponsive after ${WARN_AFTER_ATTEMPTS} attempts; still retrying:`,
+          error
+        );
+      }
+      const wait = backoffMs;
+      await new Promise(resolve => setTimeout(resolve, wait));
+      backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+    }
+  }
+  return null;
+}
 
 /**
  * Read the SW's last-broadcast sync snapshot from chrome.storage.local and
@@ -66,47 +88,31 @@ async function rehydrateBalancesFromStorage(accountPublicKey: string): Promise<v
  */
 export function useIntercomSync() {
   const syncFromBackend = useWalletStore(s => s.syncFromBackend);
-  const isInitialized = useWalletStore(s => s.isInitialized);
 
   useEffect(() => {
-    let cancelled = false;
-
-    // Retry the initial GetStateRequest indefinitely with exponential backoff.
     // The backend broadcasts `StateUpdated` once SW init completes (see
     // main.ts:start), which is caught by the subscriber below — either path
-    // hydrates the store. Using an unbounded loop here is a belt-and-braces
-    // guarantee that a missed broadcast or slow port setup never leaves the
-    // popup permanently stuck (the failure mode in #113).
-    const fetchInitialState = async () => {
-      let backoffMs = INITIAL_BACKOFF_MS;
-      while (!cancelled) {
-        try {
-          const state = await fetchStateFromBackend();
-          if (cancelled) return;
-          syncFromBackend(state);
+    // hydrates the store. Unbounded retry here is a belt-and-braces guarantee
+    // that a missed broadcast or slow port setup never leaves the popup
+    // permanently stuck (the failure mode in #113).
+    let cancelled = false;
 
-          // Rehydrate balances from the last SW sync snapshot BEFORE the app
-          // renders. Without this, any non-MIDEN token (e.g. a custom faucet)
-          // is missing from `useAllBalances` until the 3s poll ticks below,
-          // so Send's token list shows only the MIDEN fallback for the first
-          // few seconds after any page (re)load. Surfaced by the E2E stress
-          // suite — receivers that claim mid-run would render Send as
-          // MIDEN-only until the next poll cycle.
-          if (isExtension() && state.currentAccount) {
-            await rehydrateBalancesFromStorage(state.currentAccount.publicKey);
-          }
-          return;
-        } /* c8 ignore next 8 -- retry path, requires backend error simulation */ catch (error) {
-          if (cancelled) return;
-          console.warn('[useIntercomSync] initial fetch failed, retrying:', error);
-          const wait = backoffMs;
-          await new Promise(resolve => setTimeout(resolve, wait));
-          backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
-        }
+    (async () => {
+      const state = await retryFetchState(() => cancelled);
+      if (cancelled || !state) return;
+      syncFromBackend(state);
+
+      // Rehydrate balances from the last SW sync snapshot BEFORE the app
+      // renders. Without this, any non-MIDEN token (e.g. a custom faucet)
+      // is missing from `useAllBalances` until the 3s poll ticks below,
+      // so Send's token list shows only the MIDEN fallback for the first
+      // few seconds after any page (re)load. Surfaced by the E2E stress
+      // suite — receivers that claim mid-run would render Send as
+      // MIDEN-only until the next poll cycle.
+      if (isExtension() && state.currentAccount) {
+        await rehydrateBalancesFromStorage(state.currentAccount.publicKey);
       }
-    };
-
-    fetchInitialState();
+    })();
 
     return () => {
       cancelled = true;
@@ -121,12 +127,16 @@ export function useIntercomSync() {
 
     const store = useWalletStore.getState;
 
+    // Track in-flight refetches so we can cancel them on unmount — the
+    // subscriber is also retry-wrapped (prev bug was a missed refetch on a
+    // racy port reconnect during a StateUpdated broadcast).
+    let refetchCancelled = false;
+
     const unsubscribe = intercom.subscribe((msg: WalletNotification) => {
       if (msg?.type === WalletMessageType.StateUpdated) {
-        // Refetch state when backend notifies of changes
-        fetchStateFromBackend()
-          .then(syncFromBackend)
-          .catch(error => console.error('Failed to sync state:', error));
+        retryFetchState(() => refetchCancelled).then(state => {
+          if (state) syncFromBackend(state);
+        });
       } else if (msg?.type === WalletMessageType.SyncCompleted) {
         // Service worker finished a sync cycle — update sync status
         setSyncStatus(false);
@@ -137,7 +147,10 @@ export function useIntercomSync() {
       }
     });
 
-    return unsubscribe;
+    return () => {
+      refetchCancelled = true;
+      unsubscribe();
+    };
   }, [syncFromBackend]);
 
   // Poll balance data from chrome.storage.local (vault assets).
@@ -193,32 +206,31 @@ export function useIntercomSync() {
     return () => clearInterval(timer);
   }, [currentAccount]);
   /* c8 ignore stop */
-
-  return isInitialized;
 }
 
 /**
- * Fetch state from backend (single attempt, 3s timeout).
+ * Fetch state from backend — single attempt, bounded by
+ * `PER_ATTEMPT_TIMEOUT_MS`. On timeout the underlying intercom request is
+ * aborted via AbortController so the port listener is removed (otherwise the
+ * extension port would accumulate dead listeners across retries — the intercom
+ * port is long-lived and only recycled on disconnect).
  *
  * Callers that want to keep trying until the SW is ready should wrap this in
- * a retry loop (see `fetchInitialState` above). The 3s per-attempt timeout
- * guards against the intercom port hanging indefinitely on cold-start.
+ * `retryFetchState` (see above).
  */
 async function fetchStateFromBackend(): Promise<MidenState> {
   const intercom = getIntercom();
-
-  const res = await withTimeout(
-    (async () => {
-      const res = await intercom.request({ type: WalletMessageType.GetStateRequest });
-      if (res?.type !== WalletMessageType.GetStateResponse) {
-        throw new Error('Invalid response type');
-      }
-      return res;
-    })(),
-    3_000
-  );
-
-  return res.state;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PER_ATTEMPT_TIMEOUT_MS);
+  try {
+    const res = await intercom.request({ type: WalletMessageType.GetStateRequest }, { signal: controller.signal });
+    if (res?.type !== WalletMessageType.GetStateResponse) {
+      throw new Error('Invalid response type');
+    }
+    return res.state;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
-export { fetchStateFromBackend };
+export { fetchStateFromBackend, retryFetchState };

--- a/src/lib/store/hooks/useIntercomSync.ts
+++ b/src/lib/store/hooks/useIntercomSync.ts
@@ -26,13 +26,15 @@ const WARN_AFTER_ATTEMPTS = 20; // ~1 min of failed retries — indicates a wedg
 async function retryFetchState(isCancelled: () => boolean): Promise<MidenState | null> {
   let backoffMs = INITIAL_BACKOFF_MS;
   let attempt = 0;
+  let warned = false;
   while (!isCancelled()) {
     try {
       return await fetchStateFromBackend();
-    } /* c8 ignore next 10 -- retry path exercised by fake-timers test */ catch (error) {
+    } /* c8 ignore next 11 -- retry path exercised by fake-timers test */ catch (error) {
       if (isCancelled()) return null;
       attempt += 1;
-      if (attempt === WARN_AFTER_ATTEMPTS) {
+      if (!warned && attempt >= WARN_AFTER_ATTEMPTS) {
+        warned = true;
         console.warn(
           `[useIntercomSync] backend unresponsive after ${WARN_AFTER_ATTEMPTS} attempts; still retrying:`,
           error
@@ -127,15 +129,18 @@ export function useIntercomSync() {
 
     const store = useWalletStore.getState;
 
-    // Track in-flight refetches so we can cancel them on unmount — the
-    // subscriber is also retry-wrapped (prev bug was a missed refetch on a
-    // racy port reconnect during a StateUpdated broadcast).
-    let refetchCancelled = false;
+    // Each StateUpdated broadcast launches a retry-wrapped refetch. A slow
+    // retry from an earlier broadcast must not clobber the newer state, so we
+    // cancel the previous loop's token on every new broadcast (and on unmount).
+    let currentRefetchToken = { cancelled: false };
 
     const unsubscribe = intercom.subscribe((msg: WalletNotification) => {
       if (msg?.type === WalletMessageType.StateUpdated) {
-        retryFetchState(() => refetchCancelled).then(state => {
-          if (state) syncFromBackend(state);
+        currentRefetchToken.cancelled = true;
+        const token = { cancelled: false };
+        currentRefetchToken = token;
+        retryFetchState(() => token.cancelled).then(state => {
+          if (state && !token.cancelled) syncFromBackend(state);
         });
       } else if (msg?.type === WalletMessageType.SyncCompleted) {
         // Service worker finished a sync cycle — update sync status
@@ -148,7 +153,7 @@ export function useIntercomSync() {
     });
 
     return () => {
-      refetchCancelled = true;
+      currentRefetchToken.cancelled = true;
       unsubscribe();
     };
   }, [syncFromBackend]);


### PR DESCRIPTION
Closes #113

## Summary

Fixes #113 — popup white-screens with `Failed to fetch initial state: Error: Timeout` after a Chrome/service-worker restart, with no recovery path.

Root cause (three call-sites, all in `src/lib/store/`):
1. `WalletStoreProvider` hard-gated the entire app tree on `isInitialized` → null fallback = white popup.
2. `useIntercomSync` used a fixed 15 s retry budget (5 × 3 s `withTimeout`) — too tight for MV3 SW cold-start + WASM init + initial chain sync.
3. On exhaustion, `initialFetchDone.current = false` set a "retry allowed" flag but nothing re-triggered the effect, so the popup stayed dead until fully reopened.

## Changes

- **`WalletStoreProvider`** — render children unconditionally. `getFrontState()` on the backend already short-circuits to `Idle` while the SW inits, and Zustand's defaults match that shape, so there's no visual regression; the gate was the problem, not a safety net.
- **`useIntercomSync`** — replaced the one-shot `retry(5)` + `initialFetchDone` latch with a cancellable unbounded retry loop (250 ms → 3 s exponential backoff). `fetchStateFromBackend` is now plainly single-attempt with a 3 s per-call timeout; the effect owns the retry policy.
- The existing `StateUpdated` subscriber (broadcast from `main.ts:start` after `Actions.init()`) continues to hydrate the store as soon as the SW is ready — either path now lands state, so a missed broadcast or slow port setup can no longer leave the popup permanently stuck.
- Dropped the now-unused `async-retry` import; updated tests for the simplified `fetchStateFromBackend()` signature.

## Test plan

- [x] `yarn jest` — 1703/1703 pass
- [x] `yarn lint` — clean (0 warnings)
- [x] `yarn format` — clean
- [x] `yarn build` — tsc + vite succeed, `dist/chrome_unpacked/manifest.json` produced
- [ ] Reviewer: reproduce #113 by closing Chrome fully, waiting ≥30 s for the SW to suspend, reopening and clicking the extension — popup should render (Idle state if cold, Ready once the SW hydrates) instead of staying blank.