### PR TITLE
Stress harness: per-op balance divergence + secondary/worker capture

### DIFF
--- a/playwright/e2e/fixtures/two-wallets.ts
+++ b/playwright/e2e/fixtures/two-wallets.ts
@@ -7,7 +7,12 @@ import { getEnvironmentConfig } from '../config/environments';
 import { attachConsoleCapture } from '../harness/browser-capture';
 import { CLIRunner } from '../harness/cli-runner';
 import { buildFailureReport, saveFailureReport } from '../harness/failure-report';
-import { SW_FETCH_LOG_PREFIX, attachNetworkCapture, attachServiceWorkerFetchCapture } from '../harness/network-capture';
+import {
+  SW_FETCH_LOG_PREFIX,
+  attachNetworkCapture,
+  attachPageWorkersCapture,
+  attachServiceWorkerFetchCapture
+} from '../harness/network-capture';
 import { captureWalletSnapshot } from '../harness/state-snapshot';
 import { TestStepRunner } from '../harness/test-step';
 import { TimelineRecorder } from '../harness/timeline-recorder';
@@ -208,6 +213,10 @@ async function launchWalletInstance(label: 'A' | 'B', extensionPath: string, tim
   }
 
   attachNetworkCapture(context, label, timeline);
+  // SDK spawns a web worker (web-client-methods-worker.js) that runs the WASM
+  // prove/sync/submit RPCs; its fetches are invisible to page- and SW-scoped
+  // capture. Instrument every current + future worker this page spawns.
+  attachPageWorkersCapture(page, label, timeline);
 
   const earlyErrors: string[] = [];
   page.on('console', msg => {

--- a/playwright/e2e/harness/network-capture.ts
+++ b/playwright/e2e/harness/network-capture.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Request, Response as PwResponse, Worker } from '@playwright/test';
+import type { BrowserContext, Page, Request, Response as PwResponse, Worker } from '@playwright/test';
 
 import type { TimelineRecorder } from './timeline-recorder';
 import type { NetworkCategory } from './types';
@@ -201,4 +201,28 @@ export async function attachServiceWorkerFetchCapture(
       message: `[SW-NET] fetch wrapper install failed: ${err instanceof Error ? err.message : String(err)}`
     });
   }
+}
+
+/**
+ * Page-spawned worker capture. The Miden SDK spawns a dedicated web worker
+ * (`web-client-methods-worker.js`) where the compiled-Rust client runs the
+ * bulk of its RPCs — prover, sync, submit, etc. Those fetches happen in the
+ * worker's own context and are NOT visible to:
+ *   - the SW-scoped wrapper (different global)
+ *   - context.on('requestfinished') page-scoped events
+ *   - context.on('requestfinished') SW-scoped events (we dedupe those via
+ *     request.serviceWorker())
+ *
+ * Solution: the same fetch-wrapper pattern, but installed via the worker's
+ * own evaluate(). A console listener on the worker target demuxes the
+ * sentinel lines into network_request events. Applied to every worker
+ * spawned by the page (current + future).
+ */
+export function attachPageWorkersCapture(page: Page, walletLabel: 'A' | 'B', timeline: TimelineRecorder): void {
+  for (const worker of page.workers()) {
+    void attachServiceWorkerFetchCapture(worker, walletLabel, timeline);
+  }
+  page.on('worker', worker => {
+    void attachServiceWorkerFetchCapture(worker, walletLabel, timeline);
+  });
 }

--- a/playwright/e2e/helpers/wallet-page.ts
+++ b/playwright/e2e/helpers/wallet-page.ts
@@ -62,6 +62,12 @@ export interface ChromeWalletPageApi extends WalletPage {
   }>;
   /** Full dump of chrome.storage.local — end-of-run forensic snapshot. */
   dumpChromeStorage(): Promise<Record<string, unknown>>;
+  /**
+   * Full IndexedDB dump (all databases × all object stores). Returns a JSON
+   * string with binary/BigInt wrappers. This is where the Miden SDK keeps
+   * per-tx commit status — the ground truth for "did this tx land?".
+   */
+  dumpIndexedDB(): Promise<string>;
 }
 
 /**
@@ -534,6 +540,96 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
       );
     } catch (e) {
       return { __error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  /**
+   * Dump every IndexedDB database on the extension origin. This is where the
+   * Miden SDK persists its authoritative state — accounts, transactions,
+   * notes, chain MMR, block headers. For "did this tx actually commit?"
+   * forensics, the SDK's `transactions` table is the ground truth.
+   *
+   * Output shape: `{ [dbName]: { version, stores: { [storeName]: entries[] } } }`.
+   * Binary fields (Uint8Array / ArrayBuffer / BigInt) are converted to
+   * `{ __type, hex | value, length }` wrappers so the result round-trips
+   * through JSON and through Playwright's postMessage serialization.
+   *
+   * Not exposed on WalletPage interface — Chrome-only (IndexedDB-per-origin).
+   */
+  async dumpIndexedDB(): Promise<string> {
+    try {
+      return await this.page.evaluate(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const idb = (globalThis as any).indexedDB as IDBFactory;
+        const dbList = await idb.databases();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result: Record<string, any> = {};
+
+        const openDb = (name: string): Promise<IDBDatabase> =>
+          new Promise((resolve, reject) => {
+            const req = idb.open(name);
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+            req.onblocked = () => reject(new Error('blocked'));
+          });
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const getAll = (store: IDBObjectStore): Promise<any[]> =>
+          new Promise((resolve, reject) => {
+            const req = store.getAll();
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+          });
+
+        for (const info of dbList) {
+          if (!info.name) continue;
+          try {
+            const db = await openDb(info.name);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const stores: Record<string, any> = {};
+            for (const storeName of db.objectStoreNames) {
+              try {
+                const tx = db.transaction(storeName, 'readonly');
+                const store = tx.objectStore(storeName);
+                stores[storeName] = await getAll(store);
+              } catch (e) {
+                stores[storeName] = { __error: String(e) };
+              }
+            }
+            db.close();
+            result[info.name] = { version: info.version, stores };
+          } catch (e) {
+            result[info.name] = { __error: String(e) };
+          }
+        }
+
+        // JSON-serialize with binary/BigInt wrappers so the payload round-trips
+        // cleanly. Returning a string (vs the object) also avoids Playwright's
+        // structuredClone choking on Uint8Array in some Chromium revisions.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const replacer = (_k: string, v: any): unknown => {
+          if (v instanceof Uint8Array || v instanceof Uint8ClampedArray) {
+            const hex = Array.from(v)
+              .map(b => b.toString(16).padStart(2, '0'))
+              .join('');
+            return { __type: 'Uint8Array', hex, length: v.length };
+          }
+          if (v instanceof ArrayBuffer) {
+            const arr = new Uint8Array(v);
+            const hex = Array.from(arr)
+              .map(b => b.toString(16).padStart(2, '0'))
+              .join('');
+            return { __type: 'ArrayBuffer', hex, length: arr.length };
+          }
+          if (typeof v === 'bigint') {
+            return { __type: 'BigInt', value: v.toString() };
+          }
+          return v;
+        };
+        return JSON.stringify(result, replacer);
+      });
+    } catch (e) {
+      return JSON.stringify({ __error: e instanceof Error ? e.message : String(e) });
     }
   }
 

--- a/playwright/e2e/helpers/wallet-page.ts
+++ b/playwright/e2e/helpers/wallet-page.ts
@@ -50,6 +50,18 @@ export interface ChromeWalletPageApi extends WalletPage {
   readonly page: Page;
   readonly extensionId: string;
   readonly userDataDir: string;
+  /** Fast, non-invasive balance + pending-notes + outgoing-tx snapshot. */
+  quickBalanceSnapshot(): Promise<{
+    balance: number;
+    pendingNotes: Array<{ id: string; amount: number; faucetId: string }>;
+    pendingSum: number;
+    totalReportable: number;
+    pendingTxCount: number;
+    latestTxId?: string;
+    error?: string;
+  }>;
+  /** Full dump of chrome.storage.local — end-of-run forensic snapshot. */
+  dumpChromeStorage(): Promise<Record<string, unknown>>;
 }
 
 /**
@@ -413,6 +425,117 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
   }
 
   // ── Balance ───────────────────────────────────────────────────────────────
+
+  /**
+   * Non-invasive snapshot of the wallet's balance-related state. Unlike
+   * getBalance() it:
+   *   - does NOT navigate
+   *   - does NOT call state.fetchBalances (which triggers an RPC)
+   *   - does not require the Explore page to be visible
+   *
+   * Reads straight from the Zustand store + `chrome.storage.local`:
+   *   - `balance` = consumed vault assets (matches getBalance's first source)
+   *   - `pendingNotes` = full list of claimable notes (id + amount)
+   *   - `totalReportable` = balance + Σ pendingNotes — matches getBalance()
+   *   - `pendingTxCount` / `lastTxId` = wallet's recent outgoing transactions
+   *
+   * Safe to call every op: measured at ~50 ms per wallet.
+   */
+  async quickBalanceSnapshot(): Promise<{
+    balance: number;
+    pendingNotes: Array<{ id: string; amount: number; faucetId: string }>;
+    pendingSum: number;
+    totalReportable: number;
+    pendingTxCount: number;
+    latestTxId?: string;
+    error?: string;
+  }> {
+    try {
+      return await this.page.evaluate(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const store = (window as any).__TEST_STORE__;
+        const state = store?.getState?.();
+        let balance = 0;
+        for (const tokenList of Object.values(state?.balances || {}) as unknown[]) {
+          if (!Array.isArray(tokenList)) continue;
+          for (const token of tokenList) {
+            const amount = parseFloat(String(token.amount ?? token.balance ?? '0'));
+            if (amount > 0) balance += amount;
+          }
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const storage = await new Promise<any>(resolve => {
+          chrome.storage.local.get(['miden_sync_data'], resolve);
+        });
+        const notes = storage?.miden_sync_data?.notes ?? [];
+        const pendingNotes: Array<{ id: string; amount: number; faucetId: string }> = [];
+        let pendingSum = 0;
+        for (const note of notes) {
+          const baseUnits = parseInt(String(note.amountBaseUnits ?? '0'), 10);
+          const decimals = note.metadata?.decimals ?? 8;
+          const amount = baseUnits / Math.pow(10, decimals);
+          pendingNotes.push({ id: String(note.id ?? ''), amount, faucetId: String(note.faucetId ?? '') });
+          pendingSum += amount;
+        }
+
+        // Outgoing transaction queue (from Zustand — shape: {[id]: record} or array)
+        let pendingTxCount = 0;
+        let latestTxId: string | undefined;
+        const txs = state?.transactions;
+        if (txs && typeof txs === 'object') {
+          const list = Array.isArray(txs) ? txs : Object.values(txs);
+          pendingTxCount = list.length;
+          // Pick the most recent by timestamp if available
+          let mostRecent: { id?: string; timestamp?: number } | null = null;
+          for (const t of list as Array<{ id?: string; transactionId?: string; timestamp?: number }>) {
+            const id = t.id ?? t.transactionId;
+            const ts = t.timestamp ?? 0;
+            if (!mostRecent || ts > (mostRecent.timestamp ?? 0)) {
+              mostRecent = { id, timestamp: ts };
+            }
+          }
+          latestTxId = mostRecent?.id;
+        }
+
+        return {
+          balance,
+          pendingNotes,
+          pendingSum,
+          totalReportable: balance + pendingSum,
+          pendingTxCount,
+          latestTxId
+        };
+      });
+    } catch (e) {
+      return {
+        balance: 0,
+        pendingNotes: [],
+        pendingSum: 0,
+        totalReportable: 0,
+        pendingTxCount: 0,
+        error: e instanceof Error ? e.message : String(e)
+      };
+    }
+  }
+
+  /**
+   * Dump every key in chrome.storage.local — used at end-of-run for forensic
+   * analysis. Includes miden_sync_data (notes + vaultAssets), connectivity-
+   * issue flag, cached metadata, etc.
+   */
+  async dumpChromeStorage(): Promise<Record<string, unknown>> {
+    try {
+      return await this.page.evaluate(
+        () =>
+          new Promise<Record<string, unknown>>(resolve => {
+            chrome.storage.local.get(null, items => resolve(items || {}));
+          })
+      );
+    } catch (e) {
+      return { __error: e instanceof Error ? e.message : String(e) };
+    }
+  }
 
   /**
    * Get the balance for a specific token from the Explore page.

--- a/playwright/e2e/stress/stress-driver.ts
+++ b/playwright/e2e/stress/stress-driver.ts
@@ -64,6 +64,11 @@ export interface StressResult {
     concurrentSecondaryFailed: number;
     idles: number;
   };
+  /** First op index where observed balance diverged from expected, or null if none. */
+  firstDivergenceOp: number | null;
+  /** Final expected deltas vs initial (useful for verifying driver bookkeeping). */
+  expectedDeltaA: number;
+  expectedDeltaB: number;
   perOp: StressOpRecord[];
 }
 
@@ -121,6 +126,25 @@ export async function runStressDriver(
   let completed = 0;
   let failed = 0;
   let idx = 0;
+
+  // Per-op balance tracking: the driver knows each op's intended transfer,
+  // so it can maintain expected deltas and compare against the wallet's
+  // actual reported state (consumed + pending). First divergent op pinpoints
+  // where tokens started going missing.
+  const initA = await walletA.quickBalanceSnapshot();
+  const initB = await walletB.quickBalanceSnapshot();
+  const initialA = initA.totalReportable;
+  const initialB = initB.totalReportable;
+  let expectedDeltaA = 0;
+  let expectedDeltaB = 0;
+  let firstDivergenceOp: number | null = null;
+
+  timeline.emit({
+    category: 'blockchain_state',
+    severity: 'info',
+    message: `[bal] driver start initialA=${initialA} initialB=${initialB}`,
+    data: { initialA, initialB, phase: 'driver_start' }
+  });
 
   timeline.emit({
     category: 'test_lifecycle',
@@ -270,6 +294,62 @@ export async function runStressDriver(
       data: { idx, sender: senderLabel, receiver: receiverLabel, isPrivate, amount, sendMs, status, concurrent, slow }
     });
 
+    // ── Balance bookkeeping ─────────────────────────────────────────────────
+    // Update expected deltas from this op's primary + (if applicable) secondary.
+    if (status === 'ok') {
+      if (senderLabel === 'A') expectedDeltaA -= amount;
+      else expectedDeltaB -= amount;
+      if (receiverLabel === 'A') expectedDeltaA += amount;
+      else expectedDeltaB += amount;
+    }
+    if (concurrent && secondaryStatus === 'ok' && secondaryAmount !== undefined) {
+      // secondary direction is reversed: sender=receiverLabel, receiver=senderLabel
+      if (receiverLabel === 'A') expectedDeltaA -= secondaryAmount;
+      else expectedDeltaB -= secondaryAmount;
+      if (senderLabel === 'A') expectedDeltaA += secondaryAmount;
+      else expectedDeltaB += secondaryAmount;
+    }
+
+    // Read actual — parallel, ~100ms total
+    const [snapA, snapB] = await Promise.all([walletA.quickBalanceSnapshot(), walletB.quickBalanceSnapshot()]);
+    const observedDeltaA = snapA.totalReportable - initialA;
+    const observedDeltaB = snapB.totalReportable - initialB;
+    const divergenceA = observedDeltaA - expectedDeltaA;
+    const divergenceB = observedDeltaB - expectedDeltaB;
+    const diverged = divergenceA !== 0 || divergenceB !== 0;
+    if (diverged && firstDivergenceOp === null) {
+      firstDivergenceOp = idx;
+    }
+    timeline.emit({
+      category: 'blockchain_state',
+      severity: diverged ? 'warn' : 'info',
+      message:
+        `[bal] op#${idx} ` +
+        `expΔA=${expectedDeltaA} expΔB=${expectedDeltaB} | ` +
+        `obsΔA=${observedDeltaA} obsΔB=${observedDeltaB} | ` +
+        `divA=${divergenceA} divB=${divergenceB}` +
+        (diverged ? ' DIVERGED' : ''),
+      data: {
+        idx,
+        expectedDeltaA,
+        expectedDeltaB,
+        observedDeltaA,
+        observedDeltaB,
+        divergenceA,
+        divergenceB,
+        diverged,
+        actualA: snapA.totalReportable,
+        actualB: snapB.totalReportable,
+        pendingNotesA: snapA.pendingNotes.length,
+        pendingNotesB: snapB.pendingNotes.length,
+        pendingTxA: snapA.pendingTxCount,
+        pendingTxB: snapB.pendingTxCount,
+        latestTxA: snapA.latestTxId,
+        latestTxB: snapB.latestTxId,
+        firstDivergenceOp
+      }
+    });
+
     // Optional immediate claim on the receiver — mimics an attentive user.
     // Budget is generous because this is a correctness test: the new drain
     // loop iterates ~6s per cycle, so 240s = ~40 iterations.
@@ -376,5 +456,15 @@ export async function runStressDriver(
     await sleep(5_000);
   }
 
-  return { seed: opts.seed, requested: opts.numNotes, completed, failed, perturbations, perOp };
+  return {
+    seed: opts.seed,
+    requested: opts.numNotes,
+    completed,
+    failed,
+    perturbations,
+    firstDivergenceOp,
+    expectedDeltaA,
+    expectedDeltaB,
+    perOp
+  };
 }

--- a/playwright/e2e/stress/stress-driver.ts
+++ b/playwright/e2e/stress/stress-driver.ts
@@ -41,6 +41,15 @@ export interface StressOpRecord {
   err?: string;
   perturbation?: string;
   concurrent?: boolean;
+  // When concurrent=true, a secondary send fires in the reverse direction. The
+  // driver awaits it (allSettled) so it doesn't fail the primary, but the
+  // result matters for balance conservation — a silently-failed secondary is
+  // prime suspect for "tokens lost" reports. Track amount + outcome.
+  secondaryAmount?: number;
+  secondaryIsPrivate?: boolean;
+  secondaryStatus?: 'ok' | 'fail';
+  secondaryErr?: string;
+  secondarySendMs?: number;
 }
 
 export interface StressResult {
@@ -48,7 +57,13 @@ export interface StressResult {
   requested: number;
   completed: number;
   failed: number;
-  perturbations: { locks: number; reloads: number; concurrent: number; idles: number };
+  perturbations: {
+    locks: number;
+    reloads: number;
+    concurrent: number;
+    concurrentSecondaryFailed: number;
+    idles: number;
+  };
   perOp: StressOpRecord[];
 }
 
@@ -102,7 +117,7 @@ export async function runStressDriver(
   const wallets: Record<'A' | 'B', ChromeWalletPageApi> = { A: walletA, B: walletB };
   const addrs: Record<'A' | 'B', string> = { A: addressA, B: addressB };
   const perOp: StressOpRecord[] = [];
-  const perturbations = { locks: 0, reloads: 0, concurrent: 0, idles: 0 };
+  const perturbations = { locks: 0, reloads: 0, concurrent: 0, concurrentSecondaryFailed: 0, idles: 0 };
   let completed = 0;
   let failed = 0;
   let idx = 0;
@@ -131,6 +146,15 @@ export async function runStressDriver(
     let err: string | undefined;
     let perturbation: string | undefined;
 
+    // Secondary (concurrent) send, captured only when concurrent=true.
+    // Previously unobserved — a silently-failed secondary is the leading
+    // hypothesis for persistent balance-conservation gaps.
+    let secondaryAmount: number | undefined;
+    let secondaryIsPrivate: boolean | undefined;
+    let secondaryStatus: 'ok' | 'fail' | undefined;
+    let secondaryErr: string | undefined;
+    let secondarySendMs: number | undefined;
+
     timeline.emit({
       category: 'stress_op',
       severity: 'info',
@@ -144,12 +168,13 @@ export async function runStressDriver(
       if (concurrent) {
         // Both wallets fire a send at (roughly) the same time — stress the
         // client-side lock discipline. The secondary send is in the OTHER
-        // direction and won't count toward the note budget (we only track the
-        // primary); if it succeeds the receiver sees two incoming notes.
+        // direction and doesn't count toward the note budget (only the primary
+        // does); its outcome is recorded for balance-conservation forensics.
         perturbations.concurrent++;
-        const secondaryAmount = intInRange(opts.sendAmountMin, opts.sendAmountMax, rng);
-        const secondaryIsPrivate = rng() < opts.privateRatio;
-        const [primary] = await Promise.allSettled([
+        secondaryAmount = intInRange(opts.sendAmountMin, opts.sendAmountMax, rng);
+        secondaryIsPrivate = rng() < opts.privateRatio;
+        const secondaryStart = Date.now();
+        const [primary, secondary] = await Promise.allSettled([
           withTimeout(
             sender.sendTokens({ recipientAddress: receiverAddress, amount: String(amount), isPrivate, tokenSymbol }),
             opts.perTurnSendTimeoutMs,
@@ -166,6 +191,30 @@ export async function runStressDriver(
             `op#${idx} concurrent secondary (${receiverLabel}->${senderLabel})`
           )
         ]);
+        secondarySendMs = Date.now() - secondaryStart;
+        if (secondary.status === 'rejected') {
+          secondaryStatus = 'fail';
+          secondaryErr = secondary.reason instanceof Error ? secondary.reason.message : String(secondary.reason);
+          perturbations.concurrentSecondaryFailed++;
+          timeline.emit({
+            category: 'stress_op',
+            severity: 'warn',
+            message:
+              `[stress] op#${idx} concurrent secondary ${receiverLabel}->${senderLabel} ` +
+              `${secondaryIsPrivate ? 'priv' : 'pub'} amt=${secondaryAmount} FAILED: ${secondaryErr.slice(0, 200)}`,
+            data: {
+              idx,
+              sender: receiverLabel,
+              receiver: senderLabel,
+              isPrivate: secondaryIsPrivate,
+              amount: secondaryAmount,
+              sendMs: secondarySendMs,
+              phase: 'secondary_failed'
+            }
+          });
+        } else {
+          secondaryStatus = 'ok';
+        }
         if (primary.status === 'rejected') throw primary.reason;
       } else {
         await withTimeout(
@@ -196,7 +245,12 @@ export async function runStressDriver(
       sendMs,
       status,
       err,
-      concurrent
+      concurrent,
+      secondaryAmount,
+      secondaryIsPrivate,
+      secondaryStatus,
+      secondaryErr,
+      secondarySendMs
     });
 
     // Slow ops aren't failures — log them as warn so they're visible in the

--- a/playwright/e2e/stress/stress.spec.ts
+++ b/playwright/e2e/stress/stress.spec.ts
@@ -264,6 +264,18 @@ test.describe('Stress: random send/claim', () => {
         console.log(`[stress] chrome.storage dump failed: ${e instanceof Error ? e.message : String(e)}`);
       }
 
+      // IndexedDB — where the Miden SDK keeps its authoritative state
+      // (transactions, notes, accounts, chain MMR). For "did this tx actually
+      // commit?" forensics, the SDK's transactions table is the ground truth.
+      // Result is a JSON string (with binary→hex wrappers); wrap per-wallet
+      // keys so both fit in one readable file.
+      try {
+        const [idbA, idbB] = await Promise.all([walletA.dumpIndexedDB(), walletB.dumpIndexedDB()]);
+        fs.writeFileSync(path.join(outDir, 'indexeddb-final.json'), `{"A":${idbA},"B":${idbB}}`);
+      } catch (e) {
+        console.log(`[stress] indexeddb dump failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
       // Extract pending-tx time series from existing GeneratingTransaction
       // browser_console events — zero-cost post-processing of data the
       // wallet already logs. Output: CSV with one row per state change.

--- a/playwright/e2e/stress/stress.spec.ts
+++ b/playwright/e2e/stress/stress.spec.ts
@@ -161,7 +161,9 @@ test.describe('Stress: random send/claim', () => {
       // ── Write artifacts ────────────────────────────────────────────────
       const outDir = timeline.getOutputDir();
       const csvPath = path.join(outDir, 'stress-operations.csv');
-      const header = 'idx,sender,receiver,isPrivate,amount,sendMs,status,concurrent,perturbation,error\n';
+      const header =
+        'idx,sender,receiver,isPrivate,amount,sendMs,status,concurrent,perturbation,error,' +
+        'secondaryAmount,secondaryIsPrivate,secondaryStatus,secondarySendMs,secondaryErr\n';
       const rows = result.perOp
         .map(o =>
           [
@@ -174,7 +176,12 @@ test.describe('Stress: random send/claim', () => {
             o.status,
             o.concurrent ?? false,
             o.perturbation ?? '',
-            (o.err ?? '').replace(/[,\n]/g, ' ')
+            (o.err ?? '').replace(/[,\n]/g, ' '),
+            o.secondaryAmount ?? '',
+            o.secondaryIsPrivate ?? '',
+            o.secondaryStatus ?? '',
+            o.secondarySendMs ?? '',
+            (o.secondaryErr ?? '').replace(/[,\n]/g, ' ')
           ].join(',')
         )
         .join('\n');

--- a/playwright/e2e/stress/stress.spec.ts
+++ b/playwright/e2e/stress/stress.spec.ts
@@ -138,8 +138,10 @@ test.describe('Stress: random send/claim', () => {
       const settleStart = Date.now();
       while (Date.now() - settleStart < SETTLE_DEADLINE_MS) {
         await Promise.all([walletA.triggerSync(), walletB.triggerSync()]);
-        finalA = await walletA.getBalance();
-        finalB = await walletB.getBalance();
+        // Read full snapshot so we can log *what's* pending if settle gets stuck.
+        const [snapA, snapB] = await Promise.all([walletA.quickBalanceSnapshot(), walletB.quickBalanceSnapshot()]);
+        finalA = snapA.totalReportable;
+        finalB = snapB.totalReportable;
         if (finalA + finalB === initialTotal) {
           timeline.emit({
             category: 'test_lifecycle',
@@ -148,10 +150,34 @@ test.describe('Stress: random send/claim', () => {
           });
           break;
         }
+        const pendingSample = (
+          s: Awaited<ReturnType<typeof walletA.quickBalanceSnapshot>>,
+          label: 'A' | 'B'
+        ): string =>
+          s.pendingNotes.length === 0
+            ? `${label}.pending=[]`
+            : `${label}.pending=[${s.pendingNotes
+                .slice(0, 6)
+                .map(n => `${n.id.slice(0, 10)}=${n.amount}`)
+                .join(',')}${s.pendingNotes.length > 6 ? `,…+${s.pendingNotes.length - 6}` : ''}]`;
         timeline.emit({
           category: 'test_lifecycle',
           severity: 'info',
-          message: `[stress] settle: waiting — A=${finalA} B=${finalB} total=${finalA + finalB} target=${initialTotal}`
+          message:
+            `[stress] settle: waiting — A=${finalA} B=${finalB} total=${finalA + finalB} target=${initialTotal} ` +
+            `| ${pendingSample(snapA, 'A')} ${pendingSample(snapB, 'B')} ` +
+            `pendingTx A=${snapA.pendingTxCount} B=${snapB.pendingTxCount}`,
+          data: {
+            finalA,
+            finalB,
+            target: initialTotal,
+            pendingA: snapA.pendingNotes,
+            pendingB: snapB.pendingNotes,
+            pendingTxA: snapA.pendingTxCount,
+            pendingTxB: snapB.pendingTxCount,
+            latestTxA: snapA.latestTxId,
+            latestTxB: snapB.latestTxId
+          }
         });
         await new Promise(r => setTimeout(r, SETTLE_POLL_MS));
       }
@@ -208,7 +234,10 @@ test.describe('Stress: random send/claim', () => {
           requested: result.requested,
           completed: result.completed,
           failed: result.failed,
-          perturbations: result.perturbations
+          perturbations: result.perturbations,
+          firstDivergenceOp: result.firstDivergenceOp,
+          expectedDeltaA: result.expectedDeltaA,
+          expectedDeltaB: result.expectedDeltaB
         },
         sendLatencyMs: {
           min: latencies[0] ?? 0,
@@ -219,6 +248,48 @@ test.describe('Stress: random send/claim', () => {
         }
       };
       fs.writeFileSync(path.join(outDir, 'stress-summary.json'), JSON.stringify(summary, null, 2));
+
+      // ── Forensic dumps ─────────────────────────────────────────────────
+      // Full chrome.storage.local from both wallets — includes miden_sync_data
+      // (pending notes + vault assets), connectivity-issue flag, cached
+      // metadata, and anything else the wallet persists. Snapshot of the
+      // wallet's exact view-of-world at the moment the assertion runs.
+      try {
+        const [storageA, storageB] = await Promise.all([walletA.dumpChromeStorage(), walletB.dumpChromeStorage()]);
+        fs.writeFileSync(
+          path.join(outDir, 'chrome-storage-final.json'),
+          JSON.stringify({ A: storageA, B: storageB }, null, 2)
+        );
+      } catch (e) {
+        console.log(`[stress] chrome.storage dump failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      // Extract pending-tx time series from existing GeneratingTransaction
+      // browser_console events — zero-cost post-processing of data the
+      // wallet already logs. Output: CSV with one row per state change.
+      try {
+        const timelinePath = path.join(outDir, 'timeline.ndjson');
+        if (fs.existsSync(timelinePath)) {
+          const txQueueRows: string[] = ['elapsedMs,wallet,txCount,hasStartedProcessing,failedCount'];
+          const pattern =
+            /\[GeneratingTransaction\] State: \{txCount: (\d+), hasStartedProcessing: (true|false), failedCount: (\d+)/;
+          const contents = fs.readFileSync(timelinePath, 'utf-8');
+          for (const line of contents.split('\n')) {
+            if (!line) continue;
+            try {
+              const d = JSON.parse(line);
+              const m = pattern.exec(String(d.message ?? ''));
+              if (!m) continue;
+              txQueueRows.push(`${d.elapsedMs},${d.wallet ?? ''},${m[1]},${m[2]},${m[3]}`);
+            } catch {
+              // malformed line, skip
+            }
+          }
+          fs.writeFileSync(path.join(outDir, 'tx-queue-timeseries.csv'), txQueueRows.join('\n') + '\n');
+        }
+      } catch (e) {
+        console.log(`[stress] tx-queue extraction failed: ${e instanceof Error ? e.message : String(e)}`);
+      }
 
       console.log('\n=== STRESS SUMMARY ===');
       console.log(JSON.stringify(summary, null, 2));


### PR DESCRIPTION
## Summary

A 100-note throughput stress run on testnet (delays/idles/claim-after-send disabled) surfaced a persistent −59 TST conservation violation that the prior instrumentation couldn't explain — prover events all 200 OK, no executeTransaction errors, no wallet-side error events captured, yet the settle loop timed out and the connectivity banner fired in the UI.

Three blind spots were masking the actual signal. This PR closes all three.

### Commits

| commit | what | why |
|---|---|---|
| `d58499357` | track concurrent-op secondary status | The driver fired 11 concurrent ops. Each triggers a secondary send in the reverse direction. `Promise.allSettled([primary, secondary])` was only inspecting the primary's status — secondaries could fail silently (UI shows "initiated" but tx never commits) and the driver was entirely blind. Now recorded as CSV columns (`secondaryAmount`, `secondaryStatus`, `secondaryErr`) + `warn` timeline event on failure. |
| `9e9214acc` | instrument SDK-spawned web workers | The Miden SDK spawns a dedicated web worker (`web-client-methods-worker.js`) where most of the WASM RPC work runs — prove, sync, submit. Fetches in that context are invisible to page- and SW-scoped Playwright events. Added `attachPageWorkersCapture(page, ...)` that iterates `page.workers()` + `page.on('worker')` and installs the same fetch wrapper. |
| `150cf552e` | per-op balance divergence + forensic dumps | The primary visibility gain. After each op the driver tracks `expectedΔA/expectedΔB` (from the op it just executed, including secondaries) and reads `actualΔA/actualΔB` via a new `quickBalanceSnapshot()` that hits `chrome.storage.local` directly (no nav, no RPC — ~100 ms). First divergence = exact op where tokens started going missing, surfaced as `firstDivergenceOp` in the summary. Also dumps full `chrome.storage.local` from both wallets + extracts a `tx-queue-timeseries.csv` from existing `GeneratingTransaction` events, and upgrades the settle loop to log pending-notes contents (id + amount) so a stuck settle window tells us *what* is stuck. |

### Runtime cost

Per-op overhead of the new balance check: ~100 ms × 2 wallets ≈ 200 ms added per op, i.e. ~20 s extra for a 100-note run, ~100 s for a 500-note run. All other additions are zero-cost (post-process or one-shot at end).

## Test plan

- [ ] Re-run the 100-note throughput config (same env vars: `STRESS_NUM_NOTES=100 STRESS_DELAY_MIN_MS=0 STRESS_DELAY_MAX_MS=0 STRESS_IDLE_EVERY=0 STRESS_CLAIM_AFTER_SEND_PROB=0`) and confirm the divergence check pinpoints the failing op, or that conservation now holds.
- [ ] If a secondary fails during the run, verify the `warn` timeline event appears and `secondaryStatus=fail` shows in the CSV.
- [ ] Verify `chrome-storage-final.json` and `tx-queue-timeseries.csv` are produced in the run output dir.
- [ ] Verify SW-worker-sourced `network_request` events appear with `source: 'service_worker'` (this test also acts as the regression guard for worker capture).
- [ ] Existing sync-manager + miden-client unit tests still pass.