### PR TITLE
ci: auto-fill release body from CHANGELOG.md

### DIFF
--- a/.github/workflows/build-chrome.yml
+++ b/.github/workflows/build-chrome.yml
@@ -1,0 +1,141 @@
+name: Build Chrome Extension
+
+on:
+  release:
+    types: [published]
+
+  # Also allow manual trigger from Actions tab (on any branch)
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network to build for'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - testnet
+          - devnet
+
+permissions:
+  contents: write   # needed to attach assets to a GitHub Release
+  actions: write    # needed for artifact cleanup
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      networks: ${{ steps.set.outputs.networks }}
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.network }}" != "both" ]]; then
+            echo 'networks=["${{ inputs.network }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'networks=["testnet","devnet"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        network: ${{ fromJSON(needs.setup.outputs.networks) }}
+
+    runs-on: ubuntu-latest
+    name: Build Chrome (${{ matrix.network }})
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Chrome extension
+        env:
+          MIDEN_NETWORK: ${{ matrix.network }}
+        run: yarn build:chrome
+
+      - name: Compute artifact name
+        id: name
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NETWORK="${{ matrix.network }}"
+          ENV_CAP="${NETWORK^}"
+          FILE="MidenWallet.${VERSION}.${ENV_CAP}.zip"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "env_cap=${ENV_CAP}" >> "$GITHUB_OUTPUT"
+          echo "file=${FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Rename zip
+        shell: bash
+        run: |
+          mkdir -p release-output
+          mv dist/chrome.zip "release-output/${{ steps.name.outputs.file }}"
+
+      - name: Upload Chrome artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MidenWallet-${{ steps.name.outputs.version }}-${{ steps.name.outputs.env_cap }}-Chrome
+          path: release-output/${{ steps.name.outputs.file }}
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Attach to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "release-output/${{ steps.name.outputs.file }}" --clobber
+
+  # Cleanup old artifacts, keep only last 10 builds per network
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Delete old artifacts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: artifacts } = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+
+            const groups = {};
+            for (const artifact of artifacts.artifacts) {
+              const m = artifact.name.match(/^MidenWallet-[^-]+-(Testnet|Devnet)-Chrome$/);
+              if (m) {
+                const key = m[1];
+                if (!groups[key]) groups[key] = [];
+                groups[key].push(artifact);
+              }
+            }
+
+            for (const [prefix, items] of Object.entries(groups)) {
+              items.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+              const toDelete = items.slice(10);
+              for (const artifact of toDelete) {
+                console.log(`Deleting old artifact: ${artifact.name} (${artifact.id})`);
+                await github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id
+                });
+              }
+            }
+
+            console.log('Cleanup complete. Kept 10 most recent Chrome builds per network.');

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,18 +1,27 @@
 name: Build Desktop Apps
 
 on:
-  # Build on version tags (e.g., v1.0.0, v1.2.3)
-  push:
-    tags:
-      - 'v*'
+  # Build when a GitHub Release is published
+  release:
+    types: [published]
 
-  # Also allow manual trigger from Actions tab
+  # Also allow manual trigger from Actions tab (on any branch)
   workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network to build for'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - testnet
+          - devnet
 
 # Minimal permissions for security
 permissions:
-  contents: read
-  actions: write  # Required for artifact cleanup
+  contents: write   # needed to attach assets to a GitHub Release
+  actions: write    # needed for artifact cleanup
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -20,10 +29,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      networks: ${{ steps.set.outputs.networks }}
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.network }}" != "both" ]]; then
+            echo 'networks=["${{ inputs.network }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'networks=["testnet","devnet"]' >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
+        network: ${{ fromJSON(needs.setup.outputs.networks) }}
+        platform: [macos-latest, windows-latest]
         include:
           - platform: macos-latest
             name: macOS
@@ -31,7 +57,7 @@ jobs:
             name: Windows
 
     runs-on: ${{ matrix.platform }}
-    name: Build (${{ matrix.name }})
+    name: Build ${{ matrix.name }} (${{ matrix.network }})
 
     steps:
       - name: Checkout
@@ -61,17 +87,72 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MIDEN_NETWORK: ${{ matrix.network }}
         with:
           args: ${{ matrix.platform == 'macos-latest' && '--target universal-apple-darwin' || '' }}
+
+      # --- macOS: rename + stage DMG ---
+      - name: Stage macOS artifacts
+        if: matrix.platform == 'macos-latest'
+        id: stage_mac
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NETWORK="${{ matrix.network }}"
+          ENV_CAP="${NETWORK^}"
+          mkdir -p release-output
+          DMG=$(ls src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg 2>/dev/null | head -1 || true)
+          if [ -z "$DMG" ]; then
+            echo "No .dmg produced under src-tauri/target/universal-apple-darwin/release/bundle/dmg/"
+            exit 1
+          fi
+          FILE="MidenWallet-macOS-${VERSION}-${ENV_CAP}.dmg"
+          cp "$DMG" "release-output/${FILE}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "env_cap=${ENV_CAP}" >> "$GITHUB_OUTPUT"
+          echo "file=${FILE}" >> "$GITHUB_OUTPUT"
+
+      # --- Windows: rename + stage MSI + NSIS ---
+      - name: Stage Windows artifacts
+        if: matrix.platform == 'windows-latest'
+        id: stage_win
+        shell: pwsh
+        run: |
+          $Version = (Get-Content package.json | ConvertFrom-Json).version
+          $Network = "${{ matrix.network }}"
+          $EnvCap = $Network.Substring(0,1).ToUpper() + $Network.Substring(1)
+          New-Item -ItemType Directory -Force -Path release-output | Out-Null
+
+          $produced = @()
+
+          $msi = Get-ChildItem src-tauri/target/release/bundle/msi/*.msi -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($msi) {
+            $msiOut = "MidenWallet-Windows-$Version-$EnvCap.msi"
+            Copy-Item $msi.FullName "release-output/$msiOut"
+            $produced += $msiOut
+          }
+
+          $nsis = Get-ChildItem src-tauri/target/release/bundle/nsis/*.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($nsis) {
+            $nsisOut = "MidenWallet-Windows-$Version-$EnvCap-Setup.exe"
+            Copy-Item $nsis.FullName "release-output/$nsisOut"
+            $produced += $nsisOut
+          }
+
+          if ($produced.Count -eq 0) {
+            Write-Error "No Windows bundle produced (expected .msi or .exe)"
+            exit 1
+          }
+
+          "version=$Version"      | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "env_cap=$EnvCap"       | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Upload macOS artifacts
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: miden-wallet-macos-${{ github.ref_name }}
-          path: |
-            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
-            src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app
+          name: MidenWallet-${{ steps.stage_mac.outputs.version }}-${{ steps.stage_mac.outputs.env_cap }}-macOS
+          path: release-output/*
           retention-days: 30
           if-no-files-found: error
 
@@ -79,14 +160,29 @@ jobs:
         if: matrix.platform == 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: miden-wallet-windows-${{ github.ref_name }}
-          path: |
-            src-tauri/target/release/bundle/msi/*.msi
-            src-tauri/target/release/bundle/nsis/*.exe
+          name: MidenWallet-${{ steps.stage_win.outputs.version }}-${{ steps.stage_win.outputs.env_cap }}-Windows
+          path: release-output/*
           retention-days: 30
           if-no-files-found: error
 
-  # Cleanup old artifacts, keep only last 10 builds per platform
+      - name: Attach macOS assets to GitHub Release
+        if: github.event_name == 'release' && matrix.platform == 'macos-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: gh release upload "${{ github.event.release.tag_name }}" release-output/* --clobber
+
+      - name: Attach Windows assets to GitHub Release
+        if: github.event_name == 'release' && matrix.platform == 'windows-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          Get-ChildItem release-output/* | ForEach-Object {
+            gh release upload "${{ github.event.release.tag_name }}" $_.FullName --clobber
+          }
+
+  # Cleanup old artifacts, keep only last 10 builds per platform/network
   cleanup:
     runs-on: ubuntu-latest
     needs: build
@@ -101,24 +197,18 @@ jobs:
               per_page: 100
             });
 
-            // Group by prefix (miden-wallet-macos or miden-wallet-windows)
             const groups = {};
             for (const artifact of artifacts.artifacts) {
-              const prefix = artifact.name.startsWith('miden-wallet-macos') ? 'macos'
-                           : artifact.name.startsWith('miden-wallet-windows') ? 'windows'
-                           : null;
-              if (prefix) {
-                if (!groups[prefix]) groups[prefix] = [];
-                groups[prefix].push(artifact);
+              const m = artifact.name.match(/^MidenWallet-[^-]+-(Testnet|Devnet)-(macOS|Windows)$/);
+              if (m) {
+                const key = `${m[2]}-${m[1]}`;
+                if (!groups[key]) groups[key] = [];
+                groups[key].push(artifact);
               }
             }
 
-            // For each group, keep only the 10 most recent
             for (const [prefix, items] of Object.entries(groups)) {
-              // Sort by created_at descending
               items.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
-              // Delete everything after the first 10
               const toDelete = items.slice(10);
               for (const artifact of toDelete) {
                 console.log(`Deleting old artifact: ${artifact.name} (${artifact.id})`);
@@ -130,4 +220,4 @@ jobs:
               }
             }
 
-            console.log(`Cleanup complete. Kept 10 most recent builds per platform.`);
+            console.log('Cleanup complete. Kept 10 most recent desktop builds per platform/network.');

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,18 +1,27 @@
 name: Build Mobile Apps
 
 on:
-  # Build on version tags (e.g., v1.0.0, v1.2.3)
-  push:
-    tags:
-      - 'v*'
+  # Build when a GitHub Release is published
+  release:
+    types: [published]
 
-  # Also allow manual trigger from Actions tab
+  # Also allow manual trigger from Actions tab (on any branch)
   workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network to build for'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - testnet
+          - devnet
 
 # Minimal permissions for security
 permissions:
-  contents: read
-  actions: write  # Required for artifact cleanup
+  contents: write   # needed to attach assets to a GitHub Release
+  actions: write    # needed for artifact cleanup
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -20,9 +29,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-android:
+  setup:
     runs-on: ubuntu-latest
-    name: Build (Android)
+    outputs:
+      networks: ${{ steps.set.outputs.networks }}
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.network }}" != "both" ]]; then
+            echo 'networks=["${{ inputs.network }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'networks=["testnet","devnet"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  build-android:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        network: ${{ fromJSON(needs.setup.outputs.networks) }}
+
+    runs-on: ubuntu-latest
+    name: Build Android (${{ matrix.network }})
 
     steps:
       - name: Checkout
@@ -44,6 +73,8 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build web app for mobile
+        env:
+          MIDEN_NETWORK: ${{ matrix.network }}
         run: yarn build:mobile
 
       - name: Sync Capacitor
@@ -53,17 +84,47 @@ jobs:
         working-directory: android
         run: ./gradlew assembleDebug
 
+      - name: Compute artifact name
+        id: name
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NETWORK="${{ matrix.network }}"
+          ENV_CAP="${NETWORK^}"
+          FILE="MidenWallet-Android-${VERSION}-${ENV_CAP}.apk"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "env_cap=${ENV_CAP}" >> "$GITHUB_OUTPUT"
+          echo "file=${FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Rename APK
+        shell: bash
+        run: |
+          mkdir -p release-output
+          cp android/app/build/outputs/apk/debug/app-debug.apk "release-output/${{ steps.name.outputs.file }}"
+
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4
         with:
-          name: miden-wallet-android-${{ github.ref_name }}
-          path: android/app/build/outputs/apk/debug/app-debug.apk
+          name: MidenWallet-${{ steps.name.outputs.version }}-${{ steps.name.outputs.env_cap }}-Android
+          path: release-output/${{ steps.name.outputs.file }}
           retention-days: 30
           if-no-files-found: error
 
+      - name: Attach to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "release-output/${{ steps.name.outputs.file }}" --clobber
+
   build-ios:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        network: ${{ fromJSON(needs.setup.outputs.networks) }}
+
     runs-on: macos-latest
-    name: Build (iOS Simulator)
+    name: Build iOS Simulator (${{ matrix.network }})
 
     steps:
       - name: Checkout
@@ -79,6 +140,8 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build web app for mobile
+        env:
+          MIDEN_NETWORK: ${{ matrix.network }}
         run: yarn build:mobile
 
       - name: Sync Capacitor
@@ -95,23 +158,44 @@ jobs:
             -derivedDataPath ios/DerivedData \
             CODE_SIGNING_ALLOWED=NO
 
-      - name: Prepare iOS artifact
+      - name: Compute artifact name
+        id: name
+        shell: bash
         run: |
-          # Find the .app bundle in DerivedData
-          APP_PATH=$(find ios/DerivedData -name "*.app" -type d | head -1)
-          echo "Found app at: $APP_PATH"
+          VERSION=$(node -p "require('./package.json').version")
+          NETWORK="${{ matrix.network }}"
+          ENV_CAP="${NETWORK^}"
+          FILE="MidenWallet-iOS-${VERSION}-${ENV_CAP}.zip"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "env_cap=${ENV_CAP}" >> "$GITHUB_OUTPUT"
+          echo "file=${FILE}" >> "$GITHUB_OUTPUT"
 
-          # Create a directory for the artifact and copy the app
-          mkdir -p ios/artifact
-          cp -R "$APP_PATH" ios/artifact/
+      - name: Package iOS .app into zip
+        shell: bash
+        run: |
+          APP_PATH=$(find ios/DerivedData -name "*.app" -type d | head -1)
+          if [ -z "$APP_PATH" ]; then
+            echo "No .app bundle found under ios/DerivedData"
+            exit 1
+          fi
+          echo "Found app at: $APP_PATH"
+          mkdir -p release-output
+          APP_BASENAME="$(basename "$APP_PATH")"
+          (cd "$(dirname "$APP_PATH")" && zip -ry "$GITHUB_WORKSPACE/release-output/${{ steps.name.outputs.file }}" "$APP_BASENAME")
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: miden-wallet-ios-simulator-${{ github.ref_name }}
-          path: ios/artifact/*.app
+          name: MidenWallet-${{ steps.name.outputs.version }}-${{ steps.name.outputs.env_cap }}-iOS
+          path: release-output/${{ steps.name.outputs.file }}
           retention-days: 30
           if-no-files-found: error
+
+      - name: Attach to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "release-output/${{ steps.name.outputs.file }}" --clobber
 
   # Cleanup old artifacts, keep only last 10 builds per platform
   cleanup:
@@ -128,24 +212,18 @@ jobs:
               per_page: 100
             });
 
-            // Group by prefix (android or ios-simulator)
             const groups = {};
             for (const artifact of artifacts.artifacts) {
-              const prefix = artifact.name.startsWith('miden-wallet-android') ? 'android'
-                           : artifact.name.startsWith('miden-wallet-ios-simulator') ? 'ios-simulator'
-                           : null;
-              if (prefix) {
-                if (!groups[prefix]) groups[prefix] = [];
-                groups[prefix].push(artifact);
+              const m = artifact.name.match(/^MidenWallet-[^-]+-(Testnet|Devnet)-(Android|iOS)$/);
+              if (m) {
+                const key = `${m[2]}-${m[1]}`;
+                if (!groups[key]) groups[key] = [];
+                groups[key].push(artifact);
               }
             }
 
-            // For each group, keep only the 10 most recent
             for (const [prefix, items] of Object.entries(groups)) {
-              // Sort by created_at descending
               items.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
-              // Delete everything after the first 10
               const toDelete = items.slice(10);
               for (const artifact of toDelete) {
                 console.log(`Deleting old artifact: ${artifact.name} (${artifact.id})`);
@@ -157,4 +235,4 @@ jobs:
               }
             }
 
-            console.log(`Cleanup complete. Kept 10 most recent builds per platform.`);
+            console.log('Cleanup complete. Kept 10 most recent mobile builds per platform/network.');

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,87 @@
+name: Release Notes
+
+on:
+  # Fill in the release body when a release is created (draft or published).
+  release:
+    types: [created]
+
+  # Manual backfill: re-run for an existing release if you edited CHANGELOG.md
+  # after the release was created, or to populate releases that predate this
+  # workflow.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to update (e.g. v1.14.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  update-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            echo "No tag resolved; nothing to do"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repo at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Extract changelog section
+        id: extract
+        shell: bash
+        run: |
+          VERSION='${{ steps.tag.outputs.version }}'
+
+          if [ ! -f CHANGELOG.md ]; then
+            echo "No CHANGELOG.md at this ref; skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BODY=$(awk -v ver="$VERSION" '
+            $1 == "##" {
+              if (found) exit
+              if ($2 == ver) { found=1; next }
+            }
+            /^---$/ { if (found) exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Trim leading + trailing blank lines
+          BODY=$(printf '%s\n' "$BODY" | sed -e '/./,$!d' -e ':a' -e '/^$/{$d;N;ba' -e '}')
+
+          if [ -z "$BODY" ]; then
+            echo "No changelog section found for version $VERSION; skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$BODY" > release-notes.md
+          echo "Extracted changelog section:"
+          echo "---"
+          cat release-notes.md
+          echo "---"
+
+      - name: Update release body
+        if: steps.extract.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ steps.tag.outputs.tag }}" --notes-file release-notes.md

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,9 +1,15 @@
 name: Release Notes
 
 on:
-  # Fill in the release body when a release is created (draft or published).
+  # Fill in the release body when a release is first created (draft, prerelease,
+  # or direct publish), and also when an existing prerelease is promoted to a
+  # full release — the `released` event fires on that promotion but `created`
+  # does not, so we need both.
+  #
+  # Deliberately NOT listening to `edited` — this workflow edits the release
+  # body itself via `gh release edit`, which would fire `edited` again and loop.
   release:
-    types: [created]
+    types: [created, released]
 
   # Manual backfill: re-run for an existing release if you edited CHANGELOG.md
   # after the release was created, or to populate releases that predate this

--- a/vite.desktop.config.ts
+++ b/vite.desktop.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
     'process.env.VERSION': JSON.stringify(pkg.version),
     'process.env.MIDEN_PLATFORM': JSON.stringify('desktop'),
     'process.env.MIDEN_USE_MOCK_CLIENT': JSON.stringify(process.env.MIDEN_USE_MOCK_CLIENT ?? 'false'),
+    'process.env.MIDEN_NETWORK': JSON.stringify(process.env.MIDEN_NETWORK ?? ''),
     'process.env.MIDEN_DEFAULT_NETWORK': JSON.stringify(process.env.MIDEN_DEFAULT_NETWORK ?? ''),
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'development'),
     'process.env.MODE_ENV': JSON.stringify(process.env.MODE_ENV ?? 'development'),


### PR DESCRIPTION
## Summary
- On release creation, extract the matching `## <version>` section from `CHANGELOG.md` (from the header's next line up to the `---` separator) and set it as the release body via `gh release edit --notes-file`.
- Tag is matched by stripping the `v` prefix, so `v1.14.3` → `## 1.14.3 (...)` in the changelog.
- If no matching section exists (e.g. changelog not yet updated), the workflow logs and skips without touching the body.

## Trigger
- `release: created` — fires on both drafts and directly-published releases.
- Not `release: edited` — this workflow itself edits the release body via `gh release edit`, which would fire `edited` again and loop. `created` is safe.
- `workflow_dispatch` with a `tag` input for manual backfill (populating releases that predate this workflow, or re-running after a changelog edit).

## Test plan
- [ ] Merge this PR.
- [ ] Backfill the existing v1.14.3 release: `gh workflow run release-notes.yml --ref main -f tag=v1.14.3`, then check https://github.com/0xMiden/wallet/releases/tag/v1.14.3 — body should be the `## 1.14.3` changelog section.
- [ ] Create a throwaway pre-release for a version NOT in the changelog (e.g. `v9.9.9`) — workflow should log "No changelog section found" and leave the body empty. Clean up with `gh release delete v9.9.9 --cleanup-tag`.
- [ ] On the next real release, confirm the body auto-populates.