### PR TITLE
fix(ci): use macos-26 runner for iOS build

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -123,7 +123,10 @@ jobs:
       matrix:
         network: ${{ fromJSON(needs.setup.outputs.networks) }}
 
-    runs-on: macos-latest
+    # macos-26 is required for the iOS 26 SDK (UIGlassEffect in dapp-browser's
+    # WKWebViewController.swift). macos-latest currently ships Xcode 16.4 with
+    # the iOS 18 SDK, which can't resolve iOS 26 Liquid Glass APIs.
+    runs-on: macos-26
     name: Build iOS Simulator (${{ matrix.network }})
 
     steps:


### PR DESCRIPTION
Mobile Android jobs are green after #207. iOS still fails at \`Build iOS Simulator app\` with:

\`\`\`
WKWebViewController.swift:2360:28: error: cannot find 'UIGlassEffect' in scope
\`\`\`

\`UIGlassEffect\` is an iOS 26 API (Liquid Glass). The \`macos-latest\` runner currently uses **Xcode 16.4 + iPhoneSimulator18.5.sdk**, which can't resolve it. Local dev machines building successfully are on Xcode 26.

Fix: pin the iOS job to \`macos-26\`, which ships Xcode 26 + iOS 26 SDK as default.

Failed run: https://github.com/0xMiden/wallet/actions/runs/24809238643/job/72610299562

## Test plan
- [ ] Merge.
- [ ] Re-run the mobile workflow on main and confirm both iOS matrix jobs go green end-to-end (Sync Capacitor → xcodebuild → zip .app → upload).