### PR TITLE
fix(ci): portable uppercase-first for ${NETWORK}

### DIFF
--- a/.github/workflows/build-chrome.yml
+++ b/.github/workflows/build-chrome.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           NETWORK="${{ matrix.network }}"
-          ENV_CAP="${NETWORK^}"
+          ENV_CAP=$(echo "$NETWORK" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
           FILE="MidenWallet.${VERSION}.${ENV_CAP}.zip"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "env_cap=${ENV_CAP}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           NETWORK="${{ matrix.network }}"
-          ENV_CAP="${NETWORK^}"
+          ENV_CAP=$(echo "$NETWORK" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
           mkdir -p release-output
           DMG=$(ls src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg 2>/dev/null | head -1 || true)
           if [ -z "$DMG" ]; then

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           NETWORK="${{ matrix.network }}"
-          ENV_CAP="${NETWORK^}"
+          ENV_CAP=$(echo "$NETWORK" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
           FILE="MidenWallet-Android-${VERSION}-${ENV_CAP}.apk"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "env_cap=${ENV_CAP}" >> "$GITHUB_OUTPUT"
@@ -167,7 +167,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           NETWORK="${{ matrix.network }}"
-          ENV_CAP="${NETWORK^}"
+          ENV_CAP=$(echo "$NETWORK" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
           FILE="MidenWallet-iOS-${VERSION}-${ENV_CAP}.zip"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "env_cap=${ENV_CAP}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Found while triaging the v1.14.3 release run's desktop \`Build macOS\` failure:

\`\`\`
/Users/runner/work/_temp/.../1.sh: line 3: \${NETWORK^}: bad substitution
\`\`\`

\`\${var^}\` is a bash 4 feature for capitalizing the first character. macOS GitHub runners ship with system **bash 3.2** (Apple pins it at the last GPLv2 release), so the step fails on every macOS job. Android passed because ubuntu-latest has bash 5.

The iOS matrix in \`build-mobile.yml\` has the same code but hasn't reached the step yet — xcodebuild was failing earlier (fixed in #208). Once that clears, iOS would have hit this same bug.

Replacing with a portable one-liner that works in any POSIX shell:

\`\`\`bash
ENV_CAP=\$(echo \"\$NETWORK\" | awk '{print toupper(substr(\$0,1,1)) substr(\$0,2)}')
\`\`\`

Normalized across all three workflows (chrome, mobile, desktop) for consistency, even though chrome runs on ubuntu where the original would have worked.

## Test plan
- [ ] Merge.
- [ ] Re-run mobile + desktop workflows on main. Confirm macOS DMG stage + iOS artifact-name step both succeed.