### PR TITLE
ci: add blockchain e2e workflow (chrome + mobile, devnet/testnet)

### DIFF
--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -76,8 +76,13 @@ jobs:
         shell: bash
         run: |
           VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
-          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
-          cargo install miden-client-cli --version "$VERSION"
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
 
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
@@ -127,8 +132,13 @@ jobs:
         shell: bash
         run: |
           VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
-          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
-          cargo install miden-client-cli --version "$VERSION"
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
 
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
@@ -202,14 +212,44 @@ jobs:
         shell: bash
         run: |
           VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
-          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
-          cargo install miden-client-cli --version "$VERSION"
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
 
       # CDP bridge (appium-remote-debugger) requires Simulator.app GUI to be
       # running — headless simctl boots don't expose webinspectord. Ignore
       # exit status because `open -a` returns 0 even if already open.
       - name: Launch Simulator.app
         run: open -a Simulator || true
+
+      # Fresh-create + boot of custom simulators hangs multi-minute then
+      # errors on macos-26 runners. Pin the test harness to preinstalled
+      # Xcode sims by writing .device-pair.json before globalSetup reads it.
+      - name: Pin test pair to preinstalled simulators
+        shell: bash
+        run: |
+          list_json=$(xcrun simctl list devices --json)
+          UDID_A=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17" and .isAvailable) ]
+            | first | .udid // empty')
+          UDID_B=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17 Pro" and .isAvailable) ]
+            | first | .udid // empty')
+          if [[ -z "$UDID_A" || -z "$UDID_B" ]]; then
+            echo "Missing preinstalled sim. A='$UDID_A'  B='$UDID_B'"
+            echo "Full device list:"
+            xcrun simctl list devices
+            exit 1
+          fi
+          mkdir -p test-results-ios
+          printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
+          echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
 
       - name: Run blockchain E2E (mobile, devnet)
         run: yarn test:e2e:mobile:devnet
@@ -253,11 +293,38 @@ jobs:
         shell: bash
         run: |
           VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
-          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
-          cargo install miden-client-cli --version "$VERSION"
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
 
       - name: Launch Simulator.app
         run: open -a Simulator || true
+
+      - name: Pin test pair to preinstalled simulators
+        shell: bash
+        run: |
+          list_json=$(xcrun simctl list devices --json)
+          UDID_A=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17" and .isAvailable) ]
+            | first | .udid // empty')
+          UDID_B=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17 Pro" and .isAvailable) ]
+            | first | .udid // empty')
+          if [[ -z "$UDID_A" || -z "$UDID_B" ]]; then
+            echo "Missing preinstalled sim. A='$UDID_A'  B='$UDID_B'"
+            echo "Full device list:"
+            xcrun simctl list devices
+            exit 1
+          fi
+          mkdir -p test-results-ios
+          printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
+          echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
 
       - name: Run blockchain E2E (mobile, testnet)
         run: yarn test:e2e:mobile:testnet

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -1,0 +1,252 @@
+name: E2E Blockchain
+
+# Runs the blockchain-backed E2E suites (Chrome extension + iOS simulator)
+# against public networks on every push to main. The per-platform gate jobs
+# pass as long as AT LEAST ONE network (devnet OR testnet) succeeded for
+# that platform — this tolerates short windows where wallet@main and a
+# single network are protocol-mismatched (e.g. devnet ahead of the pinned
+# SDK version).
+
+on:
+  push:
+    branches:
+      - main
+  # TEMPORARY: enables PR iteration while wiring up this workflow.
+  # Remove the `pull_request:` block as the final commit before merging to main.
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network(s) to test against'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - devnet
+          - testnet
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # --- Chrome ---------------------------------------------------------------
+
+  chrome-devnet:
+    name: Chrome E2E (devnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      E2E_NETWORK: devnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      # cargo is needed to install miden-client-cli from crates.io on first run.
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        # Cache key follows the root package.json so a SDK version bump
+        # (or any other root-level dep change) naturally invalidates — the
+        # CLI is installed version-matched to @miden-sdk/miden-sdk by
+        # helpers/miden-cli.ts.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run blockchain E2E (devnet)
+        run: xvfb-run -a yarn test:e2e:blockchain:devnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-e2e-devnet-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  chrome-testnet:
+    name: Chrome E2E (testnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      E2E_NETWORK: testnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run blockchain E2E (testnet)
+        run: xvfb-run -a yarn test:e2e:blockchain:testnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-e2e-testnet-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  chrome-gate:
+    name: Chrome E2E Gate
+    needs: [chrome-devnet, chrome-testnet]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require at least one network to pass
+        shell: bash
+        env:
+          DEVNET_RESULT: ${{ needs.chrome-devnet.result }}
+          TESTNET_RESULT: ${{ needs.chrome-testnet.result }}
+        run: |
+          echo "devnet=$DEVNET_RESULT  testnet=$TESTNET_RESULT"
+          if [[ "$DEVNET_RESULT" == "success" || "$TESTNET_RESULT" == "success" ]]; then
+            echo "Chrome E2E: at least one network passed."
+            exit 0
+          fi
+          echo "Chrome E2E: both networks failed or were skipped."
+          exit 1
+
+  # --- iOS Simulator --------------------------------------------------------
+
+  mobile-devnet:
+    name: Mobile E2E (devnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    # macos-26 matches build-mobile.yml — required for iOS 26 SDK symbols
+    # used by dapp-browser's WKWebViewController.
+    runs-on: macos-26
+    timeout-minutes: 90
+    env:
+      E2E_NETWORK: devnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run blockchain E2E (mobile, devnet)
+        run: yarn test:e2e:mobile:devnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-e2e-devnet-${{ github.run_id }}
+          path: test-results-ios/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  mobile-testnet:
+    name: Mobile E2E (testnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
+    runs-on: macos-26
+    timeout-minutes: 90
+    env:
+      E2E_NETWORK: testnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run blockchain E2E (mobile, testnet)
+        run: yarn test:e2e:mobile:testnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-e2e-testnet-${{ github.run_id }}
+          path: test-results-ios/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  mobile-gate:
+    name: Mobile E2E Gate
+    needs: [mobile-devnet, mobile-testnet]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require at least one network to pass
+        shell: bash
+        env:
+          DEVNET_RESULT: ${{ needs.mobile-devnet.result }}
+          TESTNET_RESULT: ${{ needs.mobile-testnet.result }}
+        run: |
+          echo "devnet=$DEVNET_RESULT  testnet=$TESTNET_RESULT"
+          if [[ "$DEVNET_RESULT" == "success" || "$TESTNET_RESULT" == "success" ]]; then
+            echo "Mobile E2E: at least one network passed."
+            exit 0
+          fi
+          echo "Mobile E2E: both networks failed or were skipped."
+          exit 1

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -254,6 +254,28 @@ jobs:
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
 
+      # Pays the cold-start cost (WebKit JIT, WASM compile, first install
+      # bundle validation) outside the 15-min per-test Playwright timeout.
+      # Without this, the first spec eats ~8 min of warmup overhead that
+      # subsequent specs don't see. Terminates + uninstalls afterwards so
+      # the fixture starts from the same clean state it always has.
+      - name: Warm up simulators
+        shell: bash
+        run: |
+          UDID_A=$(node -p "require('./test-results-ios/.device-pair.json').udidA")
+          UDID_B=$(node -p "require('./test-results-ios/.device-pair.json').udidB")
+          APP_PATH=ios/App/build/Build/Products/Debug-iphonesimulator/App.app
+          for UDID in "$UDID_A" "$UDID_B"; do
+            echo "--- Warming sim $UDID ---"
+            xcrun simctl boot "$UDID" 2>/dev/null || true
+            xcrun simctl install "$UDID" "$APP_PATH"
+            xcrun simctl launch "$UDID" com.miden.wallet || true
+            sleep 20
+            xcrun simctl terminate "$UDID" com.miden.wallet 2>/dev/null || true
+            xcrun simctl uninstall "$UDID" com.miden.wallet 2>/dev/null || true
+          done
+          echo "Warmup complete."
+
       - name: Run blockchain E2E (mobile, devnet)
         # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26
         # runners. Each fixture retries install → launch → CDP connect from
@@ -335,6 +357,28 @@ jobs:
 
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
+
+      # Pays the cold-start cost (WebKit JIT, WASM compile, first install
+      # bundle validation) outside the 15-min per-test Playwright timeout.
+      # Without this, the first spec eats ~8 min of warmup overhead that
+      # subsequent specs don't see. Terminates + uninstalls afterwards so
+      # the fixture starts from the same clean state it always has.
+      - name: Warm up simulators
+        shell: bash
+        run: |
+          UDID_A=$(node -p "require('./test-results-ios/.device-pair.json').udidA")
+          UDID_B=$(node -p "require('./test-results-ios/.device-pair.json').udidB")
+          APP_PATH=ios/App/build/Build/Products/Debug-iphonesimulator/App.app
+          for UDID in "$UDID_A" "$UDID_B"; do
+            echo "--- Warming sim $UDID ---"
+            xcrun simctl boot "$UDID" 2>/dev/null || true
+            xcrun simctl install "$UDID" "$APP_PATH"
+            xcrun simctl launch "$UDID" com.miden.wallet || true
+            sleep 20
+            xcrun simctl terminate "$UDID" com.miden.wallet 2>/dev/null || true
+            xcrun simctl uninstall "$UDID" com.miden.wallet 2>/dev/null || true
+          done
+          echo "Warmup complete."
 
       - name: Run blockchain E2E (mobile, testnet)
         # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -254,28 +254,6 @@ jobs:
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
 
-      # Pays the cold-start cost (WebKit JIT, WASM compile, first install
-      # bundle validation) outside the 15-min per-test Playwright timeout.
-      # Without this, the first spec eats ~8 min of warmup overhead that
-      # subsequent specs don't see. Terminates + uninstalls afterwards so
-      # the fixture starts from the same clean state it always has.
-      - name: Warm up simulators
-        shell: bash
-        run: |
-          UDID_A=$(node -p "require('./test-results-ios/.device-pair.json').udidA")
-          UDID_B=$(node -p "require('./test-results-ios/.device-pair.json').udidB")
-          APP_PATH=ios/App/build/Build/Products/Debug-iphonesimulator/App.app
-          for UDID in "$UDID_A" "$UDID_B"; do
-            echo "--- Warming sim $UDID ---"
-            xcrun simctl boot "$UDID" 2>/dev/null || true
-            xcrun simctl install "$UDID" "$APP_PATH"
-            xcrun simctl launch "$UDID" com.miden.wallet || true
-            sleep 20
-            xcrun simctl terminate "$UDID" com.miden.wallet 2>/dev/null || true
-            xcrun simctl uninstall "$UDID" com.miden.wallet 2>/dev/null || true
-          done
-          echo "Warmup complete."
-
       - name: Run blockchain E2E (mobile, devnet)
         # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26
         # runners. Each fixture retries install → launch → CDP connect from
@@ -357,28 +335,6 @@ jobs:
 
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
-
-      # Pays the cold-start cost (WebKit JIT, WASM compile, first install
-      # bundle validation) outside the 15-min per-test Playwright timeout.
-      # Without this, the first spec eats ~8 min of warmup overhead that
-      # subsequent specs don't see. Terminates + uninstalls afterwards so
-      # the fixture starts from the same clean state it always has.
-      - name: Warm up simulators
-        shell: bash
-        run: |
-          UDID_A=$(node -p "require('./test-results-ios/.device-pair.json').udidA")
-          UDID_B=$(node -p "require('./test-results-ios/.device-pair.json').udidB")
-          APP_PATH=ios/App/build/Build/Products/Debug-iphonesimulator/App.app
-          for UDID in "$UDID_A" "$UDID_B"; do
-            echo "--- Warming sim $UDID ---"
-            xcrun simctl boot "$UDID" 2>/dev/null || true
-            xcrun simctl install "$UDID" "$APP_PATH"
-            xcrun simctl launch "$UDID" com.miden.wallet || true
-            sleep 20
-            xcrun simctl terminate "$UDID" com.miden.wallet 2>/dev/null || true
-            xcrun simctl uninstall "$UDID" com.miden.wallet 2>/dev/null || true
-          done
-          echo "Warmup complete."
 
       - name: Run blockchain E2E (mobile, testnet)
         # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -181,17 +181,8 @@ jobs:
   # --- iOS Simulator --------------------------------------------------------
 
   mobile-devnet:
-    name: Mobile E2E (devnet shard ${{ matrix.shard }}/2)
+    name: Mobile E2E (devnet)
     if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
-    # Sharded across 2 runners in parallel. Playwright's --shard=N/M
-    # distributes tests alphabetically, so the split may be imperfect
-    # (send-private is the longest spec) — still a substantial wall-clock
-    # win over the single-runner ~45 min baseline. Aggregate job result is
-    # "success" only if BOTH shards pass, which is what the gate needs.
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
     # macos-26 matches build-mobile.yml — required for iOS 26 SDK symbols
     # used by dapp-browser's WKWebViewController.
     runs-on: macos-26
@@ -263,29 +254,25 @@ jobs:
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
 
-      - name: Run blockchain E2E (mobile, devnet, shard ${{ matrix.shard }}/2)
+      - name: Run blockchain E2E (mobile, devnet)
         # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26
         # runners. Each fixture retries install → launch → CDP connect from
         # scratch, so a transient webinspectord hiccup doesn't fail the run.
         # Config stays at retries: 0 for fast local dev feedback.
-        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2 --retries=1
+        run: yarn playwright test --config playwright.ios.config.ts --retries=1
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mobile-e2e-devnet-shard-${{ matrix.shard }}-${{ github.run_id }}
+          name: mobile-e2e-devnet-${{ github.run_id }}
           path: test-results-ios/
           retention-days: 7
           if-no-files-found: ignore
 
   mobile-testnet:
-    name: Mobile E2E (testnet shard ${{ matrix.shard }}/2)
+    name: Mobile E2E (testnet)
     if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
     runs-on: macos-26
     timeout-minutes: 90
     env:
@@ -349,18 +336,18 @@ jobs:
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
 
-      - name: Run blockchain E2E (mobile, testnet, shard ${{ matrix.shard }}/2)
+      - name: Run blockchain E2E (mobile, testnet)
         # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26
         # runners. Each fixture retries install → launch → CDP connect from
         # scratch, so a transient webinspectord hiccup doesn't fail the run.
         # Config stays at retries: 0 for fast local dev feedback.
-        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2 --retries=1
+        run: yarn playwright test --config playwright.ios.config.ts --retries=1
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mobile-e2e-testnet-shard-${{ matrix.shard }}-${{ github.run_id }}
+          name: mobile-e2e-testnet-${{ github.run_id }}
           path: test-results-ios/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -181,8 +181,17 @@ jobs:
   # --- iOS Simulator --------------------------------------------------------
 
   mobile-devnet:
-    name: Mobile E2E (devnet)
+    name: Mobile E2E (devnet shard ${{ matrix.shard }}/2)
     if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    # Sharded across 2 runners in parallel. Playwright's --shard=N/M
+    # distributes tests alphabetically, so the split may be imperfect
+    # (send-private is the longest spec) — still a substantial wall-clock
+    # win over the single-runner ~45 min baseline. Aggregate job result is
+    # "success" only if BOTH shards pass, which is what the gate needs.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     # macos-26 matches build-mobile.yml — required for iOS 26 SDK symbols
     # used by dapp-browser's WKWebViewController.
     runs-on: macos-26
@@ -251,21 +260,28 @@ jobs:
           printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
           echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
 
-      - name: Run blockchain E2E (mobile, devnet)
-        run: yarn test:e2e:mobile:devnet
+      - name: Build iOS app
+        run: yarn test:e2e:mobile:build
+
+      - name: Run blockchain E2E (mobile, devnet, shard ${{ matrix.shard }}/2)
+        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mobile-e2e-devnet-${{ github.run_id }}
+          name: mobile-e2e-devnet-shard-${{ matrix.shard }}-${{ github.run_id }}
           path: test-results-ios/
           retention-days: 7
           if-no-files-found: ignore
 
   mobile-testnet:
-    name: Mobile E2E (testnet)
+    name: Mobile E2E (testnet shard ${{ matrix.shard }}/2)
     if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     runs-on: macos-26
     timeout-minutes: 90
     env:
@@ -326,14 +342,17 @@ jobs:
           printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
           echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
 
-      - name: Run blockchain E2E (mobile, testnet)
-        run: yarn test:e2e:mobile:testnet
+      - name: Build iOS app
+        run: yarn test:e2e:mobile:build
+
+      - name: Run blockchain E2E (mobile, testnet, shard ${{ matrix.shard }}/2)
+        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mobile-e2e-testnet-${{ github.run_id }}
+          name: mobile-e2e-testnet-shard-${{ matrix.shard }}-${{ github.run_id }}
           path: test-results-ios/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -69,6 +69,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # Pre-install the miden-client-cli so the cold-cache ~7 min cargo
+      # compile happens in its own step, not inside Playwright's 5-min
+      # per-test timeout. `cargo install` is a no-op on warm cache.
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
+          cargo install miden-client-cli --version "$VERSION"
+
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
@@ -112,6 +122,13 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
+          cargo install miden-client-cli --version "$VERSION"
 
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
@@ -181,6 +198,19 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
+          cargo install miden-client-cli --version "$VERSION"
+
+      # CDP bridge (appium-remote-debugger) requires Simulator.app GUI to be
+      # running — headless simctl boots don't expose webinspectord. Ignore
+      # exit status because `open -a` returns 0 even if already open.
+      - name: Launch Simulator.app
+        run: open -a Simulator || true
+
       - name: Run blockchain E2E (mobile, devnet)
         run: yarn test:e2e:mobile:devnet
 
@@ -218,6 +248,16 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          echo "Installing miden-client-cli@${VERSION} (no-op if already cached)..."
+          cargo install miden-client-cli --version "$VERSION"
+
+      - name: Launch Simulator.app
+        run: open -a Simulator || true
 
       - name: Run blockchain E2E (mobile, testnet)
         run: yarn test:e2e:mobile:testnet

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -264,7 +264,11 @@ jobs:
         run: yarn test:e2e:mobile:build
 
       - name: Run blockchain E2E (mobile, devnet, shard ${{ matrix.shard }}/2)
-        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2
+        # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26
+        # runners. Each fixture retries install → launch → CDP connect from
+        # scratch, so a transient webinspectord hiccup doesn't fail the run.
+        # Config stays at retries: 0 for fast local dev feedback.
+        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2 --retries=1
 
       - name: Upload artifacts
         if: always()
@@ -346,7 +350,11 @@ jobs:
         run: yarn test:e2e:mobile:build
 
       - name: Run blockchain E2E (mobile, testnet, shard ${{ matrix.shard }}/2)
-        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2
+        # --retries=1 absorbs flaky CDP "no pages found" errors on macos-26
+        # runners. Each fixture retries install → launch → CDP connect from
+        # scratch, so a transient webinspectord hiccup doesn't fail the run.
+        # Config stays at retries: 0 for fast local dev feedback.
+        run: yarn playwright test --config playwright.ios.config.ts --shard=${{ matrix.shard }}/2 --retries=1
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -11,11 +11,6 @@ on:
   push:
     branches:
       - main
-  # TEMPORARY: enables PR iteration while wiring up this workflow.
-  # Remove the `pull_request:` block as the final commit before merging to main.
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       network:

--- a/playwright/e2e/ios/fixtures/two-simulators.ts
+++ b/playwright/e2e/ios/fixtures/two-simulators.ts
@@ -72,26 +72,52 @@ async function launchSimWalletInstance(
   timeline: TimelineRecorder,
   label: 'A' | 'B'
 ): Promise<SimWalletInstance> {
+  const phaseStart = (): number => Date.now();
+  const ms = (s: number): number => Date.now() - s;
+
+  const tTerminate = phaseStart();
   await sim.terminate(udid, BUNDLE_ID);
+  const terminateMs = ms(tTerminate);
+
+  const tUninstall = phaseStart();
   await sim.uninstall(udid, BUNDLE_ID);
+  const uninstallMs = ms(tUninstall);
+
+  const tInstall = phaseStart();
   await sim.install(udid, APP_PATH);
+  const installMs = ms(tInstall);
+
+  const tLaunch = phaseStart();
   await sim.launch(udid, BUNDLE_ID, {
     MIDEN_E2E_TEST: 'true',
     MIDEN_NETWORK: envConfig.name,
   });
+  const launchMs = ms(tLaunch);
 
+  const tSleep = phaseStart();
   // The WebView needs a couple seconds to register with webinspectord_sim.
   await sleep(3_000);
+  const sleepMs = ms(tSleep);
 
+  const tCdp = phaseStart();
   const cdp = await CdpBridge.connect({ udid, bundleId: BUNDLE_ID });
+  const cdpConnectMs = ms(tCdp);
+
   const walletPage = new IosWalletPage({ cdp, sim, udid, bundleId: BUNDLE_ID });
 
   timeline.emit({
     category: 'test_lifecycle',
     severity: 'info',
     wallet: label,
-    message: `Wallet ${label} launched on udid ${udid}`,
-    data: { udid, bundleId: BUNDLE_ID },
+    message:
+      `Wallet ${label} launched on udid ${udid} ` +
+      `(terminate=${terminateMs}ms uninstall=${uninstallMs}ms install=${installMs}ms ` +
+      `launch=${launchMs}ms sleep=${sleepMs}ms cdp=${cdpConnectMs}ms)`,
+    data: {
+      udid,
+      bundleId: BUNDLE_ID,
+      fixturePhases: { terminateMs, uninstallMs, installMs, launchMs, sleepMs, cdpConnectMs },
+    },
   });
 
   return { walletPage, cdp, udid, bundleId: BUNDLE_ID };
@@ -203,6 +229,21 @@ export const test = base.extend<TwoSimulatorFixtures>({
 
     await use(instance.walletPage);
 
+    const stats = instance.walletPage.getStats();
+    timeline.emit({
+      category: 'test_lifecycle',
+      severity: 'info',
+      wallet: 'A',
+      message:
+        `Wallet A stats: ` +
+        `eval=${stats.cdp.evalCount}×${Math.round(stats.cdp.evalMs)}ms ` +
+        `async=${stats.cdp.evalAsyncCount}×${Math.round(stats.cdp.evalAsyncMs)}ms ` +
+        `evaluate=${stats.cdp.evaluateCount}×${Math.round(stats.cdp.evaluateMs)}ms ` +
+        `polls=${stats.polls.pollCount} iters=${stats.polls.pollIterations} ` +
+        `pollWall=${Math.round(stats.polls.pollMs)}ms pollSleep=${stats.polls.pollSleepMs}ms`,
+      data: stats,
+    });
+
     try {
       await instance.cdp.close();
     } catch {
@@ -222,6 +263,21 @@ export const test = base.extend<TwoSimulatorFixtures>({
     steps.registerSnapshotCaps('B', buildIosSnapshotCaps(instance.walletPage, ''));
 
     await use(instance.walletPage);
+
+    const statsB = instance.walletPage.getStats();
+    timeline.emit({
+      category: 'test_lifecycle',
+      severity: 'info',
+      wallet: 'B',
+      message:
+        `Wallet B stats: ` +
+        `eval=${statsB.cdp.evalCount}×${Math.round(statsB.cdp.evalMs)}ms ` +
+        `async=${statsB.cdp.evalAsyncCount}×${Math.round(statsB.cdp.evalAsyncMs)}ms ` +
+        `evaluate=${statsB.cdp.evaluateCount}×${Math.round(statsB.cdp.evaluateMs)}ms ` +
+        `polls=${statsB.polls.pollCount} iters=${statsB.polls.pollIterations} ` +
+        `pollWall=${Math.round(statsB.polls.pollMs)}ms pollSleep=${statsB.polls.pollSleepMs}ms`,
+      data: statsB,
+    });
 
     if (testInfo.status !== 'passed' && testInfo.error) {
       try {

--- a/playwright/e2e/ios/fixtures/two-simulators.ts
+++ b/playwright/e2e/ios/fixtures/two-simulators.ts
@@ -265,19 +265,19 @@ export const test = base.extend<TwoSimulatorFixtures>({
     const simA = new SimulatorControl();
     const simB = new SimulatorControl();
 
-    // Setup both wallets in parallel — biggest fixture-time saving (A was
-    // ~400s + B was ~185s sequentially on the first test; in parallel the
-    // max dominates).
-    const [instanceA, instanceB] = await Promise.all([
-      launchSimWalletInstance(simA, udidA, envConfig, timeline, 'A'),
-      launchSimWalletInstance(simB, udidB, envConfig, timeline, 'B'),
-    ]);
+    // Sequential: parallel simctl install/launch across two sims can deadlock
+    // CoreSimulatorService on cold macos-26 runners (observed 14+ min silent
+    // hangs in CI). The shared `_simPair` fixture still consolidates teardown
+    // and lets the wipeAppState optimization amortize across tests.
+    const instanceA = await launchSimWalletInstance(simA, udidA, envConfig, timeline, 'A');
+    const instanceB = await launchSimWalletInstance(simB, udidB, envConfig, timeline, 'B');
     steps.registerSnapshotCaps('A', buildIosSnapshotCaps(instanceA.walletPage, ''));
     steps.registerSnapshotCaps('B', buildIosSnapshotCaps(instanceB.walletPage, ''));
 
     await use({ instanceA, instanceB, simA, simB });
 
-    // Parallel teardown too. allSettled so one failure doesn't starve the other.
+    // Parallel teardown is safe — close is a CDP socket close, terminate is
+    // just `simctl terminate` which doesn't contend.
     await Promise.allSettled([
       instanceA.cdp.close().catch(() => undefined),
       instanceB.cdp.close().catch(() => undefined),

--- a/playwright/e2e/ios/fixtures/two-simulators.ts
+++ b/playwright/e2e/ios/fixtures/two-simulators.ts
@@ -43,6 +43,18 @@ type TwoSimulatorFixtures = {
   timeline: TimelineRecorder;
   steps: TestStepRunner;
   envConfig: EnvironmentConfig;
+  /**
+   * Internal fixture that brings up BOTH simulators in parallel. Exposed as
+   * a dependency for `walletA` and `walletB` so Playwright only runs the
+   * expensive launchSimWalletInstance work once per test (in parallel) and
+   * tears both down together. Tests should never reference this directly.
+   */
+  _simPair: {
+    instanceA: SimWalletInstance;
+    instanceB: SimWalletInstance;
+    simA: SimulatorControl;
+    simB: SimulatorControl;
+  };
 };
 
 interface SimWalletInstance {
@@ -65,6 +77,13 @@ function getRunOutputDir(testId: string): string {
  * install wipes the IndexedDB / Preferences sandbox without touching boot
  * state (~5s instead of the ~30s `simctl erase` would cost).
  */
+// Tracks which UDIDs have already had the app installed in this worker.
+// First-test fixture does a full install+launch; subsequent tests wipe the
+// sandbox instead — same per-test isolation guarantees (fresh IndexedDB,
+// localStorage, Preferences, WebKit caches) without paying ~5–15s for
+// simctl uninstall + install.
+const installedUdids = new Set<string>();
+
 async function launchSimWalletInstance(
   sim: SimulatorControl,
   udid: string,
@@ -79,13 +98,24 @@ async function launchSimWalletInstance(
   await sim.terminate(udid, BUNDLE_ID);
   const terminateMs = ms(tTerminate);
 
-  const tUninstall = phaseStart();
-  await sim.uninstall(udid, BUNDLE_ID);
-  const uninstallMs = ms(tUninstall);
+  const firstInstall = !installedUdids.has(udid);
+  let uninstallMs = 0;
+  let installMs = 0;
+  let wipeMs = 0;
+  if (firstInstall) {
+    const tUninstall = phaseStart();
+    await sim.uninstall(udid, BUNDLE_ID);
+    uninstallMs = ms(tUninstall);
 
-  const tInstall = phaseStart();
-  await sim.install(udid, APP_PATH);
-  const installMs = ms(tInstall);
+    const tInstall = phaseStart();
+    await sim.install(udid, APP_PATH);
+    installMs = ms(tInstall);
+    installedUdids.add(udid);
+  } else {
+    const tWipe = phaseStart();
+    await sim.wipeAppState(udid, BUNDLE_ID);
+    wipeMs = ms(tWipe);
+  }
 
   const tLaunch = phaseStart();
   await sim.launch(udid, BUNDLE_ID, {
@@ -111,12 +141,21 @@ async function launchSimWalletInstance(
     wallet: label,
     message:
       `Wallet ${label} launched on udid ${udid} ` +
-      `(terminate=${terminateMs}ms uninstall=${uninstallMs}ms install=${installMs}ms ` +
+      `(terminate=${terminateMs}ms ${firstInstall ? `uninstall=${uninstallMs}ms install=${installMs}ms` : `wipe=${wipeMs}ms`} ` +
       `launch=${launchMs}ms sleep=${sleepMs}ms cdp=${cdpConnectMs}ms)`,
     data: {
       udid,
       bundleId: BUNDLE_ID,
-      fixturePhases: { terminateMs, uninstallMs, installMs, launchMs, sleepMs, cdpConnectMs },
+      fixturePhases: {
+        terminateMs,
+        uninstallMs,
+        installMs,
+        wipeMs,
+        launchMs,
+        sleepMs,
+        cdpConnectMs,
+        firstInstall,
+      },
     },
   });
 
@@ -221,12 +260,36 @@ export const test = base.extend<TwoSimulatorFixtures>({
     await cli.cleanup();
   },
 
-  walletA: async ({ envConfig, timeline, steps }, use) => {
-    const { udidA } = await devicePair();
-    const sim = new SimulatorControl();
-    const instance = await launchSimWalletInstance(sim, udidA, envConfig, timeline, 'A');
-    steps.registerSnapshotCaps('A', buildIosSnapshotCaps(instance.walletPage, ''));
+  _simPair: async ({ envConfig, timeline, steps }, use) => {
+    const { udidA, udidB } = await devicePair();
+    const simA = new SimulatorControl();
+    const simB = new SimulatorControl();
 
+    // Setup both wallets in parallel — biggest fixture-time saving (A was
+    // ~400s + B was ~185s sequentially on the first test; in parallel the
+    // max dominates).
+    const [instanceA, instanceB] = await Promise.all([
+      launchSimWalletInstance(simA, udidA, envConfig, timeline, 'A'),
+      launchSimWalletInstance(simB, udidB, envConfig, timeline, 'B'),
+    ]);
+    steps.registerSnapshotCaps('A', buildIosSnapshotCaps(instanceA.walletPage, ''));
+    steps.registerSnapshotCaps('B', buildIosSnapshotCaps(instanceB.walletPage, ''));
+
+    await use({ instanceA, instanceB, simA, simB });
+
+    // Parallel teardown too. allSettled so one failure doesn't starve the other.
+    await Promise.allSettled([
+      instanceA.cdp.close().catch(() => undefined),
+      instanceB.cdp.close().catch(() => undefined),
+    ]);
+    await Promise.allSettled([
+      simA.terminate(udidA, BUNDLE_ID).catch(() => undefined),
+      simB.terminate(udidB, BUNDLE_ID).catch(() => undefined),
+    ]);
+  },
+
+  walletA: async ({ _simPair, timeline }, use) => {
+    const instance = _simPair.instanceA;
     await use(instance.walletPage);
 
     const stats = instance.walletPage.getStats();
@@ -243,25 +306,10 @@ export const test = base.extend<TwoSimulatorFixtures>({
         `pollWall=${Math.round(stats.polls.pollMs)}ms pollSleep=${stats.polls.pollSleepMs}ms`,
       data: stats,
     });
-
-    try {
-      await instance.cdp.close();
-    } catch {
-      // ignore
-    }
-    try {
-      await sim.terminate(udidA, BUNDLE_ID);
-    } catch {
-      // ignore
-    }
   },
 
-  walletB: async ({ envConfig, timeline, steps, walletA: _walletA, midenCli: _midenCli }, use, testInfo) => {
-    const { udidB } = await devicePair();
-    const sim = new SimulatorControl();
-    const instance = await launchSimWalletInstance(sim, udidB, envConfig, timeline, 'B');
-    steps.registerSnapshotCaps('B', buildIosSnapshotCaps(instance.walletPage, ''));
-
+  walletB: async ({ _simPair, timeline, steps, midenCli: _midenCli }, use, testInfo) => {
+    const instance = _simPair.instanceB;
     await use(instance.walletPage);
 
     const statsB = instance.walletPage.getStats();
@@ -313,17 +361,6 @@ export const test = base.extend<TwoSimulatorFixtures>({
       } catch {
         // Don't let report generation fail the test teardown
       }
-    }
-
-    try {
-      await instance.cdp.close();
-    } catch {
-      // ignore
-    }
-    try {
-      await sim.terminate(udidB, BUNDLE_ID);
-    } catch {
-      // ignore
     }
   },
 });

--- a/playwright/e2e/ios/helpers/cdp-bridge.ts
+++ b/playwright/e2e/ios/helpers/cdp-bridge.ts
@@ -33,10 +33,32 @@ export interface CdpConsoleEntry {
  * RemoteDebugger so the rest of the harness only sees a CDP-like surface
  * (eval, evaluate, console).
  */
+export interface CdpStats {
+  evalCount: number;
+  evalMs: number;
+  evalAsyncCount: number;
+  evalAsyncMs: number;
+  evaluateCount: number;
+  evaluateMs: number;
+}
+
 export class CdpSession {
   private consoleListeners: Array<(entry: CdpConsoleEntry) => void> = [];
+  private stats: CdpStats = {
+    evalCount: 0,
+    evalMs: 0,
+    evalAsyncCount: 0,
+    evalAsyncMs: 0,
+    evaluateCount: 0,
+    evaluateMs: 0,
+  };
 
   constructor(private rd: RemoteDebugger) {}
+
+  /** Read the current call stats snapshot. */
+  getStats(): CdpStats {
+    return { ...this.stats };
+  }
 
   /**
    * Evaluate synchronous JavaScript and return the result. The body is the
@@ -48,10 +70,16 @@ export class CdpSession {
    * Promise object itself, not its value.
    */
   async eval<T = unknown>(body: string): Promise<T> {
-    return (await (this.rd as unknown as ExecuteAtomCapable).executeAtom('execute_script', [
-      body,
-      [],
-    ])) as T;
+    const start = Date.now();
+    try {
+      return (await (this.rd as unknown as ExecuteAtomCapable).executeAtom('execute_script', [
+        body,
+        [],
+      ])) as T;
+    } finally {
+      this.stats.evalCount++;
+      this.stats.evalMs += Date.now() - start;
+    }
   }
 
   /**
@@ -76,10 +104,13 @@ export class CdpSession {
         timeoutMs
       );
     });
+    const start = Date.now();
     try {
       return (await Promise.race([exec, timeout])) as T;
     } finally {
       if (timer) clearTimeout(timer);
+      this.stats.evalAsyncCount++;
+      this.stats.evalAsyncMs += Date.now() - start;
     }
   }
 
@@ -94,10 +125,16 @@ export class CdpSession {
    */
   async evaluate<T = unknown>(fn: () => T | Promise<T>): Promise<T> {
     const body = `return (${fn.toString()})();`;
-    return (await (this.rd as unknown as ExecuteAtomCapable).executeAtom('execute_script', [
-      body,
-      [],
-    ])) as T;
+    const start = Date.now();
+    try {
+      return (await (this.rd as unknown as ExecuteAtomCapable).executeAtom('execute_script', [
+        body,
+        [],
+      ])) as T;
+    } finally {
+      this.stats.evaluateCount++;
+      this.stats.evaluateMs += Date.now() - start;
+    }
   }
 
   /**

--- a/playwright/e2e/ios/helpers/ios-wallet-page.ts
+++ b/playwright/e2e/ios/helpers/ios-wallet-page.ts
@@ -26,17 +26,30 @@ interface IosWalletPageOpts {
  *   - `evaluate` and `screenshot` mirror Playwright's Page shape so the same
  *     `ScreenshotCapable` / `StateCaptureCapable` typing accepts both.
  */
+export interface PollStats {
+  pollCount: number;
+  pollIterations: number;
+  pollMs: number;
+  pollSleepMs: number;
+}
+
 export class IosWalletPage implements WalletPage {
   readonly udid: string;
   readonly bundleId: string;
   private cdp: CdpSession;
   private sim: SimulatorControl;
+  private pollStats: PollStats = { pollCount: 0, pollIterations: 0, pollMs: 0, pollSleepMs: 0 };
 
   constructor(opts: IosWalletPageOpts) {
     this.cdp = opts.cdp;
     this.sim = opts.sim;
     this.udid = opts.udid;
     this.bundleId = opts.bundleId;
+  }
+
+  /** Read poll stats snapshot. Includes CdpSession totals too. */
+  getStats(): { polls: PollStats; cdp: ReturnType<CdpSession['getStats']> } {
+    return { polls: { ...this.pollStats }, cdp: this.cdp.getStats() };
   }
 
   // ── Capability surfaces (matches Playwright Page shape) ─────────────────
@@ -459,26 +472,48 @@ export class IosWalletPage implements WalletPage {
   // ── Internals (DOM helpers wired through CDP) ───────────────────────────
 
   private async pollForSelector(selector: string, timeoutMs: number): Promise<void> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      // Catch eval errors (page reload mid-poll, inspector reattach race).
-      const found = await this.cdp
-        .eval<boolean>(`return !!document.querySelector(${JSON.stringify(selector)});`)
-        .catch(() => false);
-      if (found) return;
-      await sleep(POLL_INTERVAL_MS);
+    const wallStart = Date.now();
+    let iterations = 0;
+    let totalSleepMs = 0;
+    try {
+      while (Date.now() - wallStart < timeoutMs) {
+        iterations++;
+        // Catch eval errors (page reload mid-poll, inspector reattach race).
+        const found = await this.cdp
+          .eval<boolean>(`return !!document.querySelector(${JSON.stringify(selector)});`)
+          .catch(() => false);
+        if (found) return;
+        await sleep(POLL_INTERVAL_MS);
+        totalSleepMs += POLL_INTERVAL_MS;
+      }
+      throw new Error(`pollForSelector: ${selector} did not appear within ${timeoutMs}ms`);
+    } finally {
+      this.pollStats.pollCount++;
+      this.pollStats.pollIterations += iterations;
+      this.pollStats.pollMs += Date.now() - wallStart;
+      this.pollStats.pollSleepMs += totalSleepMs;
     }
-    throw new Error(`pollForSelector: ${selector} did not appear within ${timeoutMs}ms`);
   }
 
   private async pollForCondition(jsBody: string, timeoutMs: number): Promise<void> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      const ok = await this.cdp.eval<boolean>(jsBody).catch(() => false);
-      if (ok) return;
-      await sleep(POLL_INTERVAL_MS);
+    const wallStart = Date.now();
+    let iterations = 0;
+    let totalSleepMs = 0;
+    try {
+      while (Date.now() - wallStart < timeoutMs) {
+        iterations++;
+        const ok = await this.cdp.eval<boolean>(jsBody).catch(() => false);
+        if (ok) return;
+        await sleep(POLL_INTERVAL_MS);
+        totalSleepMs += POLL_INTERVAL_MS;
+      }
+      throw new Error(`pollForCondition: condition not met within ${timeoutMs}ms — ${jsBody.slice(0, 80)}`);
+    } finally {
+      this.pollStats.pollCount++;
+      this.pollStats.pollIterations += iterations;
+      this.pollStats.pollMs += Date.now() - wallStart;
+      this.pollStats.pollSleepMs += totalSleepMs;
     }
-    throw new Error(`pollForCondition: condition not met within ${timeoutMs}ms — ${jsBody.slice(0, 80)}`);
   }
 
   private async clickByText(tag: string, pattern: RegExp): Promise<void> {

--- a/playwright/e2e/ios/helpers/simulator-control.ts
+++ b/playwright/e2e/ios/helpers/simulator-control.ts
@@ -125,6 +125,41 @@ export class SimulatorControl {
     await execSimctl(['uninstall', udid, bundleId]);
   }
 
+  /**
+   * Wipe the app's data sandbox (IndexedDB, localStorage, Preferences,
+   * WebKit caches) without reinstalling the binary. ~5–10× faster than
+   * uninstall + install on warm sims. Caller MUST terminate the app first
+   * — wiping a running app leaves partial state.
+   */
+  async wipeAppState(udid: string, bundleId: string): Promise<void> {
+    let dataContainer: string;
+    try {
+      const { stdout } = await execFileAsync('xcrun', [
+        'simctl',
+        'get_app_container',
+        udid,
+        bundleId,
+        'data',
+      ]);
+      dataContainer = stdout.trim();
+    } catch {
+      // App isn't installed — nothing to wipe.
+      return;
+    }
+    if (!dataContainer || !fs.existsSync(dataContainer)) return;
+
+    for (const sub of ['Library', 'Documents', 'tmp']) {
+      const p = path.join(dataContainer, sub);
+      if (fs.existsSync(p)) {
+        try {
+          fs.rmSync(p, { recursive: true, force: true });
+        } catch {
+          // best-effort; partial wipe is still better than a 10s reinstall
+        }
+      }
+    }
+  }
+
   async launch(udid: string, bundleId: string, env: Record<string, string> = {}): Promise<void> {
     // env vars are passed via SIMCTL_CHILD_<NAME> in the parent environment
     const childEnv: NodeJS.ProcessEnv = { ...process.env };

--- a/playwright/e2e/ios/helpers/simulator-control.ts
+++ b/playwright/e2e/ios/helpers/simulator-control.ts
@@ -15,6 +15,7 @@ const DEVICE_TYPE_B = 'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro';
 
 const BOOT_TIMEOUT_MS = 60_000;
 const BOOT_POLL_MS = 1_000;
+const BOOTSTATUS_TIMEOUT_MS = 180_000;
 
 interface DevicePair {
   udidA: string;
@@ -69,24 +70,34 @@ export class SimulatorControl {
    * occasionally races with itself if multiple boots are issued quickly).
    */
   async ensureBooted(udid: string): Promise<void> {
-    if (await this.isBooted(udid)) return;
-
-    try {
-      await execSimctl(['boot', udid]);
-    } catch (err) {
-      if (!isAlreadyBootedError(err)) {
-        // Wait briefly and retry once
-        await sleep(2_000);
+    if (!(await this.isBooted(udid))) {
+      try {
         await execSimctl(['boot', udid]);
+      } catch (err) {
+        if (!isAlreadyBootedError(err)) {
+          // Wait briefly and retry once
+          await sleep(2_000);
+          await execSimctl(['boot', udid]);
+        }
+      }
+
+      const start = Date.now();
+      while (Date.now() - start < BOOT_TIMEOUT_MS) {
+        if (await this.isBooted(udid)) break;
+        await sleep(BOOT_POLL_MS);
+      }
+      if (!(await this.isBooted(udid))) {
+        throw new Error(`Simulator ${udid} did not reach Booted state within ${BOOT_TIMEOUT_MS}ms`);
       }
     }
 
-    const start = Date.now();
-    while (Date.now() - start < BOOT_TIMEOUT_MS) {
-      if (await this.isBooted(udid)) return;
-      await sleep(BOOT_POLL_MS);
-    }
-    throw new Error(`Simulator ${udid} did not reach Booted state within ${BOOT_TIMEOUT_MS}ms`);
+    // `Booted` from simctl does NOT mean SpringBoard is ready. `simctl launch`
+    // hangs on fresh boots if we skip this — CI runs with cold simulators
+    // observed multi-minute hangs inside simctl launch. bootstatus -b blocks
+    // until the device is actually usable.
+    await execFileAsync('xcrun', ['simctl', 'bootstatus', udid, '-b'], {
+      timeout: BOOTSTATUS_TIMEOUT_MS,
+    });
   }
 
   async install(udid: string, appPath: string): Promise<void> {

--- a/playwright/e2e/ios/helpers/simulator-control.ts
+++ b/playwright/e2e/ios/helpers/simulator-control.ts
@@ -95,9 +95,22 @@ export class SimulatorControl {
     // hangs on fresh boots if we skip this — CI runs with cold simulators
     // observed multi-minute hangs inside simctl launch. bootstatus -b blocks
     // until the device is actually usable.
-    await execFileAsync('xcrun', ['simctl', 'bootstatus', udid, '-b'], {
-      timeout: BOOTSTATUS_TIMEOUT_MS,
-    });
+    //
+    // Best-effort: on some macos-26 CI runner images, bootstatus itself
+    // fails/hangs even when the sim is otherwise usable. Swallow the error
+    // and let the subsequent install/launch reveal whether the sim is
+    // really broken — a genuine sim failure produces a clearer error there.
+    try {
+      await execFileAsync('xcrun', ['simctl', 'bootstatus', udid, '-b'], {
+        timeout: BOOTSTATUS_TIMEOUT_MS,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[SimulatorControl] bootstatus for ${udid} did not complete cleanly; ` +
+          `continuing. Error: ${(err as Error).message}`
+      );
+    }
   }
 
   async install(udid: string, appPath: string): Promise<void> {


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/e2e-blockchain.yml` runs the blockchain-backed E2E suites on every push to main.
- Matrix: `chrome-{devnet,testnet}` on ubuntu-latest, `mobile-{devnet,testnet}` on macos-26 — six jobs total including two gates.
- Per-platform gate (`chrome-gate`, `mobile-gate`) passes if **at least one** of devnet/testnet succeeded — tolerates short windows where wallet@main and a single network are protocol-mismatched.
- `miden-client-cli` is cached at `~/.cargo/bin/miden-client`, keyed on the root `package.json` hash so a SDK version bump naturally invalidates.
- Runs independently of `production-branch.yml` → `cd.yml`, so a network-version mismatch never blocks the Chrome extension deploy.

## Temporary trigger
The `pull_request:` trigger is in place so this PR can iterate. **Strip it as the final commit before merging to main.**

## Test plan
- [ ] `chrome-devnet` completes (or fails with a real diagnosis, not YAML/infra)
- [ ] `chrome-testnet` completes
- [ ] `mobile-devnet` completes
- [ ] `mobile-testnet` completes
- [ ] `chrome-gate` passes (≥1 chrome network green)
- [ ] `mobile-gate` passes (≥1 mobile network green)
- [ ] `workflow_dispatch` with `network=devnet` runs only the two devnet jobs + gates
- [ ] Remove `pull_request:` trigger before merge
- [ ] After merge, add `Chrome E2E Gate` and `Mobile E2E Gate` as required checks on `main` branch protection