### PR TITLE
fix(stress): unblock wallet UI under sustained send load

### DIFF
--- a/src/lib/miden/back/sync-manager.test.ts
+++ b/src/lib/miden/back/sync-manager.test.ts
@@ -436,3 +436,90 @@ describe('doSync — note metadata branches', () => {
     delete (globalThis as any).registration;
   });
 });
+
+// The circuit-breaker state (`consecutiveSyncFailures`, `syncBackoffUntilMs`)
+// is module-level. Each test isolates the module so the counter starts at 0
+// and the backoff window is closed at the start of every case.
+describe('doSync — syncState timeout + circuit breaker', () => {
+  it('increments the failure counter when syncState rejects and trips the breaker after consecutive failures', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      mockClient.syncState.mockReset();
+      mockClient.syncState.mockRejectedValue(new Error('persistent rpc failure'));
+
+      const { doSync: isolated } = await import('./sync-manager');
+
+      // 3 back-to-back failures should trip the breaker on the 3rd.
+      await isolated();
+      await isolated();
+      await isolated();
+      expect(mockClient.syncState).toHaveBeenCalledTimes(3);
+
+      // Breaker is now open — subsequent doSync should short-circuit without
+      // calling syncState.
+      await isolated();
+      await isolated();
+      expect(mockClient.syncState).toHaveBeenCalledTimes(3);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('circuit breaker open — skipping syncs'));
+      warnSpy.mockRestore();
+    });
+  });
+
+  it('a successful syncState resets the failure counter mid-streak', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+      mockClient.syncState.mockReset();
+
+      const { doSync: isolated } = await import('./sync-manager');
+
+      // Two failures + one success → counter back to 0.
+      mockClient.syncState.mockRejectedValueOnce(new Error('blip 1'));
+      await isolated();
+      mockClient.syncState.mockRejectedValueOnce(new Error('blip 2'));
+      await isolated();
+      mockClient.syncState.mockResolvedValueOnce(undefined);
+      await isolated();
+
+      // A single subsequent failure must NOT trip the breaker (previously it
+      // would have been the 3rd consecutive failure before the reset).
+      mockClient.syncState.mockRejectedValueOnce(new Error('blip 3'));
+      await isolated();
+
+      // All four calls reached syncState; breaker never opened.
+      expect(mockClient.syncState).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  it('the breaker closes after the backoff window elapses', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+      mockClient.syncState.mockReset();
+      mockClient.syncState.mockRejectedValue(new Error('rpc offline'));
+
+      let fakeNow = 1_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+
+      const { doSync: isolated } = await import('./sync-manager');
+
+      // Trip the breaker.
+      await isolated();
+      await isolated();
+      await isolated();
+      expect(mockClient.syncState).toHaveBeenCalledTimes(3);
+
+      // Inside backoff window — skipped.
+      await isolated();
+      expect(mockClient.syncState).toHaveBeenCalledTimes(3);
+
+      // Advance past the 30s backoff. Next doSync should probe syncState again.
+      fakeNow += 35_000;
+      mockClient.syncState.mockReset();
+      mockClient.syncState.mockResolvedValueOnce(undefined);
+      await isolated();
+      expect(mockClient.syncState).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockRestore();
+    });
+  });
+});

--- a/src/lib/miden/back/sync-manager.ts
+++ b/src/lib/miden/back/sync-manager.ts
@@ -12,15 +12,41 @@ import { getBech32AddressFromAccountId } from '../sdk/helpers';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 
 const ALARM_NAME = 'miden-sync';
-const SYNC_TIMEOUT_MS = 25_000;
+
+// syncState is capped aggressively. On testnet with slow RPC a single
+// syncState can legitimately take 5-25s; the previous 25s ceiling plus the
+// wasm-client mutex meant fetchBalances (triggered by the SelectToken TST
+// tile) could queue behind a sync long enough to exceed Playwright's 10s
+// click budget and cause UI timeouts under stress. 5s keeps the sync path
+// well below any UI click budget; if testnet RPC is genuinely slow, the
+// circuit breaker (below) trips and we back off rather than hammering.
+const SYNC_TIMEOUT_MS = 5_000;
+
+// Circuit breaker: after MAX_CONSECUTIVE_SYNC_FAILURES timeouts/errors in
+// a row we skip sync attempts for BACKOFF_MS, then allow one probe. A
+// successful sync resets the counter. Protects both the wasm client and the
+// RPC backend from being hammered when the network (or the node) is flapping.
+const MAX_CONSECUTIVE_SYNC_FAILURES = 3;
+const BACKOFF_MS = 30_000;
 
 // Concurrent doSync() callers join the in-flight sync instead of being dropped.
 // The previous boolean-guard silently no-op'd concurrent calls, so a single stuck
 // sync made every triggerSync() during that window return without having synced.
 let inFlight: Promise<void> | null = null;
 
+// Circuit-breaker state. Module-level is fine — the SW process is the only
+// doSync caller in the extension path; mobile/desktop runs have one sync loop.
+let consecutiveSyncFailures = 0;
+let syncBackoffUntilMs = 0;
+
 export function doSync(): Promise<void> {
   if (inFlight) return inFlight;
+  // Circuit-breaker: short-circuit if recent syncs failed and we're waiting out
+  // the backoff window. Returning resolved-void here keeps the existing contract
+  // for callers (triggerSync, alarm) that don't distinguish success from skip.
+  if (Date.now() < syncBackoffUntilMs) {
+    return Promise.resolve();
+  }
   inFlight = runSync().finally(() => {
     inFlight = null;
   });
@@ -33,15 +59,34 @@ async function runSync(): Promise<void> {
     const exists = await Vault.isExist();
     if (!exists) return;
 
-    // [Lock 1] THE sync for the whole app
-    await withTimeout(
-      withWasmClientLock(async () => {
-        const client = await getMidenClient();
-        if (!client) return;
-        await client.syncState();
-      }),
-      SYNC_TIMEOUT_MS
-    );
+    // [Lock 1] THE sync for the whole app. Bounded by SYNC_TIMEOUT_MS so it
+    // can't stall downstream consumers; a breach bumps the circuit-breaker
+    // counter and we continue (downstream read paths should still run so the
+    // UI gets whatever state is locally cached).
+    try {
+      await withTimeout(
+        withWasmClientLock(async () => {
+          const client = await getMidenClient();
+          if (!client) return;
+          await client.syncState();
+        }),
+        SYNC_TIMEOUT_MS
+      );
+      consecutiveSyncFailures = 0;
+    } catch (err) {
+      consecutiveSyncFailures++;
+      console.warn(
+        `[SyncManager] syncState failed (${consecutiveSyncFailures}/${MAX_CONSECUTIVE_SYNC_FAILURES}):`,
+        err
+      );
+      if (consecutiveSyncFailures >= MAX_CONSECUTIVE_SYNC_FAILURES) {
+        syncBackoffUntilMs = Date.now() + BACKOFF_MS;
+        consecutiveSyncFailures = 0;
+        console.warn(`[SyncManager] circuit breaker open — skipping syncs for ${BACKOFF_MS}ms`);
+      }
+      // Continue to the downstream read path: the client may still have
+      // cached state from a prior successful sync worth surfacing.
+    }
 
     const intercom = getIntercom()!;
     const accountPubKey = await Vault.getCurrentAccountPublicKey();

--- a/src/lib/miden/front/useSyncTrigger.ts
+++ b/src/lib/miden/front/useSyncTrigger.ts
@@ -8,6 +8,30 @@ import { getIntercom, useWalletStore } from 'lib/store';
 const SYNC_INTERVAL_MS = 3_000;
 
 /**
+ * Returns true when the wallet is inside the Send flow (any step of
+ * SendManager — SelectToken, SelectRecipient, SelectAmount, Review, etc.).
+ *
+ * Woozie routes the extension under a hash URL (`USE_LOCATION_HASH_AS_URL`),
+ * so the Send root is reachable at `#/send`. All internal SendManager steps
+ * live under that same hash prefix.
+ *
+ * We pause `syncState` polling while the user is in the Send flow because:
+ *   - `SelectToken` renders its TST tile from `useAllBalances → fetchBalances
+ *     → getAccount` — an IndexedDB read serialized by the SDK. When sync is
+ *     holding the SDK's internal queue on a slow testnet (5-25s per tick),
+ *     the balance read waits and Playwright's 10s click budget on the tile
+ *     times out.
+ *   - The Send flow doesn't need fresh chain state to let the user pick a
+ *     token / recipient / amount. The sync that matters for Send happens
+ *     after submit, not during selection.
+ */
+function isInsideSendFlow(): boolean {
+  if (typeof window === 'undefined') return false;
+  // Hash can be `#/send`, `#/send/`, `#/send?...`, etc.
+  return window.location.hash.startsWith('#/send');
+}
+
+/**
  * Periodic sync every 3s while the wallet is Ready.
  *
  * - Extension: sends SyncRequest to the service worker, which runs syncState()
@@ -16,6 +40,8 @@ const SYNC_INTERVAL_MS = 3_000;
  *   wasm client lock), mirroring the old AutoSync behaviour that was removed
  *   when the zustand balance/sync state was handed off to the React SDK.
  *   Without this, nothing polls on mobile and the UI never sees new notes.
+ *
+ * Sync is paused for the duration of the Send flow (see `isInsideSendFlow`).
  */
 export function useSyncTrigger() {
   const status = useWalletStore(s => s.status);
@@ -26,6 +52,7 @@ export function useSyncTrigger() {
     if (isExtension()) {
       const intercom = getIntercom();
       const tick = () => {
+        if (isInsideSendFlow()) return;
         intercom.request({ type: WalletMessageType.SyncRequest }).catch(() => {});
       };
       tick();
@@ -46,8 +73,9 @@ export function useSyncTrigger() {
       const onGeneratingTxPage =
         typeof window !== 'undefined' && window.location.href.includes('generating-transaction');
       const mobileTxModalOpen = isMobile() && storeState.isTransactionModalOpen;
+      const inSendFlow = isInsideSendFlow();
 
-      if (!onGeneratingTxPage && !mobileTxModalOpen) {
+      if (!onGeneratingTxPage && !mobileTxModalOpen && !inSendFlow) {
         useWalletStore.getState().setSyncStatus(true);
         try {
           await withWasmClientLock(async () => {

--- a/src/lib/store/utils/fetchBalances.test.ts
+++ b/src/lib/store/utils/fetchBalances.test.ts
@@ -72,6 +72,19 @@ describe('fetchBalances', () => {
     });
   });
 
+  it('returns empty list when account not found AND native-asset discovery has not resolved', async () => {
+    // Pre-discovery state: getFaucetIdSetting returns '' / undefined, so we
+    // can't fabricate a "0 MIDEN" row and must return [] so the UI renders a
+    // skeleton instead of a misattributed token.
+    const { getFaucetIdSetting } = jest.requireMock('lib/miden/assets');
+    getFaucetIdSetting.mockReturnValueOnce(undefined);
+    mockGetAccount.mockResolvedValueOnce(null);
+
+    const result = await fetchBalances('unknown-address', {});
+
+    expect(result).toEqual([]);
+  });
+
   it('returns balances for account with assets', async () => {
     // Mock so bech32 conversion always returns the miden faucet id for this test
     // (called multiple times: filter check + map in balance building)

--- a/src/lib/store/utils/fetchBalances.ts
+++ b/src/lib/store/utils/fetchBalances.ts
@@ -6,7 +6,7 @@ import { fetchFromStorage } from 'lib/miden/front';
 import { TokenBalanceData } from 'lib/miden/front/balance';
 import { AssetMetadata, DEFAULT_TOKEN_METADATA, fetchTokenMetadata, MIDEN_METADATA } from 'lib/miden/metadata';
 import { getBech32AddressFromAccountId } from 'lib/miden/sdk/helpers';
-import { getMidenClient, withWasmClientLock } from 'lib/miden/sdk/miden-client';
+import { getMidenClient } from 'lib/miden/sdk/miden-client';
 import { getTokenPrice, type TokenPrices } from 'lib/prices';
 
 import { ALL_TOKENS_BASE_METADATA_STORAGE_KEY, setTokensBaseMetadata } from '../../miden/front/assets';
@@ -24,8 +24,14 @@ export interface FetchBalancesOptions {
  * This is the single source of truth for balance fetching logic.
  * Used by both the useAllBalances hook and the Zustand store action.
  *
- * The WASM lock is held only for getAccount (IndexedDB read).
- * Metadata fetching uses RpcClient directly and does not need the WASM lock.
+ * `getAccount` is an IndexedDB read on the SDK side; the SDK's internal
+ * `_serializeWasmCall` chain already queues it against concurrent WASM ops,
+ * so we deliberately do NOT wrap it in the wallet-side `withWasmClientLock`.
+ * Stacking our mutex on top of the SDK's queue was causing the Send-flow
+ * SelectToken tile to stall behind a long-running `syncState` on testnet,
+ * blowing past Playwright's 10s click budget and producing `locator.click`
+ * timeouts under stress. Metadata fetching uses RpcClient directly and
+ * doesn't need serialization either.
  */
 export async function fetchBalances(
   address: string,
@@ -43,17 +49,13 @@ export async function fetchBalances(
   // Get midenFaucetId early so we can use it inside the lock
   const midenFaucetId = await getFaucetIdSetting();
 
-  // Only hold the WASM lock for the getAccount call (IndexedDB read)
-  const { account, assets } = await withWasmClientLock(async () => {
-    const midenClient = await getMidenClient();
-    const acc = await midenClient.getAccount(address);
-
-    if (!acc) {
-      return { account: null, assets: [] as FungibleAsset[] };
-    }
-
-    return { account: acc, assets: acc.vault().fungibleAssets() as FungibleAsset[] };
-  });
+  // `getAccount` is serialized internally by the SDK (`_serializeWasmCall`).
+  // We intentionally skip `withWasmClientLock` here so balance reads aren't
+  // queued behind long-running writes like `syncState`.
+  const midenClient = await getMidenClient();
+  const acc = await midenClient.getAccount(address);
+  const account = acc ?? null;
+  const assets: FungibleAsset[] = acc ? (acc.vault().fungibleAssets() as FungibleAsset[]) : [];
 
   // Fetch missing metadata OUTSIDE the lock — RpcClient doesn't use the WASM client
   const fetchedMetadatas: Record<string, AssetMetadata> = { ...cachedMetadatas };

--- a/src/lib/store/utils/fetchBalances.ts
+++ b/src/lib/store/utils/fetchBalances.ts
@@ -54,8 +54,12 @@ export async function fetchBalances(
   // queued behind long-running writes like `syncState`.
   const midenClient = await getMidenClient();
   const acc = await midenClient.getAccount(address);
-  const account = acc ?? null;
-  const assets: FungibleAsset[] = acc ? (acc.vault().fungibleAssets() as FungibleAsset[]) : [];
+  let account: typeof acc | null = null;
+  let assets: FungibleAsset[] = [];
+  if (acc) {
+    account = acc;
+    assets = acc.vault().fungibleAssets() as FungibleAsset[];
+  }
 
   // Fetch missing metadata OUTSIDE the lock — RpcClient doesn't use the WASM client
   const fetchedMetadatas: Record<string, AssetMetadata> = { ...cachedMetadatas };


### PR DESCRIPTION
## Summary

Three wallet-side fixes for the ~86% \`locator.click\` timeout rate observed in long stress runs (1000-op, full default perturbations, testnet). Root cause is that the Send-flow \`SelectToken\` tile renders from \`useAllBalances → fetchBalances → getAccount\`, and that balance read was queued behind \`syncState\` via the wallet-side \`withWasmClientLock\` mutex. On slow testnet RPC (\`176 net::ERR_ABORTED\` + \`28 missing content-type\` gRPC errors observed), \`syncState\` can hold the mutex for 5-25s — longer than Playwright's 10s click budget on the tile.

The SDK (\`@miden-sdk/miden-sdk@0.14.4\`) already serializes every async WebClient method internally via \`_serializeWasmCall\`, so stacking the wallet's mutex on top just creates a second JS-layer queue that turns short SDK reads into tail-latency victims of long SDK writes.

## Fixes

| commit | fix | file | LOC |
|---|---|---|---|
| \`0a0387874\` | Drop wallet mutex around \`getAccount\` in \`fetchBalances\`. SDK serializes \`getAccount\` internally; the wallet wrapper was redundant and was the actual cause of the SelectToken TST tile stalling behind \`syncState\`. | \`src/lib/store/utils/fetchBalances.ts\` | +16 / −14 |
| \`f1f7e1a21\` | Pause \`useSyncTrigger\` while the user is inside the Send flow (URL hash prefix \`#/send\`). The Send screens don't need fresh chain state during token / recipient / amount selection. Frees the SDK queue for the balance read during the critical UI window. | \`src/lib/miden/front/useSyncTrigger.ts\` | +29 / −1 |
| \`5ef5c4d51\` | Cap \`syncState\` at 5s (was 25s) + circuit breaker (3 consecutive failures → 30s backoff, resets on success). 5s keeps the sync path well under any UI click budget; circuit breaker prevents hammering the node / wasm client during RPC flaps. | \`src/lib/miden/back/sync-manager.ts\` | +55 / −10 |

## Why these three and not others

Other \`withWasmClientLock\` usages in the wallet fall into three categories: (a) single-read SDK calls that are also redundant and could be dropped but aren't in the UI fast path (\`Receive.tsx\`, \`ExportFileComplete\`, etc.); (b) multi-step sequences where atomicity actually matters (\`importNoteBytes + syncState\`, wallet creation); (c) critical paths where the wallet-side mutex is load-bearing (the \`actions.ts\` vault-lock gate that drains in-flight consume loops; \`transactions.ts\` \`sendPrivateNote\` transport-upload pair). A full lock-hygiene audit is better as its own PR with a targeted testing matrix; this PR is scoped to the stress-run failure mode.

## What was happening under stress

- 1000-op run, default perturbations, testnet: 86% primary failure rate, all failures uniform \`locator.click\` timeouts on the TST tile in SelectToken
- Balance divergence of ~190 TST per wallet despite most ops \"failing\" — UI aborts after 10s, but the WASM tx underneath still commits on-chain and drains the sender (driver's accounting doesn't count these as success, but funds still moved)
- Not a transport-layer issue: NTS PR (\`note-transport-service#77\`, now v0.3.2) already verified clean in the 100-op + 500-op runs yesterday against the same \`transport.miden.io\`
- Cross-referenced against yesterday's 500-op run artifacts (500/500 ok, 0 UI timeouts, same wallet code, \`100% private + claimAfterSend=0\` quiet config): the difference is the default perturbation config (claim-after-send=0.5, mixed ratio) which stacks more WASM ops per second and pushes the lock contention past the click budget

## Test plan

- [x] \`yarn lint\` clean
- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn jest src/lib/miden/back/sync-manager.test.ts src/lib/store/utils/fetchBalances src/lib/miden/front/useSyncTrigger\` — 31/31 pass
- [ ] Re-run the 1000-op stress test on testnet with these fixes; expect failure rate to drop from 86% to single-digit or zero
- [ ] Sanity check Receive screen still claims notes (fix #2 pauses sync in \`#/send\` only; Receive is under \`/receive\`)
- [ ] Sanity check dApp connect flow: DAppConnect doesn't use \`#/send\` hash, sync continues as expected

## Follow-ups (separate PRs)

1. **Lock-hygiene audit** — drop the 7 other \`withWasmClientLock\` wrappers around single-read SDK methods (listed in review comments). Low-leverage in the UI fast path but reduces overall lock contention.
2. **SW-side sync suppression during Send** — this PR only pauses the popup's 3s trigger. The SW's 30-60s browser.alarms alarm still fires independently. Less pressure but still contends. Could plumb a \"suspend sync\" message from popup to SW.
3. **\`completeCustomTransaction\` silent-loss path** — the dApp 'execute' transaction type still swallows transport errors (flagged in earlier PR #201). Orthogonal to this PR.

## Cross-ref

- NTS fix v0.3.2 (\`note-transport-service#77\`): separate, already shipped, verified in yesterday's 100-op + 500-op runs.
- Stress harness: uses Playwright's \`locator.click({ timeout: 10_000 })\` on the TST tile; any balance read > 10s produces the failure mode fixed here.