### PR TITLE
Service worker init race causing stuck transactions (#212)

### DIFF
--- a/src/lib/miden/back/actions.ts
+++ b/src/lib/miden/back/actions.ts
@@ -55,9 +55,20 @@ function getUnlockQueue() {
   return _unlockQueue;
 }
 
+// service worker cold-start race
+let _vault: typeof Vault | null = null;
+async function getVault() {
+  if (!_vault) {
+    await init_vault(); // init_vault completes before returning
+    _vault = Vault;
+  }
+  return _vault;
+}
+
 export async function init() {
   console.log('[Actions.init] Starting...');
-  const vaultExist = await Vault.isExist();
+  const vault = await getVault(); // wait for vault initialization
+  const vaultExist = await vault.isExist();
   console.log('[Actions.init] Vault exists:', vaultExist);
   inited(vaultExist);
   console.log('[Actions.init] Called inited()');

--- a/src/lib/miden/back/sync-manager.ts
+++ b/src/lib/miden/back/sync-manager.ts
@@ -10,6 +10,7 @@ import { mergeAndPersistSeenNoteIds } from './note-checker-storage';
 import { Vault } from './vault';
 import { getBech32AddressFromAccountId } from '../sdk/helpers';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
+import { init_vault } from './vault';
 
 const ALARM_NAME = 'miden-sync';
 
@@ -39,6 +40,16 @@ let inFlight: Promise<void> | null = null;
 let consecutiveSyncFailures = 0;
 let syncBackoffUntilMs = 0;
 
+// Lazy Vault initialization to prevent service worker cold-start race
+let _vault: typeof Vault | null = null;
+async function getVault() {
+  if (!_vault) {
+    await init_vault();
+    _vault = Vault;
+  }
+  return _vault;
+}
+
 export function doSync(): Promise<void> {
   if (inFlight) return inFlight;
   // Circuit-breaker: short-circuit if recent syncs failed and we're waiting out
@@ -56,7 +67,8 @@ export function doSync(): Promise<void> {
 async function runSync(): Promise<void> {
   try {
     // Skip if wallet not set up
-    const exists = await Vault.isExist();
+    const vault = await getVault();
+    const exists = await vault.isExist();
     if (!exists) return;
 
     // [Lock 1] THE sync for the whole app. Bounded by SYNC_TIMEOUT_MS so it
@@ -89,7 +101,8 @@ async function runSync(): Promise<void> {
     }
 
     const intercom = getIntercom()!;
-    const accountPubKey = await Vault.getCurrentAccountPublicKey();
+    const vault2 = await getVault();
+    const accountPubKey = await vault2.getCurrentAccountPublicKey();
 
     if (accountPubKey) {
       // [Lock 2] Read notes + vault assets from warm WASM client

--- a/vite.background.config.ts
+++ b/vite.background.config.ts
@@ -196,11 +196,11 @@ export default defineConfig({
                 'async function processRequest'
               ].join('\n')
             );
-            // processRequest awaits inits for any request except GetStateRequest/SyncRequest
-            // (those are handled early via getFrontState's Idle fallback)
+            // processRequest awaits inits for any request except GET_STATE_REQUEST
+            // SYNC_REQUEST removed from bypass - it should now properly wait for init
             chunk.code = chunk.code.replace(
               /async function processRequest\(req[^)]*\)\s*\{/,
-              '$&\n  if (req?.type !== "GET_STATE_REQUEST" && req?.type !== "SYNC_REQUEST") { await __initsReady; }'
+              '$&\n  if (req?.type !== "GET_STATE_REQUEST") { await __initsReady; }'
             );
           }
         }


### PR DESCRIPTION
## Summary
Fixes #212 - Service worker initialization race condition that causes transactions to remain stuck in "sending" state indefinitely after Chrome MV3 service worker cold-start.

## Problem
When Chrome terminates the MV3 service worker after idle timeout (~30s), the next cold-start triggers a module initialization race:

1. `Actions.init()` and `doSync()` both call `Vault.isExist()` before `init_vault()` completes
2. `Vault` is `undefined` during the race → `TypeError: Cannot read properties of undefined (reading 'isExist')`
3. `Actions.init()` throws, so `inited(vaultExist)` never fires
4. Backend's `inited` flag stays `false`
5. All `withInited(...)` guards block forever
6. Any in-flight transaction is permanently stuck

**Root cause locations:**
- `src/lib/miden/back/actions.ts:60` - unguarded `Vault.isExist()` call
- `src/lib/miden/back/sync-manager.ts:69` - same unguarded access
- `vite.background.config.ts:201` - SYNC_REQUEST bypasses init barrier

## Solution
Applied the **lazy accessor pattern** already used in the same codebase (`_dappQueue`/`_unlockQueue` at `actions.ts:47-56`) to the `Vault` reference:

### Changes Made:
1.  **`sync-manager.ts`**: Added `getVault()` lazy accessor and replaced direct `Vault` calls with `await getVault()`
2. **`actions.ts`**: Applied the same lazy accessor pattern (if not already present)
3. **`vite.background.config.ts`**: Removed `SYNC_REQUEST` from the `__initsReady` bypass so sync requests properly wait for initialization

This ensures `Vault` is always initialized before use, regardless of service worker cold-start timing.

## Testing
- Code follows existing lazy-init pattern from the same file
- Fixes both identified throw sites (`actions.ts` + `sync-manager.ts`)
- Removes the incorrect SYNC_REQUEST bypass assumption

## Related
- Confirmed by user console logs + video in #212
- No existing PR addresses this issue
- Issue opened Apr 23, 2026 with full forensic analysis