### PR TITLE
fix(wallet): auto-dismiss transaction modal on user navigation

### DIFF
--- a/src/components/TransactionProgressModal.tsx
+++ b/src/components/TransactionProgressModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 
 import classNames from 'clsx';
 import { createPortal } from 'react-dom';
@@ -20,6 +20,7 @@ import { useHideNavbarWhileOpen } from 'lib/mobile/useHideNavbarWhileOpen';
 import { isExtension } from 'lib/platform';
 import { useWalletStore } from 'lib/store';
 import { useRetryableSWR } from 'lib/swr';
+import { useLocation } from 'lib/woozie';
 import { GeneratingTransaction } from 'screens/generating-transaction/GeneratingTransaction';
 
 export const TransactionProgressModal: FC = () => {
@@ -174,6 +175,69 @@ export const TransactionProgressModal: FC = () => {
     closeModal(true);
     setError(false);
   }, [closeModal]);
+
+  // Auto-dismiss the modal when the user navigates somewhere else.
+  //
+  // Why: PR #217 made the modal overlay click-through, but the modal CONTENT
+  // (the centered card + progress SVG) still occupies pixel area. When the
+  // user — or the stress harness — moves to a new screen and tries to click
+  // anything that falls behind the card's bounding box, Playwright's
+  // actionability check sees `transaction-modal-root subtree intercepts
+  // pointer events` and times out. The 04-28 stress run reproduced this
+  // 504 times on the post-#217 wallet (Δ = −141 TST).
+  //
+  // The fix: when the user navigates AWAY from the screen the modal opened
+  // on, dismiss the modal. Tx processing keeps running via the
+  // `isProcessing` flag — independent of `isOpen` — so nothing in flight is
+  // cancelled.
+  //
+  // Two complications:
+  //
+  // 1. SendManager's own onSubmit/onGenerateTransaction calls
+  //    `openTransactionModal()` immediately followed by `navigate('/')` (on
+  //    desktop) or stays put (on mobile). We do NOT want to dismiss on that
+  //    self-initiated navigation — the user just submitted, the modal needs
+  //    to land on the home screen so they can see progress.
+  //
+  // 2. `pathname` flips through many intermediate values during a test run
+  //    even when the user is "stationary" (e.g., the SendManager's internal
+  //    multi-step routes within /send). We track the FINAL post-open
+  //    pathname and only react to changes from THAT.
+  //
+  // Implementation: capture the pathname while a 2s grace timer runs (this
+  // covers SendManager's auto-nav). Once the timer fires, the latest
+  // captured pathname becomes the reference; subsequent changes from it
+  // dismiss the modal.
+  const { pathname } = useLocation();
+  const settledPathnameRef = useRef<string | null>(null);
+  const [graceElapsed, setGraceElapsed] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      settledPathnameRef.current = null;
+      setGraceElapsed(false);
+      return;
+    }
+    setGraceElapsed(false);
+    const POST_OPEN_GRACE_MS = 2000;
+    const timer = setTimeout(() => setGraceElapsed(true), POST_OPEN_GRACE_MS);
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!graceElapsed) {
+      // During the grace window, keep updating the snapshot so SendManager's
+      // own `navigate('/')` lands as the post-open settled pathname.
+      settledPathnameRef.current = pathname;
+      return;
+    }
+    // Grace window done. From here on, any pathname change is a user
+    // navigation away from where the modal opened — dismiss.
+    if (settledPathnameRef.current !== null && pathname !== settledPathnameRef.current) {
+      handleClose();
+    }
+  }, [isOpen, graceElapsed, pathname, handleClose]);
 
   const progress = transactions.length > 0 ? (1 / transactions.length) * 80 : 0;
   // Only show complete if we've loaded AND there are no transactions


### PR DESCRIPTION
## Summary

Follow-up to #217. That PR made the modal **overlay** click-through, but the modal **content** (centered card + progress SVG) still occupies pixel area. When the user — or the stress harness — moves to a new screen and tries to click anything that falls behind the card's bounding box, Playwright reports `transaction-modal-root subtree intercepts pointer events` and the click times out.

This PR auto-dismisses the modal when the user navigates somewhere else. Tx processing keeps running via the existing `isProcessing` flag (independent of `isOpen`), so nothing in flight gets cancelled.

## Empirical motivation

The 04-28 100-loop testnet stress run on the **post-#217** wallet:

| Metric | Pre-#217 (04-27) | Post-#217 (04-28) |
|---|---|---|
| Conservation Δ | −124 TST | **−141 TST** |
| Sub-step failures | 595 | **504** |
| All errors mention `transaction-modal-root` | yes | **yes** |
| Click timeout | 10000ms | **30000ms** (the bumped budget — overlay-pointer-events fix is in effect) |

So #217's `pointer-events-none` on the overlay propagated into the deployed wallet (the 30s timeout proves it), but the loss is essentially unchanged. The card content is the residual click trap.

## How

```ts
const { pathname } = useLocation();
const settledPathnameRef = useRef<string | null>(null);
const [graceElapsed, setGraceElapsed] = useState(false);

useEffect(() => {
  if (!isOpen) {
    settledPathnameRef.current = null;
    setGraceElapsed(false);
    return;
  }
  setGraceElapsed(false);
  const timer = setTimeout(() => setGraceElapsed(true), 2000);
  return () => clearTimeout(timer);
}, [isOpen]);

useEffect(() => {
  if (!isOpen) return;
  if (!graceElapsed) {
    settledPathnameRef.current = pathname;
    return;
  }
  if (settledPathnameRef.current !== null && pathname !== settledPathnameRef.current) {
    handleClose();
  }
}, [isOpen, graceElapsed, pathname, handleClose]);
```

The 2s grace window covers two cases that would otherwise dismiss the modal prematurely:
1. SendManager's own `openTransactionModal()` → `navigate('/')` on desktop (which would dismiss before the user sees the modal)
2. SendManager's internal multi-step routes inside `/send` flipping `pathname` while the form is being filled

Once the grace elapses, the captured `pathname` becomes the reference; subsequent changes from it trigger `handleClose()`.

## What this preserves

- Modal still opens normally on submit, shows progress / completion / error states as before
- Tx pipeline runs to completion regardless of dismissal (tested by the existing `isProcessing` flag pattern)
- Hide / Done buttons still work (modal content is `pointer-events-auto`, unchanged from #217)
- ESC still dismisses

## What this changes (intentionally)

- **View Explorer** — currently the success modal is the only place to click "View on Midenscan". After this PR, if the user navigates away while the modal is in the success state, that affordance disappears. `lastCompletedTxHash` is already in the Zustand store, so a future history-detail surface can re-introduce it. Out of scope for this PR; flagged so reviewers know.

## Test plan

- [x] `yarn ts --noEmit` (tsc strict) — clean
- [x] `yarn lint` (eslint `--max-warnings 0`) — clean
- [x] `yarn test` (jest) — 124 suites / 1729 tests pass
- [ ] Same-seed stress re-run (`STRESS_SEED=3436891266` from 04-27, or 3485613780 from 04-28) — predicted: conservation Δ → 0 if the modal-content intercept is the whole residual; small residual implies one more mechanism (most likely the harness's concurrent-secondary tracking in `stress-driver.ts:305-311`).

## Related

- #217 — overlay pointer-events-none + harness 30s timeout bump (the precursor)
- `0xMiden/miden-client#2127` — durable NTL relay for `Client::send_private_note`. Orthogonal; closes a different exposure.