### PR TITLE
stress: tune waitForTransactionCommit poll + wasm-lock instrumentation

### DIFF
--- a/src/lib/miden/activity/notes.ts
+++ b/src/lib/miden/activity/notes.ts
@@ -22,6 +22,6 @@ export const importAllNotes = async () => {
     }
     await new Promise(resolve => setTimeout(resolve, 2000));
     await midenClient.syncState();
-  });
+  }, 'notes.import');
   await putToStorage(IMPORT_NOTES_KEY, []);
 };

--- a/src/lib/miden/activity/transactions.ts
+++ b/src/lib/miden/activity/transactions.ts
@@ -90,7 +90,7 @@ export const completeCustomTransaction = async (transaction: ITransaction, resul
         const midenClient = await getMidenClient();
 
         try {
-          await midenClient.waitForTransactionCommit(executedTx.id().toHex());
+          await midenClient.waitForTransactionCommit(executedTx.id().toHex(), 60_000, 1_000);
           await midenClient.sendPrivateNote(fullNote, transaction.secondaryAccountId!);
         } catch (error) {
           console.error('Failed to send private note through the transport layer', {
@@ -317,7 +317,7 @@ export const completeSendTransaction = async (tx: SendTransaction, result: Trans
     const sendResult = await withWasmClientLock<SendResult>(async () => {
       try {
         const midenClient = await getMidenClient();
-        await midenClient.waitForTransactionCommit(executedTx.id().toHex());
+        await midenClient.waitForTransactionCommit(executedTx.id().toHex(), 60_000, 1_000);
         await setTransactionStage(tx.id, 'delivering');
         await midenClient.sendPrivateNote(note, tx.secondaryAccountId);
         return { success: true };

--- a/src/lib/miden/activity/transactions.ts
+++ b/src/lib/miden/activity/transactions.ts
@@ -99,7 +99,7 @@ export const completeCustomTransaction = async (transaction: ITransaction, resul
             error
           });
         }
-      });
+      }, 'tx.complete-custom.private-deliver');
     } catch (error) {
       console.error('Failed to initialize Miden client for private note send', {
         txId: transaction.id,
@@ -123,7 +123,7 @@ export const initiateConsumeTransactionFromId = async (
     const midenClient = await getMidenClient();
 
     return midenClient.getInputNote(noteId);
-  });
+  }, 'tx.consume-from-id.get-note');
   if (!sdkNote) {
     throw new Error(`Note with id ${noteId} not found`);
   }
@@ -324,7 +324,7 @@ export const completeSendTransaction = async (tx: SendTransaction, result: Trans
       } catch (error) {
         return { success: false, errorType: 'transport', error };
       }
-    }).catch(error => ({ success: false, errorType: 'init' as const, error }));
+    }, 'tx.complete-send.private-deliver').catch(error => ({ success: false, errorType: 'init' as const, error }));
 
     if (!sendResult.success) {
       if (sendResult.errorType === 'transport') {
@@ -568,7 +568,7 @@ export const verifyStuckTransactionsFromNode = async (): Promise<number> => {
       const noteDetails = await withWasmClientLock(async () => {
         const midenClient = await getMidenClient();
         return await midenClient.getInputNoteDetails({ ids: [tx.noteId] });
-      });
+      }, 'tx.recover-stuck.get-note');
 
       const note = noteDetails[0];
       if (!note) {
@@ -620,7 +620,7 @@ export const generateTransaction = async (
   await withWasmClientLock(async () => {
     const midenClient = await getMidenClient();
     await midenClient.syncState();
-  });
+  }, 'tx.pipeline.sync');
 
   // Mark transaction as in progress
   await updateTransactionStatus(transaction.id, ITransactionStatus.GeneratingTransaction, {

--- a/src/lib/miden/back/sync-manager.ts
+++ b/src/lib/miden/back/sync-manager.ts
@@ -69,7 +69,7 @@ async function runSync(): Promise<void> {
           const client = await getMidenClient();
           if (!client) return;
           await client.syncState();
-        }),
+        }, 'sync.manager.poll'),
         SYNC_TIMEOUT_MS
       );
       consecutiveSyncFailures = 0;
@@ -137,7 +137,7 @@ async function runSync(): Promise<void> {
         }
 
         return { parsedNotes: notes, vaultAssets: assets };
-      });
+      }, 'sync.manager.notes');
 
       // Fetch metadata for all faucets in parallel (RPC, outside lock — no WASM needed)
       // Collect all unique faucet IDs from both notes and vault assets

--- a/src/lib/miden/front/claimable-notes.ts
+++ b/src/lib/miden/front/claimable-notes.ts
@@ -149,7 +149,7 @@ async function fetchNotesFromLocalClient(
     rawNotes = await withWasmClientLock(async () => {
       const midenClient = await getMidenClient();
       return midenClient.getConsumableNotes(publicAddress);
-    });
+    }, 'claimable.list');
   } catch (e) {
     debugInfoRef.current = {
       ...debugInfoRef.current,

--- a/src/lib/miden/front/useSyncTrigger.ts
+++ b/src/lib/miden/front/useSyncTrigger.ts
@@ -82,7 +82,7 @@ export function useSyncTrigger() {
             const client = await getMidenClient();
             if (!client || cancelled) return;
             await client.syncState();
-          });
+          }, 'sync.trigger');
         } catch (error) {
           console.warn('[useSyncTrigger] sync error:', error);
         } finally {

--- a/src/lib/miden/sdk/miden-client.ts
+++ b/src/lib/miden/sdk/miden-client.ts
@@ -25,6 +25,10 @@ class AsyncMutex {
     });
   }
 
+  pendingCount(): number {
+    return this.queue.length;
+  }
+
   release(): void {
     const next = this.queue.shift();
     if (next) {
@@ -99,12 +103,28 @@ const wasmClientMutex = new AsyncMutex();
 /**
  * Execute an operation with the WASM client mutex held.
  * This ensures only one WASM client operation runs at a time across the entire app.
+ *
+ * Stress instrumentation: when wait or hold time exceeds 50ms, emits a
+ * `[lock]` console.log line. The Playwright stress harness captures these
+ * via browser_console events and writes them into timeline.ndjson for
+ * per-call-site attribution. Strip the `label` arg + the gated log block
+ * when the contention question is answered.
  */
-export async function withWasmClientLock<T>(operation: () => Promise<T>): Promise<T> {
+export async function withWasmClientLock<T>(operation: () => Promise<T>, label: string = 'unlabeled'): Promise<T> {
+  const requestedAt = performance.now();
   await wasmClientMutex.acquire();
+  const acquiredAt = performance.now();
+  const waitMs = acquiredAt - requestedAt;
   try {
     return await operation();
   } finally {
+    const heldMs = performance.now() - acquiredAt;
+    if (waitMs > 50 || heldMs > 50) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[lock] label=${label} wait=${waitMs.toFixed(0)}ms held=${heldMs.toFixed(0)}ms qDepth=${wasmClientMutex.pendingCount()}`
+      );
+    }
     wasmClientMutex.release();
   }
 }


### PR DESCRIPTION
## Summary

Two changes from the 04-28 / 04-30 stress-report deep-dive, kept as separate commits so the instrumentation can be reverted independently once the contention question is answered.

- **perf(wallet)** — Set `waitForTransactionCommit` `delayMs` to 1s (down from the SDK's 5s default) at the two private-send call sites (`transactions.ts:93`, `transactions.ts:320`). Cuts the poll-cadence rounding component of the wait phase from ~5s avg to ~1s; net ~2s off private-send p50, ~30% off the private/public gap. Block-time floor (~2.5s avg on testnet) is unchanged. RPC headroom is fine — 04-28 deep-dive recorded p99 348ms / p99.9 4.2s across 50,260 calls; 5x more `GetTransaction` polls per send is well within budget.

- **chore(stress)** — Wrap `withWasmClientLock` with timing + a gated `console.log` on the >50ms hot path; thread a `label` arg through 10 hot-path call sites (`sync.trigger`, `sync.manager.poll`/`.notes`, `tx.complete-{custom,send}.private-deliver`, `tx.consume-from-id.get-note`, `tx.recover-stuck.get-note`, `tx.pipeline.sync`, `notes.import`, `claimable.list`). The 11th hot-path site (the actual `tx.pipeline` send at `transactions.ts:640`) is intentionally left as `unlabeled`. Playwright's existing `browser_console` capture writes the `[lock]` lines into `timeline.ndjson`, so per-op attribution falls out of grepping `[lock]` lines aligned with per-op send windows — directly answers which call site is starving op#222 etc. without a harness change. Comment in `miden-client.ts` says strip when done.

## Why this exists

04-30 100-loop pure-infra stress run on the same #218 wallet hit p95 = 71.2s — same magnitude as the 04-28 300-loop (~70s), despite 3x fewer ops. Tail is `NUM_NOTES`-independent, so the prior "more dice rolls" framing is wrong; the wedge is intrinsic. RPC was already ruled out via Pearson `r(sendMs, max_RPC_call_in_window) = 0.13` across 50,260 events. Of the three remaining candidates — (a) `withWasmClientLock` contention, (b) worker queueing inside the SDK, (c) local CPU on serialization — only the lock can be told apart from RPC trace data with a label, hence this patch.

Tier 2 from the 04-29 follow-up (release the WASM lock around `waitForTransactionCommit`) is **not** included: SDK's `client.transactions.waitFor` runs `syncStateWithTimeout(0)` per poll plus a WASM-side `TransactionFilter` build (see `node_modules/@miden-sdk/miden-sdk/dist/index.js:1011-1052`), so releasing the lock during the wait would let `useSyncTrigger` / `claimAllNotes` run `syncState` concurrently — exactly the WASM concurrency error the lock exists to prevent. Needs SDK-side fix first.

## Test plan

- [x] `yarn lint --max-warnings 0` clean
- [x] `yarn format` clean
- [x] `yarn build` produces `dist/chrome_unpacked/manifest.json` with 0 errors
- [x] 87/87 tests pass across `miden-client`, `transactions`, `sync-manager`, `claimable-notes`, `notes`
- [ ] Run pure-infra stress harness on this branch (same config as 04-30: `STRESS_LOCK_EVERY=0 STRESS_RELOAD_EVERY=0 STRESS_IDLE_EVERY=0 STRESS_CONCURRENT_PROB=0`), grep `[lock]` lines in `timeline.ndjson`, attribute the 70s p95 to a labelled call site
- [ ] Verify the 7 early-op `locator.click: TST token-picker` failures in the 04-30 run correspond to lock-holds with high `qDepth` — this confirms the "WASM lock starvation, not transport loss" hypothesis from the report
- [ ] Once the call site is identified, revert `4491ecf7d` and keep only the perf commit on main

## Commits

- \`617da9c92\` perf(wallet): tune waitForTransactionCommit poll interval to 1s
- \`4491ecf7d\` chore(stress): add wasm-lock instrumentation with per-callsite labels