### PR TITLE
ci: split chrome e2e per-network for nightly + node-monitor symmetry

### DIFF
--- a/.github/workflows/e2e-blockchain-chrome-devnet.yml
+++ b/.github/workflows/e2e-blockchain-chrome-devnet.yml
@@ -1,0 +1,131 @@
+name: E2E Blockchain (Chrome, devnet)
+
+# Chrome extension blockchain-backed E2E suite against devnet.
+# Runs on every push to main AND nightly at 04:00 UTC.
+#
+# Split out from the multi-network workflow so the devnet network-monitor
+# card can pin to a single workflow id (its symmetric testnet counterpart
+# lives in `e2e-blockchain-chrome-testnet.yml`). Each network is now
+# independently merge-required / monitorable.
+#
+# NOTE: with this split the previous "AT LEAST ONE network passed"
+# merge-tolerance is no longer enforced inside a workflow. If you want
+# that tolerance preserved at the merge gate, configure branch protection
+# to NOT require both workflows; the on-dashboard signal handles the
+# day-to-day visibility.
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write  # for the schedule-only failure-issue step below
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chrome-devnet:
+    name: Chrome E2E (devnet)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      E2E_NETWORK: devnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      # cargo is needed to install miden-client-cli from crates.io on first run.
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        # Cache key follows the root package.json so a SDK version bump
+        # (or any other root-level dep change) naturally invalidates — the
+        # CLI is installed version-matched to @miden-sdk/miden-sdk by
+        # helpers/miden-cli.ts.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # Pre-install the miden-client-cli so the cold-cache ~7 min cargo
+      # compile happens in its own step, not inside Playwright's 5-min
+      # per-test timeout. `cargo install` is a no-op on warm cache.
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run blockchain E2E (devnet)
+        run: xvfb-run -a yarn test:e2e:blockchain:devnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-e2e-devnet-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Auto-create a tracking issue when the SCHEDULED nightly fails. Push
+  # failures stay visible on the merge commit + Actions tab and don't need
+  # an issue (PR context already covers them); only the nightly cadence —
+  # which has no PR context — gets an issue so a red night doesn't rot
+  # silently.
+  nightly-failure-issue:
+    name: Open issue on nightly failure
+    needs: chrome-devnet
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `Nightly Chrome E2E (devnet) failed — ${today}`;
+            const body = [
+              `Nightly run [\`${context.runId}\`](${runUrl}) failed on devnet.`,
+              ``,
+              `Workflow: \`${context.workflow}\``,
+              `Commit: \`${context.sha}\``,
+              ``,
+              `<sub>Auto-created by \`e2e-blockchain-chrome-devnet.yml\` on schedule failure.</sub>`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['ci-failure', 'nightly-e2e', 'devnet'],
+            });

--- a/.github/workflows/e2e-blockchain-chrome-devnet.yml
+++ b/.github/workflows/e2e-blockchain-chrome-devnet.yml
@@ -1,23 +1,13 @@
-name: E2E Blockchain (Chrome, devnet)
+name: E2E Blockchain (Chrome, devnet) — Nightly
 
-# Chrome extension blockchain-backed E2E suite against devnet.
-# Runs on every push to main AND nightly at 04:00 UTC.
-#
-# Split out from the multi-network workflow so the devnet network-monitor
-# card can pin to a single workflow id (its symmetric testnet counterpart
-# lives in `e2e-blockchain-chrome-testnet.yml`). Each network is now
-# independently merge-required / monitorable.
-#
-# NOTE: with this split the previous "AT LEAST ONE network passed"
-# merge-tolerance is no longer enforced inside a workflow. If you want
-# that tolerance preserved at the merge gate, configure branch protection
-# to NOT require both workflows; the on-dashboard signal handles the
-# day-to-day visibility.
+# Chrome extension blockchain-backed E2E suite against devnet — NIGHTLY only.
+# Push-on-main coverage (with the OR-tolerance gate across both networks)
+# lives in `e2e-blockchain-chrome.yml`; this workflow exists per-network
+# so the devnet network-monitor card can pin to a single workflow id
+# without contention from push runs. Symmetric testnet sibling:
+# `e2e-blockchain-chrome-testnet.yml`.
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch: {}

--- a/.github/workflows/e2e-blockchain-chrome-testnet.yml
+++ b/.github/workflows/e2e-blockchain-chrome-testnet.yml
@@ -1,23 +1,13 @@
-name: E2E Blockchain (Chrome, testnet)
+name: E2E Blockchain (Chrome, testnet) — Nightly
 
-# Chrome extension blockchain-backed E2E suite against testnet.
-# Runs on every push to main AND nightly at 04:00 UTC.
-#
-# Split out from the multi-network workflow so the testnet network-monitor
-# card can pin to a single workflow id (its symmetric devnet counterpart
-# lives in `e2e-blockchain-chrome-devnet.yml`). Each network is now
-# independently merge-required / monitorable.
-#
-# NOTE: with this split the previous "AT LEAST ONE network passed"
-# merge-tolerance is no longer enforced inside a workflow. If you want
-# that tolerance preserved at the merge gate, configure branch protection
-# to NOT require both workflows; the on-dashboard signal handles the
-# day-to-day visibility.
+# Chrome extension blockchain-backed E2E suite against testnet — NIGHTLY only.
+# Push-on-main coverage (with the OR-tolerance gate across both networks)
+# lives in `e2e-blockchain-chrome.yml`; this workflow exists per-network
+# so the testnet network-monitor card can pin to a single workflow id
+# without contention from push runs. Symmetric devnet sibling:
+# `e2e-blockchain-chrome-devnet.yml`.
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch: {}

--- a/.github/workflows/e2e-blockchain-chrome-testnet.yml
+++ b/.github/workflows/e2e-blockchain-chrome-testnet.yml
@@ -1,0 +1,123 @@
+name: E2E Blockchain (Chrome, testnet)
+
+# Chrome extension blockchain-backed E2E suite against testnet.
+# Runs on every push to main AND nightly at 04:00 UTC.
+#
+# Split out from the multi-network workflow so the testnet network-monitor
+# card can pin to a single workflow id (its symmetric devnet counterpart
+# lives in `e2e-blockchain-chrome-devnet.yml`). Each network is now
+# independently merge-required / monitorable.
+#
+# NOTE: with this split the previous "AT LEAST ONE network passed"
+# merge-tolerance is no longer enforced inside a workflow. If you want
+# that tolerance preserved at the merge gate, configure branch protection
+# to NOT require both workflows; the on-dashboard signal handles the
+# day-to-day visibility.
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write  # for the schedule-only failure-issue step below
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chrome-testnet:
+    name: Chrome E2E (testnet)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      E2E_NETWORK: testnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run blockchain E2E (testnet)
+        run: xvfb-run -a yarn test:e2e:blockchain:testnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-e2e-testnet-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Auto-create a tracking issue when the SCHEDULED nightly fails. Push
+  # failures stay visible on the merge commit + Actions tab and don't need
+  # an issue (PR context already covers them); only the nightly cadence —
+  # which has no PR context — gets an issue so a red night doesn't rot
+  # silently.
+  nightly-failure-issue:
+    name: Open issue on nightly failure
+    needs: chrome-testnet
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `Nightly Chrome E2E (testnet) failed — ${today}`;
+            const body = [
+              `Nightly run [\`${context.runId}\`](${runUrl}) failed on testnet.`,
+              ``,
+              `Workflow: \`${context.workflow}\``,
+              `Commit: \`${context.sha}\``,
+              ``,
+              `<sub>Auto-created by \`e2e-blockchain-chrome-testnet.yml\` on schedule failure.</sub>`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['ci-failure', 'nightly-e2e', 'testnet'],
+            });

--- a/.github/workflows/e2e-blockchain-chrome.yml
+++ b/.github/workflows/e2e-blockchain-chrome.yml
@@ -1,0 +1,181 @@
+name: E2E Blockchain (Chrome) — Push
+
+# Chrome extension blockchain-backed E2E suites against public networks.
+# Runs on every push to main. The gate job passes as long as AT LEAST
+# ONE network (devnet OR testnet) succeeded — this tolerates short
+# windows where wallet@main and a single network are protocol-mismatched
+# (e.g. devnet ahead of the pinned SDK version).
+#
+# This workflow only runs on push. Nightly per-network coverage lives in
+# the schedule-only siblings:
+#   - e2e-blockchain-chrome-devnet.yml
+#   - e2e-blockchain-chrome-testnet.yml
+#
+# The split exists because the network-monitor's devnet/testnet
+# instances each pin to one schedule-only workflow file; running both
+# networks in a single push workflow keeps the merge-gate tolerance the
+# team has come to rely on.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network(s) to test against'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - devnet
+          - testnet
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chrome-devnet:
+    name: Chrome E2E (devnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      E2E_NETWORK: devnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      # cargo is needed to install miden-client-cli from crates.io on first run.
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        # Cache key follows the root package.json so a SDK version bump
+        # (or any other root-level dep change) naturally invalidates — the
+        # CLI is installed version-matched to @miden-sdk/miden-sdk by
+        # helpers/miden-cli.ts.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # Pre-install the miden-client-cli so the cold-cache ~7 min cargo
+      # compile happens in its own step, not inside Playwright's 5-min
+      # per-test timeout. `cargo install` is a no-op on warm cache.
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run blockchain E2E (devnet)
+        run: xvfb-run -a yarn test:e2e:blockchain:devnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-e2e-devnet-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  chrome-testnet:
+    name: Chrome E2E (testnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      E2E_NETWORK: testnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run blockchain E2E (testnet)
+        run: xvfb-run -a yarn test:e2e:blockchain:testnet
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-e2e-testnet-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  chrome-gate:
+    name: Chrome E2E Gate
+    needs: [chrome-devnet, chrome-testnet]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require at least one network to pass
+        shell: bash
+        env:
+          DEVNET_RESULT: ${{ needs.chrome-devnet.result }}
+          TESTNET_RESULT: ${{ needs.chrome-testnet.result }}
+        run: |
+          echo "devnet=$DEVNET_RESULT  testnet=$TESTNET_RESULT"
+          if [[ "$DEVNET_RESULT" == "success" || "$TESTNET_RESULT" == "success" ]]; then
+            echo "Chrome E2E: at least one network passed."
+            exit 0
+          fi
+          echo "Chrome E2E: both networks failed or were skipped."
+          exit 1

--- a/.github/workflows/e2e-blockchain-mobile.yml
+++ b/.github/workflows/e2e-blockchain-mobile.yml
@@ -1,11 +1,14 @@
-name: E2E Blockchain
+name: E2E Blockchain (Mobile)
 
-# Runs the blockchain-backed E2E suites (Chrome extension + iOS simulator)
-# against public networks on every push to main. The per-platform gate jobs
-# pass as long as AT LEAST ONE network (devnet OR testnet) succeeded for
-# that platform — this tolerates short windows where wallet@main and a
-# single network are protocol-mismatched (e.g. devnet ahead of the pinned
-# SDK version).
+# iOS-simulator blockchain-backed E2E suites against public networks.
+# Runs on every push to main. The gate job passes as long as AT LEAST
+# ONE network (devnet OR testnet) succeeded — same protocol-mismatch
+# tolerance as the Chrome suite.
+#
+# NOT on schedule: mobile lanes are macOS-runner-bound (~10× the cost
+# of the Chrome lanes) and the on-push cadence already gives same-day
+# signal. If a nightly mobile cadence is ever wanted, mirror the
+# `schedule:` block from `e2e-blockchain-chrome.yml`.
 
 on:
   push:
@@ -31,150 +34,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # --- Chrome ---------------------------------------------------------------
-
-  chrome-devnet:
-    name: Chrome E2E (devnet)
-    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      E2E_NETWORK: devnet
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: yarn
-
-      # cargo is needed to install miden-client-cli from crates.io on first run.
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache miden-client-cli
-        # Cache key follows the root package.json so a SDK version bump
-        # (or any other root-level dep change) naturally invalidates — the
-        # CLI is installed version-matched to @miden-sdk/miden-sdk by
-        # helpers/miden-cli.ts.
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/miden-client
-          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      # Pre-install the miden-client-cli so the cold-cache ~7 min cargo
-      # compile happens in its own step, not inside Playwright's 5-min
-      # per-test timeout. `cargo install` is a no-op on warm cache.
-      - name: Install miden-client-cli
-        shell: bash
-        run: |
-          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
-          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
-            echo "miden-client already present from cache:"
-            "$HOME/.cargo/bin/miden-client" --version || true
-          else
-            echo "Installing miden-client-cli@${VERSION}..."
-            cargo install miden-client-cli --version "$VERSION"
-          fi
-
-      - name: Install xvfb
-        run: sudo apt-get update && sudo apt-get install -y xvfb
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: Run blockchain E2E (devnet)
-        run: xvfb-run -a yarn test:e2e:blockchain:devnet
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: chrome-e2e-devnet-${{ github.run_id }}
-          path: test-results/
-          retention-days: 7
-          if-no-files-found: ignore
-
-  chrome-testnet:
-    name: Chrome E2E (testnet)
-    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      E2E_NETWORK: testnet
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: yarn
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache miden-client-cli
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/miden-client
-          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Install miden-client-cli
-        shell: bash
-        run: |
-          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
-          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
-            echo "miden-client already present from cache:"
-            "$HOME/.cargo/bin/miden-client" --version || true
-          else
-            echo "Installing miden-client-cli@${VERSION}..."
-            cargo install miden-client-cli --version "$VERSION"
-          fi
-
-      - name: Install xvfb
-        run: sudo apt-get update && sudo apt-get install -y xvfb
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: Run blockchain E2E (testnet)
-        run: xvfb-run -a yarn test:e2e:blockchain:testnet
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: chrome-e2e-testnet-${{ github.run_id }}
-          path: test-results/
-          retention-days: 7
-          if-no-files-found: ignore
-
-  chrome-gate:
-    name: Chrome E2E Gate
-    needs: [chrome-devnet, chrome-testnet]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require at least one network to pass
-        shell: bash
-        env:
-          DEVNET_RESULT: ${{ needs.chrome-devnet.result }}
-          TESTNET_RESULT: ${{ needs.chrome-testnet.result }}
-        run: |
-          echo "devnet=$DEVNET_RESULT  testnet=$TESTNET_RESULT"
-          if [[ "$DEVNET_RESULT" == "success" || "$TESTNET_RESULT" == "success" ]]; then
-            echo "Chrome E2E: at least one network passed."
-            exit 0
-          fi
-          echo "Chrome E2E: both networks failed or were skipped."
-          exit 1
-
-  # --- iOS Simulator --------------------------------------------------------
-
   mobile-devnet:
     name: Mobile E2E (devnet)
     if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'


### PR DESCRIPTION
## Summary

Splits `e2e-blockchain.yml` into four workflows so chrome push-coverage and per-network nightly coverage can each have their own trigger and own gate strategy. The split is what unlocks the symmetric **per-network nightly CI card** in `0xMiden/node`, while keeping the existing OR-tolerance gate for main-push merges.

## Changes

| File | Trigger | Lanes | Gate |
|---|---|---|---|
| `e2e-blockchain-chrome.yml` (new) | push to main + workflow_dispatch | chrome devnet + chrome testnet | "AT LEAST ONE network passed" gate (preserved from original) |
| `e2e-blockchain-chrome-devnet.yml` (new) | nightly cron `0 4 * * *` + workflow_dispatch | chrome devnet only | n/a — single network |
| `e2e-blockchain-chrome-testnet.yml` (new) | nightly cron `0 4 * * *` + workflow_dispatch | chrome testnet only | n/a — single network |
| `e2e-blockchain-mobile.yml` (renamed from `e2e-blockchain.yml`, mobile-only) | push to main + workflow_dispatch | iOS devnet + iOS testnet | original "AT LEAST ONE" mobile gate |

The two nightly per-network workflows auto-create a `ci-failure` / `nightly-e2e` issue on schedule failure (push reds stay on the merge commit; PR/`workflow_dispatch` reds don't open issues either).

## Why four files

Two requirements pulling in different directions:

1. **Push-time merge tolerance.** A single-network protocol mismatch (devnet ahead of the pinned SDK, etc) shouldn't block merges. The original workflow's "at least one network passed" gate handled this. Splitting per-network removed it; this PR puts it back inside `e2e-blockchain-chrome.yml` (push-only).
2. **Per-network nightly visibility.** The network-monitor exists in devnet and testnet flavors and each only cares about its own network's nightly result. Per-network workflows let each monitor pin to a single workflow file. `e2e-blockchain-chrome-{devnet,testnet}.yml` (schedule-only) carry this.

No cross-trigger duplication: `e2e-blockchain-chrome.yml` runs on push, the per-network siblings run on schedule. They don't both fire on the same event.

## Companion PR

[0xMiden/node#2050](https://github.com/0xMiden/node/pull/2050) — adds the `nightly_ci` card to the network-monitor that consumes the scheduled per-network runs.

## Test plan

- [ ] Push lands → `e2e-blockchain-chrome.yml` runs both lanes, gate evaluates OR-tolerance, `e2e-blockchain-mobile.yml` runs iOS lanes
- [ ] Push does NOT trigger `e2e-blockchain-chrome-devnet.yml` or `e2e-blockchain-chrome-testnet.yml`
- [ ] Schedule fires next 04:00 UTC → only the per-network nightly workflows run; mobile and the push workflow do not
- [ ] Force a schedule failure (`workflow_dispatch` with intentionally broken commit on a per-network workflow) → tracking issue created with `nightly-e2e` label
- [ ] `workflow_dispatch` runs do NOT create a tracking issue
- [ ] Push run with one network red, one green → push gate still passes (tolerance verified)