### PR TITLE
fix(receive): morph navbar out when QR sheet opens

### DIFF
--- a/src/app/pages/Receive.tsx
+++ b/src/app/pages/Receive.tsx
@@ -5,6 +5,7 @@ import classNames from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 
+import { InAppBrowser } from '@miden/dapp-browser';
 import FormField from 'app/atoms/FormField';
 import { useAppEnv } from 'app/env';
 import { ReactComponent as EyeClosedIcon } from 'app/icons/eye-closed.svg';
@@ -345,6 +346,33 @@ export const Receive: React.FC<ReceiveProps> = () => {
         : 'h-[600px] max-h-[600px] w-[360px] max-w-[360px]';
 
   const [isQRSheetOpen, setIsQRSheetOpen] = useState(false);
+
+  // On mobile, morph the native navbar OUT while the QR sheet
+  // covers the bottom of the screen — they'd otherwise fight for
+  // the same real estate. The navbar morph is a Swift spring
+  // animation on the native UIWindow; the `data-drawer-open` body
+  // attribute drives a matching CSS morph for parked-dApp bubbles
+  // (see main.css). Morphs back IN when the sheet closes. The
+  // unmount cleanup re-morphs in case the page unmounts mid-open
+  // (e.g. swipe-back), so nothing is stranded off-screen on the
+  // next page. Same pattern as Settings (Settings.tsx).
+  useEffect(() => {
+    if (!isMobile()) return;
+    if (isQRSheetOpen) {
+      document.body.setAttribute('data-drawer-open', '');
+      InAppBrowser.morphNavbarOut().catch(() => {});
+    } else {
+      document.body.removeAttribute('data-drawer-open');
+      InAppBrowser.morphNavbarIn().catch(() => {});
+    }
+    return () => {
+      if (!isMobile()) return;
+      if (isQRSheetOpen) {
+        document.body.removeAttribute('data-drawer-open');
+        InAppBrowser.morphNavbarIn().catch(() => {});
+      }
+    };
+  }, [isQRSheetOpen]);
 
   return (
     <div className={classNames(containerClass, 'mx-auto overflow-hidden flex flex-col bg-app-bg relative')}>


### PR DESCRIPTION
## Summary

On mobile, the native navbar pill stays put when the Receive page's QR-code bottom sheet slides up, so the two visually fight for the bottom of the screen. Settings already handles this (`Settings.tsx:254-274`) by calling `InAppBrowser.morphNavbarOut()` when its drawer/seed-warning overlay opens, and `morphNavbarIn()` when it closes. This PR ports the same effect to Receive, keyed on `isQRSheetOpen`.

## Change

Single effect in `src/app/pages/Receive.tsx`, gated on `isMobile()`:

- When the QR sheet opens → `document.body[data-drawer-open]` set + `InAppBrowser.morphNavbarOut()`
- When the QR sheet closes → both reverted
- Unmount cleanup re-morphs the navbar in if the page unmounts mid-open (e.g. swipe-back), so the pill isn't stranded off-screen on the next page

The body attribute also drives the existing CSS morph for parked-dApp bubbles via `main.css` — same mechanism Settings uses, no new CSS needed.

## Scope

Only the QR-code bottom sheet on `/receive`. The rest of the Receive page (asset list, balance area) keeps the navbar visible. Other drawer-style overlays in the wallet already handle this correctly (Settings) or don't currently — happy to widen the scope in a follow-up if you point at specific ones.

## Test plan

- [ ] iOS sim: tap QR icon on Receive → navbar slides off the bottom; close the sheet → navbar slides back in
- [ ] Android emulator: same behavior
- [ ] Desktop / extension: `isMobile()` short-circuits the effect, zero impact

Verification on simulator wasn't fully driven in my local session (CDP single-use bug bit during the unlock step), but the change is a direct clone of the already-shipping Settings pattern. The fast-path verification is opening `/receive` on a mobile build, tapping the QR icon, and watching the pill slide.