### PR TITLE
test(ios-e2e): diagnose triggerNavbarAction timeout instead of bumping it

### DIFF
--- a/playwright/e2e/ios/helpers/ios-wallet-page.ts
+++ b/playwright/e2e/ios/helpers/ios-wallet-page.ts
@@ -109,9 +109,7 @@ export class IosWalletPage implements WalletPage {
    * tap "Get started" on the confirmation screen and wait for the store to
    * reach Ready. Mirrors the Chrome `createNewWallet` contract.
    */
-  async createNewWallet(
-    password: string = DEFAULT_PASSWORD
-  ): Promise<{ address: string; seedPhrase: string[] }> {
+  async createNewWallet(password: string = DEFAULT_PASSWORD): Promise<{ address: string; seedPhrase: string[] }> {
     // Welcome screen must be visible (fixture guarantees this on cold launch).
     await this.pollForSelector('[data-testid="onboarding-welcome"]', 30_000);
 
@@ -154,8 +152,7 @@ export class IosWalletPage implements WalletPage {
     );
 
     const address = await this.cdp.eval<string>(
-      `var s = window.__TEST_STORE__.getState(); ` +
-        `return (s.currentAccount && s.currentAccount.publicKey) || '';`
+      `var s = window.__TEST_STORE__.getState(); ` + `return (s.currentAccount && s.currentAccount.publicKey) || '';`
     );
     if (!address) throw new Error('IosWalletPage.createNewWallet: no currentAccount.publicKey after Ready');
 
@@ -169,10 +166,7 @@ export class IosWalletPage implements WalletPage {
    * structurally identical. We rely on data-testid where the components
    * expose it and fall back to placeholder/text matching otherwise.
    */
-  async importWallet(
-    seedPhrase: string[],
-    password: string = DEFAULT_PASSWORD
-  ): Promise<{ address: string }> {
+  async importWallet(seedPhrase: string[], password: string = DEFAULT_PASSWORD): Promise<{ address: string }> {
     await this.navigateHome();
     await this.pollForSelector('[data-testid="onboarding-welcome"]', 30_000);
 
@@ -185,10 +179,7 @@ export class IosWalletPage implements WalletPage {
     }
     await this.clickByText('button', /continue/i);
 
-    await this.pollForCondition(
-      `return location.hash.indexOf('create-password') >= 0;`,
-      15_000
-    );
+    await this.pollForCondition(`return location.hash.indexOf('create-password') >= 0;`, 15_000);
     await this.fillInputByPlaceholder('Enter password', password);
     await this.fillInputByPlaceholder('Enter password again', password);
     await this.clickByText('button', /continue/i);
@@ -335,7 +326,7 @@ export class IosWalletPage implements WalletPage {
       [
         '[data-testid="send-flow"] input[placeholder*="wallet address"]',
         '[data-testid="send-flow"] input[placeholder*="address"]',
-        '[data-testid="send-flow"] textarea',
+        '[data-testid="send-flow"] textarea'
       ],
       params.recipientAddress
     );
@@ -344,7 +335,7 @@ export class IosWalletPage implements WalletPage {
       [
         '[data-testid="send-flow"] input[type="text"]',
         '[data-testid="send-flow"] input[type="number"]',
-        '[data-testid="send-flow"] input[inputmode="decimal"]',
+        '[data-testid="send-flow"] input[inputmode="decimal"]'
       ],
       params.amount
     );
@@ -401,7 +392,7 @@ export class IosWalletPage implements WalletPage {
           category: 'blockchain_state',
           severity: lastBalance > minBalance ? 'info' : 'warn',
           message: `Balance check: ${lastBalance} (need > ${minBalance}) attempt ${attempt}/${maxAttempts}`,
-          data: { balance: lastBalance, minBalance, attempt, maxAttempts },
+          data: { balance: lastBalance, minBalance, attempt, maxAttempts }
         });
       }
 
@@ -409,9 +400,7 @@ export class IosWalletPage implements WalletPage {
       if (attempt < maxAttempts) await sleep(intervalMs);
     }
 
-    throw new Error(
-      `Balance did not exceed ${minBalance} within ${timeoutMs}ms. Last balance: ${lastBalance}`
-    );
+    throw new Error(`Balance did not exceed ${minBalance} within ${timeoutMs}ms. Last balance: ${lastBalance}`);
   }
 
   // ── Lock / Unlock ─────────────────────────────────────────────────────────
@@ -463,9 +452,53 @@ export class IosWalletPage implements WalletPage {
       if (fired) return;
       await sleep(POLL_INTERVAL_MS);
     }
+    // Timed out without firing. The bare "no action registered" error
+    // can't distinguish between "hook never installed" (MIDEN_E2E_TEST
+    // not baked into the build) and "hook installed but no page mounted
+    // a non-null action" (sync didn't surface claimable notes). Capture
+    // the diagnostic state from the WebView so the next CI failure
+    // pinpoints the cause instead of forcing a fresh investigation.
+    const diag = await this.cdp
+      .eval<{
+        hookInstalled: boolean;
+        hash: string;
+        status: unknown;
+        balanceFaucetIds: string[];
+        balanceAmounts: string[];
+        claimableNotesCount: number | null;
+      } | null>(
+        `try {` +
+          `  var s = window.__TEST_STORE__; ` +
+          `  var st = s ? s.getState() : null; ` +
+          `  var balances = (st && st.balances) || {}; ` +
+          `  var faucetIds = []; var amounts = []; ` +
+          `  for (var k in balances) { ` +
+          `    var list = balances[k]; ` +
+          `    if (!Array.isArray(list)) continue; ` +
+          `    for (var i = 0; i < list.length; i++) { ` +
+          `      var t = list[i]; ` +
+          `      faucetIds.push(String(t.faucetId || '')); ` +
+          `      amounts.push(String(t.amount != null ? t.amount : (t.balance != null ? t.balance : '0'))); ` +
+          `    } ` +
+          `  } ` +
+          `  var notes = (st && st.claimableNotes) || (st && st.notes) || null; ` +
+          `  return {` +
+          `    hookInstalled: typeof window.__TEST_TRIGGER_NAVBAR_ACTION__ === 'function',` +
+          `    hash: location.hash || '',` +
+          `    status: st ? st.status : null,` +
+          `    balanceFaucetIds: faucetIds,` +
+          `    balanceAmounts: amounts,` +
+          `    claimableNotesCount: Array.isArray(notes) ? notes.length : null` +
+          `  }; ` +
+          `} catch (e) { return null; }`
+      )
+      .catch(() => null);
     throw new Error(
-      `triggerNavbarAction: no action registered within ${timeoutMs}ms — ` +
-        `is the wallet on the right page and is MIDEN_E2E_TEST=true baked into the build?`
+      `triggerNavbarAction: no action registered within ${timeoutMs}ms. ` +
+        `diag=${JSON.stringify(diag)} — ` +
+        `hookInstalled=false ⇒ MIDEN_E2E_TEST not baked into the build; ` +
+        `hookInstalled=true + amounts all 0 ⇒ wallet sync hasn't surfaced the note yet; ` +
+        `hash != '#/receive' ⇒ navigation didn't take.`
     );
   }
 


### PR DESCRIPTION
## Symptom

`playwright/e2e/ios/tests/mint-and-balance.ios.spec.ts` has been failing intermittently on both devnet and testnet Mobile E2E since around 2026-05-04 (was 7/7 green on 2026-04-14 per CLAUDE.md). The failure surfaces as:

```
Error: triggerNavbarAction: no action registered within 60000ms —
is the wallet on the right page and is MIDEN_E2E_TEST=true baked into the build?
   at IosWalletPage.triggerNavbarAction (playwright/e2e/ios/helpers/ios-wallet-page.ts:466)
   at IosWalletPage.claimAllNotes (playwright/e2e/ios/helpers/ios-wallet-page.ts:283)
```

## What I confirmed before changing anything

- **`MIDEN_E2E_TEST=true` IS being baked into the iOS bundle.** Built locally with the same `cross-env MIDEN_E2E_TEST=true MIDEN_NETWORK=devnet yarn mobile:sync` chain and grep'd `dist/mobile/mobile.js` — the `__TEST_TRIGGER_NAVBAR_ACTION__=()=>zX?(zX(),true):false` string is present. So the hook IS installed.
- **State at failure (from CI artifact `report.json`)**: wallet A is on `#/receive` with `status: Ready`, but `balances: [{faucetId: "", symbol: "Unknown", amount: "0"}]` — i.e. wallet hasn't surfaced the minted note.
- **60s should be enough** for devnet block-time (~5s) + RPC indexing + a single wallet auto-sync tick (every 3s on mobile). So the "the network is slow" explanation alone doesn't add up either.

Both of the two obvious hypotheses fit the data partially but not cleanly:
1. The hook isn't installed → contradicted by the local build inspection above
2. The wallet's auto-sync is silently broken or stalled → not enough evidence; the existing error message can't distinguish this from #1

## What this PR does

Replace the bare timeout error with a diagnostic snapshot captured from the WebView at the moment of timeout:

```
diag={"hookInstalled":true,"hash":"#/receive","status":"Ready","balanceFaucetIds":[""],"balanceAmounts":["0"],"claimableNotesCount":0}
```

The error message now spells out the three failure modes:

- `hookInstalled=false` ⇒ MIDEN_E2E_TEST not baked into the build (so the `if (process.env.MIDEN_E2E_TEST === 'true' …)` guard at `lib/dapp-browser/use-native-navbar-action.ts:78` evaluated to false)
- `hookInstalled=true + amounts all 0` ⇒ wallet sync didn't surface the minted note (auto-sync stalled, RPC indexing slow, or something between)
- `hash != '#/receive'` ⇒ navigation didn't take

Next CI failure will tell us exactly which one. Then we can fix the real root cause instead of guessing with a timeout bump (which the user explicitly pushed back on — and rightly so, 60s really should be enough).

## Not in this PR

No timeout change, no wallet code change, no test-flow restructure. Diagnostic-only. The plan is: ship this, watch a CI failure capture the diag, then open the actual fix PR with full context.

## Test plan

- [ ] Mobile E2E (devnet) — either passes (intermittent flake, fine) or fails with structured `diag={…}` payload
- [ ] Mobile E2E (testnet) — same
- [ ] Chrome E2E unaffected (helper is iOS-only)