### PR TITLE
fix(ci): use pull_request_target so linked-web-sdk-pr gate works for fork PRs

### DIFF
--- a/.github/workflows/check-linked-web-sdk-pr.yml
+++ b/.github/workflows/check-linked-web-sdk-pr.yml
@@ -32,7 +32,25 @@ name: Linked web-sdk PR ready
 #   - Status context: `linked-web-sdk-pr-ready`.
 
 on:
-  pull_request:
+  # `pull_request_target` (not `pull_request`) so the gate works for PRs
+  # from forks. GitHub gives the workflow's GITHUB_TOKEN read-only perms
+  # on `pull_request` events from forks for security reasons, regardless
+  # of what `permissions:` declares below. That makes the
+  # `POST /repos/.../statuses/<sha>` call 403, and the workflow fails on
+  # any fork PR — including ones that have no Web SDK PR marker and just
+  # need the gate to post `success`.
+  #
+  # `pull_request_target` runs in the base repo's context with the base
+  # repo's permissions, so the token can write statuses. This is the
+  # standard pattern for "I need to post a check result on a fork PR."
+  #
+  # SAFETY: `pull_request_target` is only safe when the workflow does NOT
+  # execute PR-supplied code. This one doesn't — it only reads metadata
+  # via `gh api` and posts a status. `actions/checkout` defaults to the
+  # base ref under `pull_request_target` (so the workflow file itself is
+  # the merged main version, not whatever the PR author shipped), and we
+  # don't run any of the PR's code or scripts.
+  pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review]
   # Re-evaluate on a schedule so the check goes green when upstream
   # catches up (web-sdk PR merges and a release tag covers it), without


### PR DESCRIPTION
## Problem

The `linked-web-sdk-pr-ready` workflow fails on PRs from forks — the `GITHUB_TOKEN` is read-only on `pull_request` events from forks (GitHub security policy, can't be overridden by the workflow's `permissions:` declaration), so the `POST /repos/.../statuses/<sha>` call 403s and the workflow exits 1. This happens even for fork PRs with no `Web SDK PR: #N` marker, which just need the gate to post a default `success`.

This is the same fix as web-sdk's [`fix(ci): use pull_request_target so linked-client-pr gate works for fork PRs`](https://github.com/0xMiden/web-sdk/pull/new/wiktor/fix-linked-pr-status-perms) — the wallet's `check-linked-web-sdk-pr.yml` was modeled on web-sdk's `check-linked-client-pr.yml` and inherited the same bug.

## Fix

Swap the trigger from `pull_request` → `pull_request_target`. Runs in the base repo's context with base-repo permissions, so the token can post statuses. Same matrix expression works since the event payload exposes `github.event.pull_request.number` identically.

## Why this is safe

`pull_request_target` is only dangerous when the workflow executes PR-supplied code. This one only reads metadata via `gh api` and posts a status — no PR code runs, no PR scripts are sourced, `actions/checkout` defaults to base ref.

## Test plan

- [ ] First fork PR after this lands posts `linked-web-sdk-pr-ready: success` automatically when the PR has no marker.
- [ ] PRs from same-repo branches keep working.
- [ ] PRs with a real `Web SDK PR: #N` marker still gate on the linked PR's merge + release state.