### PR TITLE
fix(ios-e2e): correct CDP console listener + enrich navbar-action diag

### DIFF
--- a/playwright/e2e/ios/helpers/cdp-bridge.ts
+++ b/playwright/e2e/ios/helpers/cdp-bridge.ts
@@ -139,21 +139,31 @@ export class CdpSession {
 
   /**
    * Subscribe to console.* output from the page. Returns an unsubscribe fn.
+   *
+   * Wire-format note: appium-remote-debugger pre-extracts `params.message`
+   * from `Console.messageAdded` events and passes it as the SECOND listener
+   * argument (the first is an Error, undefined for normal messages). See
+   * `node_modules/appium-remote-debugger/lib/rpc/rpc-message-handler.ts`
+   * case `'Console.messageAdded'`: `args = [params?.message]`, then
+   * `emit(name, error, ...args)`. The previous shape `(event) => event.params.message`
+   * was wrong — `event` was the Error slot, always undefined, so every
+   * console message was silently dropped.
    */
   onConsoleLog(cb: (entry: CdpConsoleEntry) => void): () => void {
     this.consoleListeners.push(cb);
     if (this.consoleListeners.length === 1) {
-      (this.rd as unknown as ConsoleCapable).startConsole((event: WebKitConsoleEvent) => {
-        const m = event?.params?.message;
-        if (!m) return;
-        const entry: CdpConsoleEntry = {
-          level: m.level ?? 'log',
-          text: extractConsoleText(m),
-          ts: m.timestamp ?? Date.now(),
-          source: m.source,
-        };
-        for (const listener of this.consoleListeners) listener(entry);
-      });
+      (this.rd as unknown as ConsoleCapable).startConsole(
+        (_error: Error | undefined, m: WebKitConsoleMessage | undefined) => {
+          if (!m) return;
+          const entry: CdpConsoleEntry = {
+            level: m.level ?? 'log',
+            text: extractConsoleText(m),
+            ts: m.timestamp ?? Date.now(),
+            source: m.source,
+          };
+          for (const listener of this.consoleListeners) listener(entry);
+        }
+      );
     }
     return () => {
       this.consoleListeners = this.consoleListeners.filter(l => l !== cb);
@@ -260,27 +270,25 @@ interface SelectPageCapable {
   selectPage(appKey: string, pageNum: number): Promise<void>;
 }
 interface ConsoleCapable {
-  startConsole(listener: (event: WebKitConsoleEvent) => void): void;
+  startConsole(
+    listener: (error: Error | undefined, message: WebKitConsoleMessage | undefined) => void
+  ): void;
   stopConsole(): void;
 }
 
-interface WebKitConsoleEvent {
-  params?: {
-    message?: {
-      level?: string;
-      text?: string;
-      source?: string;
-      timestamp?: number;
-      parameters?: Array<{ value?: unknown; description?: string }>;
-    };
-  };
+interface WebKitConsoleMessage {
+  level?: string;
+  text?: string;
+  source?: string;
+  timestamp?: number;
+  parameters?: Array<{ value?: unknown; description?: string }>;
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise(r => setTimeout(r, ms));
 }
 
-function extractConsoleText(m: NonNullable<WebKitConsoleEvent['params']>['message']): string {
+function extractConsoleText(m: WebKitConsoleMessage | undefined): string {
   if (!m) return '';
   if (m.text) return m.text;
   if (m.parameters) {

--- a/playwright/e2e/ios/helpers/ios-wallet-page.ts
+++ b/playwright/e2e/ios/helpers/ios-wallet-page.ts
@@ -478,6 +478,10 @@ export class IosWalletPage implements WalletPage {
         balanceFaucetIds: string[];
         balanceAmounts: string[];
         claimableNotesCount: number | null;
+        isSyncing: boolean | null;
+        hasCompletedInitialSync: boolean | null;
+        lastSyncedAt: number | null;
+        msSinceLastSync: number | null;
       } | null>(
         `try {` +
           `  var s = window.__TEST_STORE__; ` +
@@ -494,13 +498,18 @@ export class IosWalletPage implements WalletPage {
           `    } ` +
           `  } ` +
           `  var notes = (st && st.claimableNotes) || (st && st.notes) || null; ` +
+          `  var lastSync = st && typeof st.lastSyncedAt === 'number' ? st.lastSyncedAt : null; ` +
           `  return {` +
           `    hookInstalled: typeof window.__TEST_TRIGGER_NAVBAR_ACTION__ === 'function',` +
           `    hash: location.hash || '',` +
           `    status: st ? st.status : null,` +
           `    balanceFaucetIds: faucetIds,` +
           `    balanceAmounts: amounts,` +
-          `    claimableNotesCount: Array.isArray(notes) ? notes.length : null` +
+          `    claimableNotesCount: Array.isArray(notes) ? notes.length : null,` +
+          `    isSyncing: st ? !!st.isSyncing : null,` +
+          `    hasCompletedInitialSync: st ? !!st.hasCompletedInitialSync : null,` +
+          `    lastSyncedAt: lastSync,` +
+          `    msSinceLastSync: lastSync ? Date.now() - lastSync : null` +
           `  }; ` +
           `} catch (e) { return null; }`
       )


### PR DESCRIPTION
The console-capture wiring in #238 is structurally correct but never produced any \`browser_console\` events — the listener arg shape was wrong. \`appium-remote-debugger\` pre-extracts \`params.message\` from \`Console.messageAdded\` and emits the listener as \`(error, message)\`. Our handler read \`event.params.message\` from arg 1, which was actually the \`Error\` slot (always undefined), so every console message was silently dropped (confirmed by inspecting the empty \`browser_console\` category in run \`25777562755\` artifacts).

This PR:
1. Corrects the listener signature in \`CdpBridge.onConsoleLog\` so wallet console output actually lands in the timeline.
2. Adds \`isSyncing\`, \`hasCompletedInitialSync\`, \`lastSyncedAt\`, \`msSinceLastSync\` to the \`triggerNavbarAction\` failure diagnostic so the cause of the persistent claim_wallet_a flake is decidable without browser logs: did auto-sync run at all (\`lastSyncedAt = null\`), is it still running (\`isSyncing = true\` for the full window), is sync running but not finding the note (small \`msSinceLastSync\` + null notes), or is the timer stalled?

Still does NOT fix the underlying flake — adds the diagnostics needed to actually root-cause it on the next run.

## Test plan
- [ ] PR Tests green
- [ ] After merge, the next Mobile E2E failure on main shows: (a) actual \`browser_console\` events from the wallet, (b) sync-progress fields in the triggerNavbarAction error message.