### PR TITLE
fix(ci): decouple miden-client-cli version from JS SDK pin

### DIFF
--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -70,7 +70,16 @@ jobs:
       - name: Install miden-client-cli
         shell: bash
         run: |
-          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          # Decoupled from the JS SDK version — read the pinned CLI version
+          # from package.json's `midenClientCliVersion` field. See
+          # playwright/e2e/helpers/miden-cli.ts for the matching local-dev
+          # path. The miden-client Rust workspace and @miden-sdk/* npm
+          # packages release independently; coupling them was brittle.
+          VERSION=$(node -p "require('./package.json').midenClientCliVersion")
+          if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
+            echo "::error::midenClientCliVersion missing from package.json"
+            exit 1
+          fi
           if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
             echo "miden-client already present from cache:"
             "$HOME/.cargo/bin/miden-client" --version || true
@@ -126,7 +135,16 @@ jobs:
       - name: Install miden-client-cli
         shell: bash
         run: |
-          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          # Decoupled from the JS SDK version — read the pinned CLI version
+          # from package.json's `midenClientCliVersion` field. See
+          # playwright/e2e/helpers/miden-cli.ts for the matching local-dev
+          # path. The miden-client Rust workspace and @miden-sdk/* npm
+          # packages release independently; coupling them was brittle.
+          VERSION=$(node -p "require('./package.json').midenClientCliVersion")
+          if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
+            echo "::error::midenClientCliVersion missing from package.json"
+            exit 1
+          fi
           if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
             echo "miden-client already present from cache:"
             "$HOME/.cargo/bin/miden-client" --version || true
@@ -206,7 +224,16 @@ jobs:
       - name: Install miden-client-cli
         shell: bash
         run: |
-          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          # Decoupled from the JS SDK version — read the pinned CLI version
+          # from package.json's `midenClientCliVersion` field. See
+          # playwright/e2e/helpers/miden-cli.ts for the matching local-dev
+          # path. The miden-client Rust workspace and @miden-sdk/* npm
+          # packages release independently; coupling them was brittle.
+          VERSION=$(node -p "require('./package.json').midenClientCliVersion")
+          if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
+            echo "::error::midenClientCliVersion missing from package.json"
+            exit 1
+          fi
           if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
             echo "miden-client already present from cache:"
             "$HOME/.cargo/bin/miden-client" --version || true
@@ -294,7 +321,16 @@ jobs:
       - name: Install miden-client-cli
         shell: bash
         run: |
-          VERSION=$(node -p "require('./node_modules/@miden-sdk/miden-sdk/package.json').version")
+          # Decoupled from the JS SDK version — read the pinned CLI version
+          # from package.json's `midenClientCliVersion` field. See
+          # playwright/e2e/helpers/miden-cli.ts for the matching local-dev
+          # path. The miden-client Rust workspace and @miden-sdk/* npm
+          # packages release independently; coupling them was brittle.
+          VERSION=$(node -p "require('./package.json').midenClientCliVersion")
+          if [[ -z "$VERSION" || "$VERSION" == "undefined" ]]; then
+            echo "::error::midenClientCliVersion missing from package.json"
+            exit 1
+          fi
           if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
             echo "miden-client already present from cache:"
             "$HOME/.cargo/bin/miden-client" --version || true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "midenClientCliVersion": "0.14.8",
   "scripts": {
     "postinstall": "rimraf node_modules/@miden-sdk/react/node_modules && patch-package",
     "start": "yarn watch:src",

--- a/playwright/e2e/helpers/miden-cli.ts
+++ b/playwright/e2e/helpers/miden-cli.ts
@@ -15,7 +15,12 @@ symbol = "TST"
  * Resolve the miden-client binary path.
  * 1. MIDEN_CLIENT_BIN env var
  * 2. `miden-client` in PATH
- * 3. Auto-install from crates.io at the version matching the wallet's SDK
+ * 3. Auto-install from crates.io at the pinned `midenClientCliVersion` from
+ *    the root package.json (decoupled from the JS SDK version — the
+ *    miden-client Rust workspace and `@miden-sdk/*` npm packages release on
+ *    independent cadences, so version-matching them was brittle: a JS-only
+ *    SDK bump would request a CLI version that doesn't exist on crates.io
+ *    and CI would fail before the test even ran).
  */
 export function resolveCliPath(): string {
   // 1. Explicit override
@@ -31,16 +36,17 @@ export function resolveCliPath(): string {
     // not found
   }
 
-  // 3. Auto-install from crates.io
+  // 3. Auto-install from crates.io at the version pinned in package.json
   let version: string;
   try {
-    const sdkPkgPath = path.resolve('node_modules/@miden-sdk/miden-sdk/package.json');
-    const sdkPkg = JSON.parse(fs.readFileSync(sdkPkgPath, 'utf8'));
-    version = sdkPkg.version;
-  } catch {
-    throw new Error(
-      'Cannot determine miden-sdk version from node_modules. Run `yarn install` first.'
-    );
+    const pkgPath = path.resolve('package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    version = pkg.midenClientCliVersion;
+    if (!version || typeof version !== 'string') {
+      throw new Error('midenClientCliVersion missing from package.json');
+    }
+  } catch (err: any) {
+    throw new Error(`Cannot resolve midenClientCliVersion from package.json: ${err.message}`);
   }
 
   console.log(`Installing miden-client-cli@${version} from crates.io (first run only)...`);


### PR DESCRIPTION
The E2E \`Install miden-client-cli\` step did \`cargo install miden-client-cli --version \$VERSION\` where \`\$VERSION\` was \`require('./node_modules/@miden-sdk/miden-sdk/package.json').version\`. That worked while web-sdk and the miden-client Rust workspace released in lockstep, but #240's SDK bump 0.14.8 → 0.14.9 was a JS-only patch (\`useWorker\` opt-out + \`newCallbackProver\`); the matching CLI 0.14.9 was never released on crates.io. CI then fails before tests even run with:

\`\`\`
error: could not find \`miden-client-cli\` in registry \`crates-io\` with version \`=0.14.9\`
\`\`\`

(Confirmed in E2E Blockchain run 25785074488 on main commit \`e1853d8a\`.)

Fix: add an explicit \`midenClientCliVersion\` field in \`package.json\` (single source of truth) and read it from BOTH the workflow YAML and \`playwright/e2e/helpers/miden-cli.ts\`. The CLI version is now bumped independently — when the miden-client repo cuts a release we want to track, that's a one-line edit to \`package.json\`.

Pinning to \`0.14.8\` matches the latest published CLI today (\`curl -s 'https://crates.io/api/v1/crates/miden-client-cli' | jq .crate.max_version\` → \`"0.14.8"\`).

## Test plan
- [ ] PR Tests green
- [ ] After merge, E2E Blockchain on main reaches the actual test step (no longer fails at \`Install miden-client-cli\`)