### PR TITLE
chore(release): bump wallet to 1.14.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "private": true,
   "engines": {
     "node": ">=22.0.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Miden Wallet",
-  "version": "1.14.3",
+  "version": "1.14.4",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",


### PR DESCRIPTION
Bumps both \`package.json\` and \`public/manifest.json\` to 1.14.4.

The \`## 1.14.4 (TBD)\` CHANGELOG section is already populated by prior merged PRs:
- #195 — private key export & import
- #203 — transaction-complete modal polish, mobile boot, dark-flash fix
- #218 — auto-dismiss transaction modal on user navigation
- #230 — multi-threaded local proving + speculative pre-prove
- #231 — Linked Web SDK PR pattern
- #240 — \`useWorker: false\` on mobile (sync hang fix)
- #241 — decouple miden-client-cli version from JS SDK pin

## Test plan
- [ ] PR Tests green