### PR TITLE
fix(send-flow): dismiss stale completion modal on send-flow entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.14.5 (TBD)
+
+### Fixes
+
+* [FIX][all] Stale transaction-completion modal no longer blocks subsequent sends. After PR #230 the `TransactionProgressModal` auto-dismiss was correctly gated on terminal-state signals so the "Tx Completed → View on Midenscan" screen wouldn't be ripped away when the success-path `navigate('/')` fires after a long local prove — but with no other dismissal path the modal stayed up as a full-viewport `zIndex: 9999` overlay until the user explicitly tapped **Done**. Stress tests (and any user starting a second send before tapping Done) navigated to `/send`, found the SelectToken tile blocked behind the modal, and saw `locator.click` time out against `getByTestId('send-flow').locator('div.cursor-pointer')` in 80–99.5% of attempts. `SendManager` now closes any stale completion modal on entry — an explicit "starting a new tx" signal equivalent to tapping Done. In-flight modals (where `lastCompletedTxHash` is still null) are untouched.
+
 ## 1.14.4 (TBD)
 
 ### Fixes

--- a/src/screens/send-flow/SendManager.tsx
+++ b/src/screens/send-flow/SendManager.tsx
@@ -125,6 +125,34 @@ export const SendManager: React.FC<SendManagerProps> = ({ preselectedTokenId }) 
     return true;
   }, [cardStack.length, goBack, onClose]);
 
+  // Dismiss any stale completion modal on send-flow entry.
+  //
+  // After PR #230, the TransactionProgressModal auto-dismiss is gated on
+  // `lastCompletedTxHash !== null` so a successful tx's "Done" screen stays
+  // visible until the user explicitly taps Done. The modal renders as
+  // `fixed inset-0` with `zIndex: 9999` and no `pointer-events: none` —
+  // so while it's open it intercepts every click in the viewport.
+  //
+  // In a stress test (and in any user flow that starts a second send
+  // without first dismissing the modal), navigating to `/send` while the
+  // previous tx's completion modal is still up blocks the SelectToken
+  // tile from being clicked — Playwright sees `locator.click` time out
+  // against `getByTestId('send-flow').locator('div.cursor-pointer')`.
+  //
+  // Entering /send is a clear "I'm starting a new transaction" signal,
+  // equivalent to tapping Done on the previous completion. We only clear
+  // when `lastCompletedTxHash !== null` so in-flight modals (where the
+  // user has navigated mid-tx) are not touched.
+  useEffect(() => {
+    const state = useWalletStore.getState();
+    if (state.lastCompletedTxHash !== null) {
+      state.closeTransactionModal(true);
+      state.setLastCompletedTxHash(null);
+    }
+    // Intentionally empty deps — run once on send-flow entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const onGenerateTransaction = useCallback(async () => {
     // On mobile, open the modal and go back to home
     // The modal handles the entire transaction flow


### PR DESCRIPTION
## Summary

Stress tests at `ee1fca41b` are stalling at ~80–99.5% click-timeout rate. Root cause: the transaction-completion modal stays up as a full-viewport `zIndex: 9999` overlay until the user explicitly taps **Done**, blocking subsequent send-flow clicks. This PR makes `SendManager` dismiss any stale completion modal on entry — an explicit "starting a new tx" signal equivalent to tapping Done.

## Root cause

PR #230 added this gate to `TransactionProgressModal.tsx`'s auto-dismiss effect:

```ts
if (transactionComplete || hasErrors || lastCompletedTxHash !== null) return;
```

The intent was correct: don't auto-dismiss while the user is staring at the "Tx Completed → View on Midenscan" screen, because the success-path `navigate('/')` fires 5–10 s after open (after the local prove) and would otherwise close the modal before the user can see the completion. But there is no other dismissal path — `lastCompletedTxHash` is only cleared by `SendManager.onSubmit` at the start of the *next* send.

Combined with the modal's existing layout (`fixed inset-0`, `zIndex: 9999`, no `pointer-events: none` on the overlay), this means the previous tx's completion modal sits on top of `/send` after the test navigates to start the next send, and Playwright's actionability check on `getByTestId('send-flow').locator('div.cursor-pointer').first()` fails: the element is intercepted by the modal overlay.

QA's symptom signature fits exactly:
- Identical signature: `locator.click: Timeout 30000ms exceeded on getByTestId('send-flow').locator('div.cursor-poin…')` — same blocked tile every time
- Rate scales with how many txs each run completes successfully (80–99.5% means almost every send after the first)
- Sync RPCs healthy throughout — not a network/chain issue
- Conservation held on the ops that completed — the txs themselves succeed; their *success* is what produces the sticky modal

Verified the diagnosis by reading the modal layout (`TransactionProgressModal.tsx:215`, `:218`), the SendManager success-path hash plumbing (`SendManager.tsx:269`), and the harness selector (`playwright/e2e/helpers/wallet-page.ts:903–917`).

## Fix

`SendManager.tsx` — single `useEffect` on mount:

```ts
useEffect(() => {
  const state = useWalletStore.getState();
  if (state.lastCompletedTxHash !== null) {
    state.closeTransactionModal(true);
    state.setLastCompletedTxHash(null);
  }
}, []);
```

Semantics: entering `/send` is an explicit "I'm starting a new transaction," equivalent to tapping Done on the previous completion modal. The `lastCompletedTxHash !== null` guard ensures in-flight modals (where the user has navigated mid-tx) are not touched.

PR #230's intent — keep the completion screen visible after a long local prove — is preserved: the user lands on the completion screen, the modal stays until they choose to start a new send-flow.

## Verification

- `yarn lint` — clean
- `yarn format` — clean
- `npx tsc --noEmit` — clean
- `yarn test` — 1865/1865 pass
- `yarn build` — succeeds

## Test plan

- [ ] Stress harness re-run against this branch — expected: click-timeout rate drops to baseline
- [ ] Manual: send a tx → land on completion → enter `/send` again → SelectToken tile is clickable
- [ ] Manual: open send-flow with no prior tx → no change from current behavior

## Notes

- This is a targeted fix that does NOT undo PR #230's auto-dismiss gating. The gating still applies for users who stay on the completion screen.
- A follow-up could consider whether the modal overlay should be `pointer-events: none` so it can't block anything underneath even when present — but that's a separate UX/design call.
