### PR TITLE
docs(privacy): rename 'Miden Labs' → 'Miden' to match Play Console developer identity

### DIFF
--- a/docs/privacy/index.md
+++ b/docs/privacy/index.md
@@ -7,11 +7,11 @@ permalink: /privacy/
 
 _Last updated: 2026-05-28_
 
-Miden Wallet ("the App") is a non-custodial cryptocurrency wallet for the Miden blockchain, published by Miden Labs.
+Miden Wallet ("the App") is a non-custodial cryptocurrency wallet for the Miden blockchain, published by Miden.
 
 ## Data we collect
 
-**None.** Miden Labs does not collect, transmit, or store any data about you on our servers. The App has no user accounts, no analytics SDKs, no crash reporters, and no advertising identifiers. We never see your wallet contents.
+**None.** Miden does not collect, transmit, or store any data about you on our servers. The App has no user accounts, no analytics SDKs, no crash reporters, and no advertising identifiers. We never see your wallet contents.
 
 ## How the App uses your device
 


### PR DESCRIPTION
## Summary

The Play Console developer account is registered publicly as `Miden`. The live privacy policy at https://0xmiden.github.io/wallet/privacy/ referred to `Miden Labs` — a fabrication from when I drafted the original policy.

Play Store reviewers cross-reference developer identity across the listing, privacy policy, and Data safety form. A name mismatch is a documented cause of mid-review comeback requests, adding 2-5 days per cycle.

This 2-line change replaces both occurrences of `Miden Labs` with `Miden` in `docs/privacy/index.md`. No substantive change to any privacy claim.

## Diff

```
-Miden Wallet ('the App') is a non-custodial cryptocurrency wallet for the Miden blockchain, published by Miden Labs.
+Miden Wallet ('the App') is a non-custodial cryptocurrency wallet for the Miden blockchain, published by Miden.

-**None.** Miden Labs does not collect, transmit, or store any data about you on our servers.
+**None.** Miden does not collect, transmit, or store any data about you on our servers.
```

## Activation

Once merged, GitHub Pages auto-redeploys to https://0xmiden.github.io/wallet/privacy/ within 1-2 min.

Note: v1.14.5 is already submitted to Play Store Production review. This change applies to the live policy URL that reviewers see — they fetch the URL at review time, not at submission time, so this fix applies to the in-flight review as long as it lands before they parse the policy.