### PR TITLE
fix(dapp): dispatch requestTransaction by type so consume/send work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* [FIX][dapp] **Generalized `requestTransaction` now handles `send` / `consume`, not just `custom`.** A dApp consuming a note through the typed `Transaction(TransactionType.Consume, new ConsumeTransaction(...))` API (rather than the dedicated `requestConsume`) hit `INVALID_PARAMS: Invalid CustomTransaction payload`: the wallet's `requestTransaction` handler (`generatePromisifyTransaction` in `src/lib/miden/back/dapp.ts`) read `req.transaction.payload` and validated it as a `MidenCustomTransaction` unconditionally, ignoring the tagged `MidenTransaction.type`. It now dispatches by `type` — `send` delegates to the send flow (`generatePromisifySendTransaction`) and `consume` to the consume flow (`generatePromisifyConsumeTransaction`), reusing their existing preview / confirmation / execution paths, while `custom` (and bare/legacy payloads) keep flowing through the custom path. The `type` discriminant is compared by its wire string value rather than importing the adapter-base `TransactionType` enum (that package is ESM-only and consumed type-only here). Fixes [0xMiden/wallet-adapter#88](https://github.com/0xMiden/wallet-adapter/issues/88).
+
 ## 1.14.5 (2026-05-28)
 
 ### Fixes

--- a/src/lib/miden/back/dapp.extended.test.ts
+++ b/src/lib/miden/back/dapp.extended.test.ts
@@ -398,6 +398,54 @@ describe('requestTransaction', () => {
       } as never)
     ).rejects.toThrow(MidenDAppErrorType.InvalidParams);
   });
+
+  it('routes a Consume-typed transaction to the consume flow instead of failing as a custom payload (issue #88)', async () => {
+    mockGetTokenMetadata.mockResolvedValue({ decimals: 6, symbol: 'TOK' });
+    mockInitiateConsumeTransactionFromId.mockResolvedValue('tx-consume-1');
+    const res = await dapp.requestTransaction('https://miden.xyz', {
+      type: MidenDAppMessageType.TransactionRequest,
+      sourcePublicKey: 'miden-account-1',
+      transaction: {
+        type: 'consume',
+        payload: {
+          accountAddress: 'miden-account-1',
+          noteId: 'note-1',
+          faucetId: 'faucet-1',
+          noteType: 'Private',
+          amount: '50'
+        }
+      }
+    } as never);
+    // Response is normalized to a TransactionResponse, and the dedicated
+    // consume execution path runs (not the CustomTransaction validation).
+    expect(res.type).toBe(MidenDAppMessageType.TransactionResponse);
+    expect((res as any).transactionId).toBe('tx-consume-1');
+    expect(mockInitiateConsumeTransactionFromId).toHaveBeenCalled();
+    expect(mockRequestCustomTransaction).not.toHaveBeenCalled();
+  });
+
+  it('routes a Send-typed transaction to the send flow', async () => {
+    mockInitiateSendTransaction.mockResolvedValue('tx-send-1');
+    const res = await dapp.requestTransaction('https://miden.xyz', {
+      type: MidenDAppMessageType.TransactionRequest,
+      sourcePublicKey: 'miden-account-1',
+      transaction: {
+        type: 'send',
+        payload: {
+          senderAddress: 'miden-account-1',
+          recipientAddress: 'bob',
+          faucetId: 'faucet-1',
+          noteType: 'Private',
+          amount: '100',
+          recallBlocks: 50
+        }
+      }
+    } as never);
+    expect(res.type).toBe(MidenDAppMessageType.TransactionResponse);
+    expect((res as any).transactionId).toBe('tx-send-1');
+    expect(mockInitiateSendTransaction).toHaveBeenCalled();
+    expect(mockRequestCustomTransaction).not.toHaveBeenCalled();
+  });
 });
 
 // ── requestSendTransaction ─────────────────────────────────────────

--- a/src/lib/miden/back/dapp.ts
+++ b/src/lib/miden/back/dapp.ts
@@ -899,6 +899,46 @@ const generatePromisifyTransaction = async (
   req: MidenDAppTransactionRequest,
   sessionId?: string
 ) => {
+  // The generalized TransactionRequest carries a tagged `MidenTransaction`
+  // ({ type, payload }). A `send`/`consume` payload is not a custom-transaction
+  // payload, so delegate those to their dedicated flows (preview, confirmation
+  // UI and execution) instead of validating them as a CustomTransaction —
+  // otherwise they fail with "Invalid CustomTransaction payload". Only `custom`
+  // (and bare/legacy payloads) fall through to the custom flow below. Issue #88.
+  // `req.transaction.type` is a string enum from `MidenTransaction`
+  // ('send' | 'consume' | 'custom'). Compare by value rather than importing
+  // the `TransactionType` enum as a runtime value: adapter-base is consumed
+  // type-only in this module, and its runtime exports aren't loadable in the
+  // unit-test (jest) setup. The string values are part of the dApp↔wallet
+  // wire contract, so they're stable.
+  const type: string = req.transaction.type;
+  if (type === 'send') {
+    return generatePromisifySendTransaction(
+      value =>
+        resolve({
+          type: MidenDAppMessageType.TransactionResponse,
+          transactionId: (value as MidenDAppSendTransactionResponse).transactionId
+        }),
+      reject,
+      dApp,
+      { ...req, transaction: req.transaction.payload } as unknown as MidenDAppSendTransactionRequest,
+      sessionId
+    );
+  }
+  if (type === 'consume') {
+    return generatePromisifyConsumeTransaction(
+      value =>
+        resolve({
+          type: MidenDAppMessageType.TransactionResponse,
+          transactionId: (value as MidenDAppConsumeResponse).transactionId
+        }),
+      reject,
+      dApp,
+      { ...req, transaction: req.transaction.payload } as unknown as MidenDAppConsumeRequest,
+      sessionId
+    );
+  }
+
   const id = nanoid();
   const networkRpc = await getNetworkRPC(dApp.network);
 


### PR DESCRIPTION
Wallet-side fix for [0xMiden/wallet-adapter#88](https://github.com/0xMiden/wallet-adapter/issues/88) (paired with the adapter-side fix [0xMiden/wallet-adapter#91](https://github.com/0xMiden/wallet-adapter/pull/91)).

## Problem

A dApp consuming a note through the **generalized** transaction API:

```tsx
await requestTransaction(
  new Transaction(TransactionType.Consume, new ConsumeTransaction(...)),
);
```

fails with:

```
WalletTransactionError: INVALID_PARAMS: Error: INVALID_PARAMS: Invalid CustomTransaction payload
```

even though the dedicated `requestConsume` path works.

## Root cause

The wallet's `requestTransaction` handler (`generatePromisifyTransaction` in `src/lib/miden/back/dapp.ts`) ignored the tagged `MidenTransaction.type` and validated `req.transaction.payload` as a `MidenCustomTransaction` unconditionally:

```ts
const { payload } = req.transaction;
const customTransaction = payload as MidenCustomTransaction;
if (!customTransaction.address || !customTransaction.transactionRequest) {
  throw new Error(`${MidenDAppErrorType.InvalidParams}: Invalid CustomTransaction payload`);
}
```

So a `consume` (or `send`) payload — which has no `address` / `transactionRequest` — was rejected. The wallet already has dedicated `generatePromisifySendTransaction` / `generatePromisifyConsumeTransaction` flows; the generalized handler just never routed to them.

## Fix

Dispatch by `req.transaction.type` at the top of `generatePromisifyTransaction`:

| `type` | routed to |
|---|---|
| `send` | `generatePromisifySendTransaction` |
| `consume` | `generatePromisifyConsumeTransaction` |
| `custom` / bare-legacy (default) | existing custom path (unchanged) |

Send/Consume reuse their existing preview, confirmation-UI and execution flows; the delegated response is normalized to a `TransactionResponse`. The custom path is byte-identical to before.

### Why compare `type` by string

`type` is compared against the wire string values (`'send'` / `'consume'`) rather than importing the `TransactionType` enum from `@demox-labs/miden-wallet-adapter-base`. That package is ESM-only (`module` field, no `main`) and is consumed **type-only** everywhere else in this module; importing the enum as a runtime value makes it `undefined` under the jest/swc unit-test setup (`transformIgnorePatterns` skips it). The string values are part of the stable dApp↔wallet wire contract.

## Tests

`src/lib/miden/back/dapp.extended.test.ts` adds two cases under `requestTransaction`:
- a `consume`-typed transaction routes to the consume flow (asserts it does **not** fall into the CustomTransaction path) and resolves with a `TransactionResponse`;
- a `send`-typed transaction routes to the send flow.

## Verification

- `yarn ts` (tsc): clean.
- `yarn eslint` on changed files: clean.
- `yarn test:coverage` (full suite, the CI gate): **1871 passed / 130 suites**, exit 0 — the 95% global coverage threshold holds.
- Lockfile untouched.

## Note on the two fixes

The adapter-side fix (#91) already routes consume/send to the wallet's dedicated endpoints, so it resolves the reported bug for consumers using the adapter. This wallet-side change makes the generalized `requestTransaction` endpoint correct in its own right, so any dApp hitting it directly (or via a future/older adapter) also works. The two are complementary and each correct on its own.

Cross-repo issue, so this won't auto-close wallet-adapter#88 — leaving that to be closed once both land.