### PR TITLE
fix(loader): align default-color test with currentColor default

### DIFF
--- a/src/components/Loader.test.tsx
+++ b/src/components/Loader.test.tsx
@@ -27,10 +27,10 @@ describe('Loader', () => {
     expect(screen.getByTestId('icon')).toHaveAttribute('data-name', 'Loader');
   });
 
-  it('uses default color black', () => {
+  it('uses default color currentColor', () => {
     render(<Loader />);
 
-    expect(screen.getByTestId('icon')).toHaveAttribute('data-fill', 'black');
+    expect(screen.getByTestId('icon')).toHaveAttribute('data-fill', 'currentColor');
   });
 
   it('uses custom color when provided', () => {


### PR DESCRIPTION
## Summary

`Loader.test.tsx`'s "uses default color black" test has been failing on `main` (and therefore on every open PR) since #266.

#266 ("make loaders visible in dark mode") intentionally changed `Loader`'s default `color` from `'black'` to `'currentColor'` so the spinner inherits text color, but the unit test still asserted `data-fill="black"`. This updates the test to assert the intended `'currentColor'` default.

Unblocks the Test / Coverage CI jobs for all PRs to `main`.

## Verification

`Loader.test.tsx`: 9/9 pass.