### PR TITLE
fix(sync): stop false "Cannot reach the Miden node" banner on slow syncs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- [FIX][all] **The "Cannot reach the Miden node" banner no longer flaps on a slow-but-healthy node.** Two issues compounded: (1) `SYNC_TIMEOUT_MS` was 5s while a testnet sync can legitimately take 5-25s, so healthy syncs routinely tripped the watchdog — and the timeout never actually freed the WASM client mutex early (`withTimeout` only rejects the outer promise; the underlying `syncState` keeps running and holding the lock until it settles), so the aggressive ceiling bought nothing and only manufactured false failures; (2) `markConnectivityIssue` ran on the _first_ failure, before the circuit-breaker check, so a single slow sync surfaced "node unreachable" even while block height was still advancing. `SYNC_TIMEOUT_MS` is raised to 30s (a true wedged-sync watchdog), and the connectivity banner is now gated on the same `MAX_CONSECUTIVE_SYNC_FAILURES` (3) streak that opens the circuit breaker, so it only appears when the node is persistently unreachable and clears on the next successful sync. Reported in #252.
+
 ## 1.14.6 (2026-06-03)
 
 ### Fixes

--- a/src/lib/miden/back/sync-manager.test.ts
+++ b/src/lib/miden/back/sync-manager.test.ts
@@ -316,20 +316,50 @@ describe('doSync — connectivity categorization', () => {
     expect(mockClearReachabilityIssues).toHaveBeenCalled();
   });
 
-  it('marks node category on a transport-shaped sync error', async () => {
-    mockMarkConnectivityIssue.mockClear();
-    mockClient.syncState.mockRejectedValueOnce(new Error('rpc error: deadline exceeded'));
-    await doSync();
-    expect(mockMarkConnectivityIssue).toHaveBeenCalled();
-    const arg = mockMarkConnectivityIssue.mock.calls[0]?.[0];
-    expect(['network', 'node']).toContain(arg);
+  it('does NOT mark connectivity on a single transient sync failure (debounced)', async () => {
+    // A lone slow-but-healthy sync must not flap the "node unreachable" banner.
+    await jest.isolateModulesAsync(async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+      mockMarkConnectivityIssue.mockClear();
+      mockClient.syncState.mockReset();
+      mockClient.syncState.mockRejectedValueOnce(new Error('Sync timeout'));
+      const { doSync: isolated } = await import('./sync-manager');
+      await isolated();
+      expect(mockMarkConnectivityIssue).not.toHaveBeenCalled();
+    });
   });
 
-  it('does NOT mark connectivity for a semantic / non-transport error', async () => {
-    mockMarkConnectivityIssue.mockClear();
-    mockClient.syncState.mockRejectedValueOnce(new Error('something completely unrelated'));
-    await doSync();
-    expect(mockMarkConnectivityIssue).not.toHaveBeenCalled();
+  it('marks node category only after a sustained transport-error streak', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+      mockMarkConnectivityIssue.mockClear();
+      mockClient.syncState.mockReset();
+      mockClient.syncState.mockRejectedValue(new Error('rpc error: deadline exceeded'));
+      const { doSync: isolated } = await import('./sync-manager');
+      // First two failures stay silent (debounced)…
+      await isolated();
+      await isolated();
+      expect(mockMarkConnectivityIssue).not.toHaveBeenCalled();
+      // …the 3rd consecutive failure trips the breaker and surfaces the banner.
+      await isolated();
+      expect(mockMarkConnectivityIssue).toHaveBeenCalled();
+      const arg = mockMarkConnectivityIssue.mock.calls[0]?.[0];
+      expect(['network', 'node']).toContain(arg);
+    });
+  });
+
+  it('does NOT mark connectivity for a semantic / non-transport error even when sustained', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.spyOn(console, 'warn').mockImplementation();
+      mockMarkConnectivityIssue.mockClear();
+      mockClient.syncState.mockReset();
+      mockClient.syncState.mockRejectedValue(new Error('something completely unrelated'));
+      const { doSync: isolated } = await import('./sync-manager');
+      await isolated();
+      await isolated();
+      await isolated();
+      expect(mockMarkConnectivityIssue).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/lib/miden/back/sync-manager.ts
+++ b/src/lib/miden/back/sync-manager.ts
@@ -21,14 +21,16 @@ import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 
 const ALARM_NAME = 'miden-sync';
 
-// syncState is capped aggressively. On testnet with slow RPC a single
-// syncState can legitimately take 5-25s; the previous 25s ceiling plus the
-// wasm-client mutex meant fetchBalances (triggered by the SelectToken TST
-// tile) could queue behind a sync long enough to exceed Playwright's 10s
-// click budget and cause UI timeouts under stress. 5s keeps the sync path
-// well below any UI click budget; if testnet RPC is genuinely slow, the
-// circuit breaker (below) trips and we back off rather than hammering.
-const SYNC_TIMEOUT_MS = 5_000;
+// Watchdog ceiling for a single syncState call. On testnet with slow RPC a
+// sync can legitimately take 5-25s, so this is set well above the typical
+// worst case: it exists to catch a genuinely wedged sync, not to cap a
+// slow-but-healthy one. Note this timeout does NOT release the WASM client
+// mutex early — withTimeout (below) only rejects the outer promise; the
+// underlying syncState keeps running and holding the lock until it truly
+// settles. So an aggressive ceiling buys nothing for lock contention and
+// merely turns healthy slow syncs into spurious "node unreachable" reports.
+// On a real breach the circuit breaker (below) trips and we back off.
+const SYNC_TIMEOUT_MS = 30_000;
 
 // Circuit breaker: after MAX_CONSECUTIVE_SYNC_FAILURES timeouts/errors in
 // a row we skip sync attempts for BACKOFF_MS, then allow one probe. A
@@ -106,16 +108,24 @@ async function runSync(): Promise<void> {
         `[SyncManager] syncState failed (${consecutiveSyncFailures}/${MAX_CONSECUTIVE_SYNC_FAILURES}):`,
         err
       );
-      // Categorize the sync failure as network (browser is offline) or
-      // node (we can reach the open net but the Miden RPC didn't answer).
-      // Skip semantic / non-transport errors so a malformed-response bug
-      // in the SDK doesn't masquerade as connectivity. Suppressing the
-      // synthetic `Sync timeout` from withTimeout is intentional —
-      // timeouts are themselves transport-shaped.
-      if (isLikelyNetworkError(err) || /sync timeout/i.test(String((err as any)?.message ?? err))) {
-        markConnectivityIssue(classifySyncError(err));
-      }
+      // Only surface a connectivity banner once failures are *sustained*.
+      // Testnet RPC syncs can legitimately run longer than the watchdog
+      // window, so a lone failure (especially a synthetic `Sync timeout`)
+      // routinely fires while the node is healthy and block height is still
+      // advancing; banner-ing on it produces a flapping false "node
+      // unreachable". Gate the banner on the same MAX_CONSECUTIVE_SYNC_FAILURES
+      // streak that opens the circuit breaker, so it only appears when the node
+      // is persistently unreachable. A later successful sync resets the counter
+      // and clears the banner via clearReachabilityIssues().
       if (consecutiveSyncFailures >= MAX_CONSECUTIVE_SYNC_FAILURES) {
+        // Categorize as network (browser is offline) or node (we reached the
+        // open net but the Miden RPC didn't answer). Skip semantic /
+        // non-transport errors so a malformed-response bug in the SDK doesn't
+        // masquerade as connectivity. The synthetic `Sync timeout` from
+        // withTimeout counts — timeouts are themselves transport-shaped.
+        if (isLikelyNetworkError(err) || /sync timeout/i.test(String((err as any)?.message ?? err))) {
+          markConnectivityIssue(classifySyncError(err));
+        }
         syncBackoffUntilMs = Date.now() + BACKOFF_MS;
         consecutiveSyncFailures = 0;
         console.warn(`[SyncManager] circuit breaker open — skipping syncs for ${BACKOFF_MS}ms`);


### PR DESCRIPTION
Closes #252.

## Problem

The header banner **"Cannot reach the Miden node — The node may be down or under heavy load. Your balance may be out of date."** flaps on a *healthy-but-slow* node (block height climbing the whole time). Two bugs compound, both shipped in v1.14.4:

### 1. `SYNC_TIMEOUT_MS = 5s` is below the real sync latency
The code's own comment notes a testnet `syncState` can legitimately take **5–25s**, so healthy syncs routinely tripped the 5s watchdog.

The stated rationale for the 5s cap — "keeps the sync path well below any UI click budget" — does not hold. `withTimeout` only rejects the **outer** promise; it never aborts `syncState()` and never releases the WASM client mutex (that releases in `withWasmClientLock`'s `finally`, which awaits the real operation). So the underlying sync keeps running and holding the lock for its full 5–25s regardless of the timeout value. The aggressive ceiling bought nothing for lock contention and only converted slow-but-healthy syncs into recorded failures.

### 2. The banner fired on the *first* failure
`markConnectivityIssue(classifySyncError(err))` ran **before** the 3-failure circuit-breaker check, so a single slow sync surfaced "node unreachable" — then a sub-5s sync cleared it → flapping.

## Fix (`src/lib/miden/back/sync-manager.ts`)

- **Raise `SYNC_TIMEOUT_MS` → 30s**: a true wedged-sync watchdog, comfortably above the 5–25s real range. Comment corrected to explain the timeout cannot free the mutex early.
- **Gate the banner on sustained failure**: move `markConnectivityIssue` inside the `>= MAX_CONSECUTIVE_SYNC_FAILURES` (3) block — the same streak that opens the circuit breaker. A genuinely-down node still surfaces after 3 consecutive failures (~9s at the 3s poll) and clears on the next successful sync.

## Out of scope

The issue's *secondary* hypothesis — the 3s poll × 4–6 RPCs brushing the node's 16 rps/IP limit — is left untouched: it measured ~2 rps avg / 0×429, so it isn't the cause of the flapping. A follow-up (jitter/coalesce/back-off-on-429) can address load separately.

## Verification

- `yarn ts` — clean
- `yarn lint` (`--max-warnings 0`) — clean
- `yarn test:coverage` (full suite, 95% gate) — **1882 passed**, gate green
- Tests updated/added: single transient failure → no banner; sustained 3-streak → banner; semantic (non-transport) error → never banners