### PR TITLE
chore(release): wallet 1.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.14.7 (2026-06-09)
 
 ### Fixes
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.miden.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11406001
-        versionName "1.14.6"
+        versionCode 11407001
+        versionName "1.14.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "private": true,
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
Prepares the **1.14.7** wallet release off `main`.

## What this bumps
- `package.json` version `1.14.6` → `1.14.7`
- `android/app/build.gradle`: versionCode `11406001` → `11407001`, versionName `1.14.6` → `1.14.7`
- CHANGELOG: promote `## Unreleased` → `## 1.14.7 (2026-06-09)`

(The iOS marketing/build version is set at archive time via `mobile:ios:set-version` from `package.json`, and the extension manifest version is injected from `package.json` at build time — no manual edits needed there.)

## Web SDK
The web-sdk wiring to `0.14.11` already landed on `main` in #274 (`@miden-sdk/miden-sdk`, `@miden-sdk/react`, `@miden-sdk/vite-plugin` + the `**/@miden-sdk/miden-sdk` resolution, all `0.14.11`; `yarn.lock` updated). This release just cuts the version. The `0.14.11` SDK bump entry is already in the changelog section being promoted.

## Contents of 1.14.7
The fixes accumulated in `## Unreleased` since v1.14.6 — local-proving re-entrancy unblock, `SyncManager` connectivity-banner false positives, stale completion-modal blocking sends, and the Miden SDK `0.14.11` bump.

## Verification
Reproduced the full mobile pipeline locally on `origin/main` (testnet): `yarn build:mobile` ✅, `cap sync android`/`ios` ✅, `gradlew assembleDebug` ✅ (APK built), `xcodebuild` iOS simulator ✅ (BUILD SUCCEEDED). Mobile E2E (testnet) is green on current `main`.

## After merge
Tag `v1.14.7` + publish a GitHub Release → triggers `build-mobile.yml` (Android + iOS, testnet + devnet artifacts attached) and `release-notes.yml` (fills the release body from the CHANGELOG).