### PR TITLE
fix(e2e): make Mobile E2E pass on CI runners

### DIFF
--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -213,7 +213,10 @@ jobs:
     # macos-26 matches build-mobile.yml — required for iOS 26 SDK symbols
     # used by dapp-browser's WKWebViewController.
     runs-on: macos-26
-    timeout-minutes: 90
+    # Observed worst case: ~40 min setup (CLI compile on cache miss + iOS
+    # build + simulator cold boot overlap) + ~55 min suite with one retry.
+    # 90 minutes guillotined an otherwise-passing run at test 7 of 7.
+    timeout-minutes: 130
     env:
       E2E_NETWORK: devnet
     steps:
@@ -356,7 +359,10 @@ jobs:
     name: Mobile E2E (testnet)
     if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
     runs-on: macos-26
-    timeout-minutes: 90
+    # Observed worst case: ~40 min setup (CLI compile on cache miss + iOS
+    # build + simulator cold boot overlap) + ~55 min suite with one retry.
+    # 90 minutes guillotined an otherwise-passing run at test 7 of 7.
+    timeout-minutes: 130
     env:
       E2E_NETWORK: testnet
     steps:

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -294,6 +294,22 @@ jobs:
           printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
           echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
 
+      # Kick the cold boot off NOW so it overlaps the ~25-minute app build.
+      # First boot of an iOS 26 runtime on a cold runner takes many minutes
+      # (dyld shared-cache build); booting only in playwright's globalSetup
+      # left the suite racing a half-booted simulator, where simctl
+      # install/launch hang for the full test timeout. `simctl boot` is
+      # asynchronous — globalSetup's bootstatus gate later confirms
+      # readiness, which by then is long since done.
+      - name: Pre-boot simulators (async, overlaps build)
+        shell: bash
+        run: |
+          UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
+          UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
+          xcrun simctl boot "$UDID_A" || true
+          xcrun simctl boot "$UDID_B" || true
+          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B"
+
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
 
@@ -391,6 +407,22 @@ jobs:
           mkdir -p test-results-ios
           printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
           echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
+
+      # Kick the cold boot off NOW so it overlaps the ~25-minute app build.
+      # First boot of an iOS 26 runtime on a cold runner takes many minutes
+      # (dyld shared-cache build); booting only in playwright's globalSetup
+      # left the suite racing a half-booted simulator, where simctl
+      # install/launch hang for the full test timeout. `simctl boot` is
+      # asynchronous — globalSetup's bootstatus gate later confirms
+      # readiness, which by then is long since done.
+      - name: Pre-boot simulators (async, overlaps build)
+        shell: bash
+        run: |
+          UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
+          UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
+          xcrun simctl boot "$UDID_A" || true
+          xcrun simctl boot "$UDID_B" || true
+          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B"
 
       - name: Build iOS app
         run: yarn test:e2e:mobile:build

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -307,11 +307,15 @@ jobs:
       - name: Pre-boot simulators (async, overlaps build)
         shell: bash
         run: |
-          # Best-effort: on a cold runner CoreSimulatorService may not be
-          # ready yet ("Unable to boot the Simulator. launchd failed to
-          # respond", SimLaunchHostService code 4) — retry with backoff,
-          # and never fail the step: playwright's globalSetup hard-gates on
-          # bootstatus either way, this step only buys boot/build overlap.
+          # On a cold runner CoreSimulatorService may not respond ("Unable
+          # to boot the Simulator. launchd failed to respond",
+          # SimLaunchHostService code 4) — retry with backoff. If retries
+          # exhaust, the service is wedged, and a wedged CoreSimulatorService
+          # breaks MORE than booting: xcodebuild stops seeing any simulator
+          # destinations, so the build step would fail 25 minutes later
+          # anyway (observed). Restart the service once; if the subsystem
+          # still can't boot, fail the job HERE — minutes in, clearly
+          # attributed, and cheap to rerun.
           UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
           UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
           boot_with_retry() {
@@ -329,11 +333,22 @@ jobs:
               echo "boot attempt $attempt for $udid failed; retrying in 20s"
               sleep 20
             done
-            echo "pre-boot for $udid did not succeed; globalSetup will boot it (slower but gated)"
-            return 0
+            return 1
           }
-          boot_with_retry "$UDID_A"
-          boot_with_retry "$UDID_B"
+          ensure_bootable() {
+            local udid="$1"
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "CoreSimulatorService appears wedged; restarting it"
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+            sleep 15
+            open -a Simulator || true
+            sleep 10
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "::error::simulator subsystem unusable on this runner (boot of $udid failed after CoreSimulatorService restart)"
+            return 1
+          }
+          ensure_bootable "$UDID_A"
+          ensure_bootable "$UDID_B"
           xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
 
       - name: Build iOS app
@@ -447,11 +462,15 @@ jobs:
       - name: Pre-boot simulators (async, overlaps build)
         shell: bash
         run: |
-          # Best-effort: on a cold runner CoreSimulatorService may not be
-          # ready yet ("Unable to boot the Simulator. launchd failed to
-          # respond", SimLaunchHostService code 4) — retry with backoff,
-          # and never fail the step: playwright's globalSetup hard-gates on
-          # bootstatus either way, this step only buys boot/build overlap.
+          # On a cold runner CoreSimulatorService may not respond ("Unable
+          # to boot the Simulator. launchd failed to respond",
+          # SimLaunchHostService code 4) — retry with backoff. If retries
+          # exhaust, the service is wedged, and a wedged CoreSimulatorService
+          # breaks MORE than booting: xcodebuild stops seeing any simulator
+          # destinations, so the build step would fail 25 minutes later
+          # anyway (observed). Restart the service once; if the subsystem
+          # still can't boot, fail the job HERE — minutes in, clearly
+          # attributed, and cheap to rerun.
           UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
           UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
           boot_with_retry() {
@@ -469,11 +488,22 @@ jobs:
               echo "boot attempt $attempt for $udid failed; retrying in 20s"
               sleep 20
             done
-            echo "pre-boot for $udid did not succeed; globalSetup will boot it (slower but gated)"
-            return 0
+            return 1
           }
-          boot_with_retry "$UDID_A"
-          boot_with_retry "$UDID_B"
+          ensure_bootable() {
+            local udid="$1"
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "CoreSimulatorService appears wedged; restarting it"
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+            sleep 15
+            open -a Simulator || true
+            sleep 10
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "::error::simulator subsystem unusable on this runner (boot of $udid failed after CoreSimulatorService restart)"
+            return 1
+          }
+          ensure_bootable "$UDID_A"
+          ensure_bootable "$UDID_B"
           xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
 
       - name: Build iOS app

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -304,11 +304,34 @@ jobs:
       - name: Pre-boot simulators (async, overlaps build)
         shell: bash
         run: |
+          # Best-effort: on a cold runner CoreSimulatorService may not be
+          # ready yet ("Unable to boot the Simulator. launchd failed to
+          # respond", SimLaunchHostService code 4) — retry with backoff,
+          # and never fail the step: playwright's globalSetup hard-gates on
+          # bootstatus either way, this step only buys boot/build overlap.
           UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
           UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
-          xcrun simctl boot "$UDID_A" || true
-          xcrun simctl boot "$UDID_B" || true
-          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B"
+          boot_with_retry() {
+            local udid="$1"
+            for attempt in 1 2 3 4; do
+              state=$(xcrun simctl list devices | grep "$udid" | grep -o '(Booted)\|(Shutdown)\|(Booting)' || true)
+              if [[ "$state" == "(Booted)" || "$state" == "(Booting)" ]]; then
+                echo "$udid already $state"
+                return 0
+              fi
+              if xcrun simctl boot "$udid"; then
+                echo "$udid boot issued (attempt $attempt)"
+                return 0
+              fi
+              echo "boot attempt $attempt for $udid failed; retrying in 20s"
+              sleep 20
+            done
+            echo "pre-boot for $udid did not succeed; globalSetup will boot it (slower but gated)"
+            return 0
+          }
+          boot_with_retry "$UDID_A"
+          boot_with_retry "$UDID_B"
+          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
 
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
@@ -418,11 +441,34 @@ jobs:
       - name: Pre-boot simulators (async, overlaps build)
         shell: bash
         run: |
+          # Best-effort: on a cold runner CoreSimulatorService may not be
+          # ready yet ("Unable to boot the Simulator. launchd failed to
+          # respond", SimLaunchHostService code 4) — retry with backoff,
+          # and never fail the step: playwright's globalSetup hard-gates on
+          # bootstatus either way, this step only buys boot/build overlap.
           UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
           UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
-          xcrun simctl boot "$UDID_A" || true
-          xcrun simctl boot "$UDID_B" || true
-          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B"
+          boot_with_retry() {
+            local udid="$1"
+            for attempt in 1 2 3 4; do
+              state=$(xcrun simctl list devices | grep "$udid" | grep -o '(Booted)\|(Shutdown)\|(Booting)' || true)
+              if [[ "$state" == "(Booted)" || "$state" == "(Booting)" ]]; then
+                echo "$udid already $state"
+                return 0
+              fi
+              if xcrun simctl boot "$udid"; then
+                echo "$udid boot issued (attempt $attempt)"
+                return 0
+              fi
+              echo "boot attempt $attempt for $udid failed; retrying in 20s"
+              sleep 20
+            done
+            echo "pre-boot for $udid did not succeed; globalSetup will boot it (slower but gated)"
+            return 0
+          }
+          boot_with_retry "$UDID_A"
+          boot_with_retry "$UDID_B"
+          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
 
       - name: Build iOS app
         run: yarn test:e2e:mobile:build

--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -351,6 +351,40 @@ jobs:
           ensure_bootable "$UDID_B"
           xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
 
+      # xcodebuild resolves destinations through Xcode's IDE-layer
+      # CoreSimulator session, which on these runners sometimes goes blind
+      # to devices that simctl sees and boots fine — it then stalls 60s and
+      # fails with "Unable to find a device matching ... iPhone 17" while
+      # listing zero simulator destinations. Verify visibility with a cheap
+      # -showdestinations BEFORE the ~15-minute build; if blind, restart
+      # CoreSimulatorService (which shuts down the sims) and re-boot the
+      # pair, then re-check. Hard-fail if it never clears: the build cannot
+      # succeed without it.
+      - name: Wait for xcodebuild to see the simulators
+        shell: bash
+        run: |
+          UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
+          UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
+          sees_sims() {
+            xcodebuild -project ios/App/App.xcodeproj -scheme App -showdestinations 2>/dev/null \
+              | grep -q "id:$UDID_A"
+          }
+          for attempt in 1 2 3 4 5; do
+            if sees_sims; then
+              echo "xcodebuild sees the pinned simulator (attempt $attempt)"
+              exit 0
+            fi
+            echo "xcodebuild does not see the simulators (attempt $attempt); restarting CoreSimulatorService"
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+            sleep 20
+            xcrun simctl boot "$UDID_A" || true
+            xcrun simctl boot "$UDID_B" || true
+            sleep 10
+          done
+          echo "::error::xcodebuild never saw the pinned simulators; build cannot succeed on this runner"
+          xcrun simctl list devices || true
+          exit 1
+
       - name: Build iOS app
         run: yarn test:e2e:mobile:build
 
@@ -505,6 +539,40 @@ jobs:
           ensure_bootable "$UDID_A"
           ensure_bootable "$UDID_B"
           xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
+
+      # xcodebuild resolves destinations through Xcode's IDE-layer
+      # CoreSimulator session, which on these runners sometimes goes blind
+      # to devices that simctl sees and boots fine — it then stalls 60s and
+      # fails with "Unable to find a device matching ... iPhone 17" while
+      # listing zero simulator destinations. Verify visibility with a cheap
+      # -showdestinations BEFORE the ~15-minute build; if blind, restart
+      # CoreSimulatorService (which shuts down the sims) and re-boot the
+      # pair, then re-check. Hard-fail if it never clears: the build cannot
+      # succeed without it.
+      - name: Wait for xcodebuild to see the simulators
+        shell: bash
+        run: |
+          UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
+          UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
+          sees_sims() {
+            xcodebuild -project ios/App/App.xcodeproj -scheme App -showdestinations 2>/dev/null \
+              | grep -q "id:$UDID_A"
+          }
+          for attempt in 1 2 3 4 5; do
+            if sees_sims; then
+              echo "xcodebuild sees the pinned simulator (attempt $attempt)"
+              exit 0
+            fi
+            echo "xcodebuild does not see the simulators (attempt $attempt); restarting CoreSimulatorService"
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+            sleep 20
+            xcrun simctl boot "$UDID_A" || true
+            xcrun simctl boot "$UDID_B" || true
+            sleep 10
+          done
+          echo "::error::xcodebuild never saw the pinned simulators; build cannot succeed on this runner"
+          xcrun simctl list devices || true
+          exit 1
 
       - name: Build iOS app
         run: yarn test:e2e:mobile:build

--- a/playwright/e2e/ios/helpers/simulator-control.ts
+++ b/playwright/e2e/ios/helpers/simulator-control.ts
@@ -15,7 +15,11 @@ const DEVICE_TYPE_B = 'com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro';
 
 const BOOT_TIMEOUT_MS = 60_000;
 const BOOT_POLL_MS = 1_000;
-const BOOTSTATUS_TIMEOUT_MS = 180_000;
+// First boot of an iOS 26 runtime on a cold macos-26 CI runner can take
+// many minutes (dyld shared-cache build, data migration). The CI workflow
+// kicks the boot off before the ~25-minute app build so this budget is
+// normally never consumed; it is the worst-case allowance, not the norm.
+const BOOTSTATUS_TIMEOUT_MS = 600_000;
 
 interface DevicePair {
   udidA: string;
@@ -96,21 +100,34 @@ export class SimulatorControl {
     // observed multi-minute hangs inside simctl launch. bootstatus -b blocks
     // until the device is actually usable.
     //
-    // Best-effort: on some macos-26 CI runner images, bootstatus itself
-    // fails/hangs even when the sim is otherwise usable. Swallow the error
-    // and let the subsequent install/launch reveal whether the sim is
-    // really broken — a genuine sim failure produces a clearer error there.
+    // bootstatus failing is a HARD error: continuing onto a half-booted
+    // simulator does not produce "a clearer error later" — it produces
+    // simctl install/launch calls that hang for the entire 15-minute test
+    // timeout, twice (observed on macos-26 runners). One shutdown→boot
+    // cycle is allowed to recover a wedged first boot; after that, fail
+    // loudly so the job dies in minutes with the real cause named.
     try {
-      await execFileAsync('xcrun', ['simctl', 'bootstatus', udid, '-b'], {
-        timeout: BOOTSTATUS_TIMEOUT_MS,
-      });
+      await this.bootstatus(udid);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn(
-        `[SimulatorControl] bootstatus for ${udid} did not complete cleanly; ` +
-          `continuing. Error: ${(err as Error).message}`
+        `[SimulatorControl] bootstatus for ${udid} failed (${(err as Error).message}); ` +
+          `recovering via shutdown → boot → bootstatus`
       );
+      try {
+        await execSimctl(['shutdown', udid]);
+      } catch {
+        // Already shut down (or mid-transition) — boot below either way.
+      }
+      await execSimctl(['boot', udid]);
+      await this.bootstatus(udid);
     }
+  }
+
+  private async bootstatus(udid: string): Promise<void> {
+    await execFileAsync('xcrun', ['simctl', 'bootstatus', udid, '-b'], {
+      timeout: BOOTSTATUS_TIMEOUT_MS,
+    });
   }
 
   async install(udid: string, appPath: string): Promise<void> {
@@ -201,8 +218,23 @@ export class SimulatorControl {
 
 // ── Internals ───────────────────────────────────────────────────────────────
 
+// Every simctl call gets a hard timeout: on macos-26 CI runners a single
+// `simctl install` / `launch` against an unhealthy simulator hangs
+// indefinitely, silently eating the whole 15-minute test timeout with no
+// attribution. Failing in 3 minutes with the command named turns that into
+// a diagnosable error (and lets the CI-level retry actually retry).
+const SIMCTL_TIMEOUT_MS = 180_000;
+
 async function execSimctl(args: string[]): Promise<{ stdout: string; stderr: string }> {
-  return execFileAsync('xcrun', ['simctl', ...args]);
+  try {
+    return await execFileAsync('xcrun', ['simctl', ...args], { timeout: SIMCTL_TIMEOUT_MS });
+  } catch (err) {
+    const e = err as Error & { killed?: boolean; signal?: string };
+    if (e.killed || e.signal === 'SIGTERM') {
+      throw new Error(`simctl timed out after ${SIMCTL_TIMEOUT_MS}ms: simctl ${args.join(' ')}`);
+    }
+    throw err;
+  }
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

Makes the Mobile E2E jobs actually pass on CI. Devnet mobile had **never been green on CI** in the visible history (every run since at least June 4 failed); the gate only used to pass because testnet mobile — green on the 0.14 line — satisfied the at-least-one-network rule. The 0.15 protocol bump made testnet expected-red and exposed it.

Validated by dispatch run [27434695607](https://github.com/0xMiden/wallet/actions/runs/27434695607): **Mobile E2E (devnet) green — 6 passed, 1 flaky (retry absorbed the known webinspectord first-contact error), 39.4m suite** — plus the Mobile E2E Gate green.

## Failure modes found and fixed (one per validation run)

1. **Cold boot raced the tests.** Simulators were booted only in playwright's globalSetup, after the ~25-minute build; `bootstatus` failed its 180s budget on the cold iOS 26 runtime, was swallowed as best-effort, and the suite ran against half-booted sims where `simctl install/launch` hang for the full 15-minute test timeout. → Pre-boot the pinned pair right after pinning so the cold boot overlaps the build; `bootstatus` is a hard gate again (600s + one shutdown→boot recovery, then loud failure).
2. **`launchd failed to respond`** when CoreSimulatorService is cold/wedged. → Pre-boot retries with backoff; on exhaustion restart CoreSimulatorService and retry; fail the job in minutes (a wedged service also blinds xcodebuild, so proceeding just defers the failure by 25 minutes).
3. **xcodebuild blind to simulators that simctl boots fine** (IDE-layer CoreSimulator session stalls 60s, then "Unable to find a device matching … iPhone 17" with zero sim destinations — same runner image as passing runs). → Cheap `-showdestinations` gate on the pinned UDID before the build, with service-restart + re-boot loop, hard-fail if it never clears.
4. **Unattributable 15-minute hangs.** → Every `simctl` call gets a 180s timeout that names the command.
5. **90-minute budget guillotined an otherwise-passing run at test 7/7.** → 130 minutes (observed worst case: ~40 min setup on a CLI-cache miss + ~55 min suite with one retry).

## Follow-up (not in this PR)

- In-fixture CDP connect retry (terminate + relaunch once on "no pages found") to stop burning a whole test attempt on the webinspectord first-contact flake.
