### PR TITLE
chore(release): wallet 1.15.1, web-sdk 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.1 (TBD)
+
+### Changes
+
+* [CHANGE][all] Bumped `@miden-sdk/miden-sdk` and `@miden-sdk/react` to the stable `0.15.1` release, replacing the `0.15.0-alpha.7` prerelease (npm `next` dist-tag) that shipped in 1.15.0 with the GA build on the `latest` dist-tag. `@miden-sdk/vite-plugin` stays at `0.14.11` (no 0.15.x is published; it's SDK-version-agnostic), and the `**/@miden-sdk/miden-sdk` resolution pin tracks the same `0.15.1`.
+
 ## 1.15.0 (2026-06-12)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": true,
   "engines": {
     "node": ">=22.0.0"
@@ -124,8 +124,8 @@
     "@dicebear/avatars-jdenticon-sprites": "4.2.5",
     "@floating-ui/react": "^0.27.16",
     "@hookform/resolvers": "^3.9.0",
-    "@miden-sdk/miden-sdk": "0.15.0-alpha.7",
-    "@miden-sdk/react": "0.15.0-alpha.7",
+    "@miden-sdk/miden-sdk": "0.15.1",
+    "@miden-sdk/react": "0.15.1",
     "@miden/dapp-browser": "link:./packages/dapp-browser",
     "@miden/native-prover": "link:./packages/native-prover",
     "@newhighsco/storybook-addon-svgr": "^2.0.7",
@@ -337,7 +337,7 @@
     "**/brace-expansion": "^2.0.3",
     "**/minimatch": "^9.0.7",
     "**/tar": "^6.2.1",
-    "**/@miden-sdk/miden-sdk": "0.15.0-alpha.7"
+    "**/@miden-sdk/miden-sdk": "0.15.1"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Miden Wallet",
-  "version": "1.14.4",
+  "version": "1.15.1",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2236,37 +2236,37 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@miden-sdk/miden-sdk@0.15.0-alpha.7":
-  version "0.15.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.15.0-alpha.7.tgz#13e77c072cf900ed45bd619c04bc74aa1a563534"
-  integrity sha512-zqYAmjRbZHDOffV2M57suP6zFdtSnGLY9ACXTq9h/R29GHxqmUj5hE/kUoVUek1GN7KPQeC0hENmFiCwvuw0wg==
+"@miden-sdk/miden-sdk@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/miden-sdk/-/miden-sdk-0.15.1.tgz#8f40b098e6d16ac5cad6766e1d596d8db578ade7"
+  integrity sha512-4S8ZsBhzfWP88vcXqPwveg+EjATWlQf7JBgpocW4t5NRCr0HvmvWQrfM/5q0YKa9gtzQDYZ8PBXqnpA93QWvzA==
   dependencies:
     dexie "^4.0.1"
     glob "^11.0.0"
   optionalDependencies:
-    "@miden-sdk/node-darwin-arm64" "0.15.0-alpha.7"
-    "@miden-sdk/node-darwin-x64" "0.15.0-alpha.7"
-    "@miden-sdk/node-linux-x64-gnu" "0.15.0-alpha.7"
+    "@miden-sdk/node-darwin-arm64" "0.15.1"
+    "@miden-sdk/node-darwin-x64" "0.15.1"
+    "@miden-sdk/node-linux-x64-gnu" "0.15.1"
 
-"@miden-sdk/node-darwin-arm64@0.15.0-alpha.7":
-  version "0.15.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-arm64/-/node-darwin-arm64-0.15.0-alpha.7.tgz#fb5bff472b7e59c663a31ab5c9a24cef8d0764f6"
-  integrity sha512-PwkoouVuesN4w6yopuLcBdHYrIncJFdGe+43VBOzJV0wyqzta/wobxXKfHvAlRoxfEPJLvxrl9qTkCdm0sPtzA==
+"@miden-sdk/node-darwin-arm64@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-arm64/-/node-darwin-arm64-0.15.1.tgz#a380ab5c30b643dc871e4b3607d7f801ac9bbff0"
+  integrity sha512-x+AnYv+7Zu8HER0PIeaBEUjyyDAkdZ3Kkwn0LXRb7/wNUB2heuvkzEKwMQ9A62yytpWd84o1/xXZOv4rqa2/aw==
 
-"@miden-sdk/node-darwin-x64@0.15.0-alpha.7":
-  version "0.15.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-x64/-/node-darwin-x64-0.15.0-alpha.7.tgz#3e7df5deb51081c4e189e8ba4eea27e6c52660f5"
-  integrity sha512-ghFvgNPlDYpWmErmtxwQ24n714SOoHL6k6qO9zVUYdkB5YJNVslcBIfwcjCTLmoOoJeES747l5iQ3hCC7NJoHA==
+"@miden-sdk/node-darwin-x64@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-darwin-x64/-/node-darwin-x64-0.15.1.tgz#f3dcd55f0fe27ed49672a3b89336faf122ddb6ce"
+  integrity sha512-rGcQXJuBv0gHVHdL7Dn7DAYxBQP2yBj1qjRZWsuG62uQmUfjvKVXPAVn/UjWD7wOoe8sz3mSnb8w3AoM3h2GwA==
 
-"@miden-sdk/node-linux-x64-gnu@0.15.0-alpha.7":
-  version "0.15.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/node-linux-x64-gnu/-/node-linux-x64-gnu-0.15.0-alpha.7.tgz#c8b963c675d4cd9bd691b7b696667edfc185f6b9"
-  integrity sha512-af6s21NBnAU5NnH/L5tfUyVK2BvDQPSPG7Yh80R5kh3u/z7VgVQ97cZQSm7s8LTIlb4MioCWYRA6pnYqYUfUPw==
+"@miden-sdk/node-linux-x64-gnu@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/node-linux-x64-gnu/-/node-linux-x64-gnu-0.15.1.tgz#fb92783424338c941b997c03619e5653b8f3bfb9"
+  integrity sha512-j8n0oJMHaM5/KnfPcw1gOKyI51lgMGnR1FxXkfyco1drKAfijgltaWRtkgvxyxRqf+6B0xZsKZiiOZ218+dpNA==
 
-"@miden-sdk/react@0.15.0-alpha.7":
-  version "0.15.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.15.0-alpha.7.tgz#a6d5e3b7968041228b07c14546e1e96415cb22b8"
-  integrity sha512-YQMyoPHSFxeqO4posk6+JAlE9Hn+KLoaBJ1hE9MUkqPLpfZtQiGUb0KAKtHBYA+B+hDJgyRz4bghf8DDvcdf4Q==
+"@miden-sdk/react@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@miden-sdk/react/-/react-0.15.1.tgz#db750a04d563d2688d58724b539d8c2dceffb6fb"
+  integrity sha512-62PDwl15xQc2G7f74pO1qGhpSy4sgNU0SzClqY+DfVhU5e4FY6jA68ehaVaHS3EreHvi+aJ5gLjrH2cgg5ilQw==
   dependencies:
     zustand "^5.0.0"
 


### PR DESCRIPTION
## Summary

Wires the wallet to the newly npm-published stable **`@miden-sdk/miden-sdk` / `@miden-sdk/react` 0.15.1**, replacing the `0.15.0-alpha.7` prerelease (npm `next` dist-tag) that shipped in 1.15.0 with the GA build on the `latest` dist-tag. Bumps the wallet to **1.15.1**.

## Changes

- `package.json`: `@miden-sdk/miden-sdk` and `@miden-sdk/react` → `0.15.1`; `**/@miden-sdk/miden-sdk` resolution pin → `0.15.1`; wallet `version` → `1.15.1`.
- `@miden-sdk/vite-plugin` stays at `0.14.11` — no `0.15.x` is published, and it's SDK-version-agnostic.
- `public/manifest.json`: `version` → `1.15.1` (was stale at `1.14.4` on main; aligned per the version-bump convention).
- `yarn.lock`: regenerated — diff is scoped to the two SDK packages and their native binaries (`node-darwin-arm64/x64`, `node-linux-x64-gnu`). `@miden-sdk/react@0.15.1`'s `^0.15.1` peer dep on `miden-sdk` is satisfied.
- `CHANGELOG.md`: new `## 1.15.1 (TBD)` section.

## Verification

- `yarn ts` — clean
- `yarn lint` (`--max-warnings 0`) — clean
- `yarn build:chrome` — succeeds; built `dist/chrome_unpacked/manifest.json` reports `1.15.1`.
