### PR TITLE
fix(e2e): stream stress IndexedDB dump store-at-a-time to avoid OOM

### DIFF
--- a/playwright/e2e/fixtures/two-wallets.ts
+++ b/playwright/e2e/fixtures/two-wallets.ts
@@ -444,7 +444,8 @@ export const test = base.extend<TwoWalletFixtures>({
     await use(instance.walletPage);
 
     const isAgentic = process.env.E2E_AGENTIC === 'true';
-    if (isAgentic && testInfo.status !== 'passed') {
+    const failed = testInfo.status !== 'passed';
+    if (isAgentic && failed) {
       // Don't close -- browser stays open for agent inspection
       const timer = setTimeout(async () => {
         try {
@@ -452,6 +453,18 @@ export const test = base.extend<TwoWalletFixtures>({
         } catch {}
       }, AGENTIC_TIMEOUT_MS);
       timer.unref();
+    } else if (failed) {
+      // Keep the on-disk profile (IndexedDB/LevelDB) so the SDK state can be
+      // recovered offline if the in-page forensic dump was incomplete (e.g. the
+      // page died mid-dump under memory pressure). Only the context is closed.
+      await instance.context.close();
+      timeline.emit({
+        category: 'test_lifecycle',
+        severity: 'warn',
+        wallet: 'A',
+        message: `Retained wallet A profile for offline recovery: ${instance.userDataDir}`,
+        data: { userDataDir: instance.userDataDir }
+      });
     } else {
       await instance.context.close();
       fs.rmSync(instance.userDataDir, { recursive: true, force: true });
@@ -501,7 +514,8 @@ export const test = base.extend<TwoWalletFixtures>({
 
     // Now handle context cleanup
     const isAgentic = process.env.E2E_AGENTIC === 'true';
-    if (isAgentic && testInfo.status !== 'passed') {
+    const failed = testInfo.status !== 'passed';
+    if (isAgentic && failed) {
       // Write debug session with both wallet details
       writeDebugSession(
         testInfo.title,
@@ -526,6 +540,17 @@ export const test = base.extend<TwoWalletFixtures>({
         }
       }, AGENTIC_TIMEOUT_MS);
       cleanupTimer.unref(); // Don't keep process alive just for this timer
+    } else if (failed) {
+      // Keep the on-disk profile (IndexedDB/LevelDB) for offline SDK-state
+      // recovery when the in-page forensic dump may be incomplete.
+      await instance.context.close();
+      timeline.emit({
+        category: 'test_lifecycle',
+        severity: 'warn',
+        wallet: 'B',
+        message: `Retained wallet B profile for offline recovery: ${instance.userDataDir}`,
+        data: { userDataDir: instance.userDataDir }
+      });
     } else {
       await instance.context.close();
       fs.rmSync(instance.userDataDir, { recursive: true, force: true });

--- a/playwright/e2e/helpers/idb-dump.ts
+++ b/playwright/e2e/helpers/idb-dump.ts
@@ -1,0 +1,146 @@
+import * as fs from 'fs';
+
+/**
+ * Store-at-a-time source of IndexedDB data. Implemented structurally by
+ * ChromeWalletPage. The streamer below pulls ONE store at a time so peak
+ * memory stays bounded — the old whole-DB-in-one-string dump OOM-killed long
+ * stress runs (see streamIndexedDBToFile).
+ */
+export interface IdbDumpSource {
+  /** Enumerate every (db, store) on the origin. Cheap — loads no row data. */
+  listIndexedDBStores(): Promise<Array<{ db: string; version: number; store: string }>>;
+  /**
+   * Read ONE object store as a JSON array string (binary/BigInt wrapped),
+   * capped at `maxRows`. `truncated` is true when the cap was hit and rows
+   * may have been dropped.
+   */
+  dumpIndexedDBStore(
+    db: string,
+    store: string,
+    maxRows: number
+  ): Promise<{ json: string; count: number; truncated: boolean }>;
+}
+
+export interface IdbDumpResult {
+  file: string;
+  storesDumped: number;
+  storesFailed: number;
+  entriesDumped: number;
+  truncatedStores: string[];
+  errors: Array<{ db: string; store: string; message: string }>;
+}
+
+interface StreamOpts {
+  /** Hard ceiling on rows pulled per store, bounding peak in-page memory. */
+  maxRowsPerStore?: number;
+}
+
+const DEFAULT_MAX_ROWS_PER_STORE = 200_000;
+
+/**
+ * Stream every IndexedDB store to `filePath` as a single JSON object, ONE
+ * store at a time. Peak memory is bounded to a single store's rows — the old
+ * `Promise.all([A.dumpIndexedDB(), B.dumpIndexedDB()])` path serialized BOTH
+ * full DBs into in-page strings at once and tripped the OOM killer on the
+ * stress runner.
+ *
+ * Partial progress is preserved: a store that throws (including the page
+ * dying mid-dump) is recorded as `{ "__error": ... }` in place of its array,
+ * and the file is always closed as valid JSON containing every store dumped
+ * before the failure.
+ *
+ * Output shape:
+ *   {
+ *     "<db>": { "version": N, "stores": { "<store>": [ ...rows ] } },
+ *     "__meta": { storesDumped, storesFailed, entriesDumped, truncatedStores, errors }
+ *   }
+ */
+export async function streamIndexedDBToFile(
+  source: IdbDumpSource,
+  filePath: string,
+  opts: StreamOpts = {}
+): Promise<IdbDumpResult> {
+  const maxRows = opts.maxRowsPerStore ?? DEFAULT_MAX_ROWS_PER_STORE;
+  const result: IdbDumpResult = {
+    file: filePath,
+    storesDumped: 0,
+    storesFailed: 0,
+    entriesDumped: 0,
+    truncatedStores: [],
+    errors: []
+  };
+
+  // List first — if this throws, nothing has been written yet, so just
+  // propagate to the caller (which logs and moves on).
+  const stores = await source.listIndexedDBStores();
+
+  // Group by db, preserving discovery order for both dbs and stores.
+  const byDb = new Map<string, { version: number; stores: string[] }>();
+  for (const s of stores) {
+    let entry = byDb.get(s.db);
+    if (!entry) {
+      entry = { version: s.version, stores: [] };
+      byDb.set(s.db, entry);
+    }
+    entry.stores.push(s.store);
+  }
+
+  const out = fs.createWriteStream(filePath, { encoding: 'utf8' });
+  let streamError: Error | null = null;
+  out.on('error', e => {
+    streamError = e as Error;
+  });
+  // Await each write's flush callback so buffering stays bounded to ~one
+  // chunk even when the consumer (disk) is slower than the producer.
+  const write = (chunk: string): Promise<void> =>
+    new Promise((resolve, reject) => {
+      if (streamError) {
+        reject(streamError);
+        return;
+      }
+      out.write(chunk, err => (err ? reject(err) : resolve()));
+    });
+
+  try {
+    await write('{\n');
+    let firstDb = true;
+    for (const [db, { version, stores: storeNames }] of byDb) {
+      await write(
+        `${firstDb ? '' : ',\n'}${JSON.stringify(db)}: {\n"version": ${JSON.stringify(version)},\n"stores": {\n`
+      );
+      firstDb = false;
+      let firstStore = true;
+      for (const store of storeNames) {
+        await write(`${firstStore ? '' : ',\n'}${JSON.stringify(store)}: `);
+        firstStore = false;
+        try {
+          const { json, count, truncated } = await source.dumpIndexedDBStore(db, store, maxRows);
+          await write(json);
+          result.storesDumped += 1;
+          result.entriesDumped += count;
+          if (truncated) result.truncatedStores.push(`${db}/${store}`);
+        } catch (e) {
+          result.storesFailed += 1;
+          const message = e instanceof Error ? e.message : String(e);
+          result.errors.push({ db, store, message });
+          // Keep the file valid JSON: error sentinel in place of the array.
+          await write(JSON.stringify({ __error: message }));
+        }
+      }
+      await write('\n}\n}');
+    }
+    await write(
+      `${byDb.size ? ',\n' : ''}"__meta": ${JSON.stringify({
+        storesDumped: result.storesDumped,
+        storesFailed: result.storesFailed,
+        entriesDumped: result.entriesDumped,
+        truncatedStores: result.truncatedStores,
+        errors: result.errors
+      })}\n}\n`
+    );
+  } finally {
+    await new Promise<void>(resolve => out.end(resolve));
+  }
+
+  return result;
+}

--- a/playwright/e2e/helpers/wallet-page.ts
+++ b/playwright/e2e/helpers/wallet-page.ts
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 import type { TimelineRecorder } from '../harness/timeline-recorder';
+import type { IdbDumpSource } from './idb-dump';
 
 const PASSWORD = 'Password123!';
 const SYNC_WAIT_MS = 3_500;
@@ -54,7 +55,7 @@ export interface WalletPage {
  * reach into the Playwright Page directly (currently multi-account's
  * DOM probe) and for captureStateFrom entries that pass extensionId.
  */
-export interface ChromeWalletPageApi extends WalletPage {
+export interface ChromeWalletPageApi extends WalletPage, IdbDumpSource {
   readonly page: Page;
   readonly extensionId: string;
   readonly userDataDir: string;
@@ -70,12 +71,10 @@ export interface ChromeWalletPageApi extends WalletPage {
   }>;
   /** Full dump of chrome.storage.local — end-of-run forensic snapshot. */
   dumpChromeStorage(): Promise<Record<string, unknown>>;
-  /**
-   * Full IndexedDB dump (all databases × all object stores). Returns a JSON
-   * string with binary/BigInt wrappers. This is where the Miden SDK keeps
-   * per-tx commit status — the ground truth for "did this tx land?".
-   */
-  dumpIndexedDB(): Promise<string>;
+  // IndexedDB forensics (listIndexedDBStores / dumpIndexedDBStore) come from
+  // IdbDumpSource — driven store-at-a-time by streamIndexedDBToFile so a long
+  // run's dump can't OOM the page. This is where the Miden SDK keeps per-tx
+  // commit status — the ground truth for "did this tx land?".
 }
 
 /**
@@ -552,93 +551,115 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
   }
 
   /**
-   * Dump every IndexedDB database on the extension origin. This is where the
-   * Miden SDK persists its authoritative state — accounts, transactions,
-   * notes, chain MMR, block headers. For "did this tx actually commit?"
-   * forensics, the SDK's `transactions` table is the ground truth.
-   *
-   * Output shape: `{ [dbName]: { version, stores: { [storeName]: entries[] } } }`.
-   * Binary fields (Uint8Array / ArrayBuffer / BigInt) are converted to
-   * `{ __type, hex | value, length }` wrappers so the result round-trips
-   * through JSON and through Playwright's postMessage serialization.
-   *
-   * Not exposed on WalletPage interface — Chrome-only (IndexedDB-per-origin).
+   * Enumerate every (db, store) on the extension origin — cheap, loads no row
+   * data. Pairs with `dumpIndexedDBStore` so `streamIndexedDBToFile` can pull
+   * one store at a time. Not on the shared WalletPage interface — Chrome-only
+   * (IndexedDB-per-origin).
    */
-  async dumpIndexedDB(): Promise<string> {
-    try {
-      return await this.page.evaluate(async () => {
+  async listIndexedDBStores(): Promise<Array<{ db: string; version: number; store: string }>> {
+    return this.page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const idb = (globalThis as any).indexedDB as IDBFactory;
+      const dbList = await idb.databases();
+      const out: Array<{ db: string; version: number; store: string }> = [];
+
+      const openDb = (name: string): Promise<IDBDatabase> =>
+        new Promise((resolve, reject) => {
+          const req = idb.open(name);
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = () => reject(req.error);
+          req.onblocked = () => reject(new Error('blocked'));
+        });
+
+      for (const info of dbList) {
+        if (!info.name) continue;
+        try {
+          const db = await openDb(info.name);
+          for (const store of Array.from(db.objectStoreNames)) {
+            out.push({ db: info.name, version: info.version ?? 0, store });
+          }
+          db.close();
+        } catch {
+          // Un-openable db — skip; the caller records nothing for it.
+        }
+      }
+      return out;
+    });
+  }
+
+  /**
+   * Read ONE object store as a JSON array string, capped at `maxRows`. The
+   * Miden SDK persists its authoritative state here (accounts, transactions,
+   * notes, chain MMR, block headers) — for "did this tx commit?" forensics the
+   * `transactions` table is the ground truth.
+   *
+   * Binary fields (Uint8Array / ArrayBuffer / BigInt) are wrapped as
+   * `{ __type, hex | value, length }` so the result round-trips through JSON
+   * and Playwright's postMessage serialization. Returning a string (vs the
+   * object) also avoids structuredClone choking on Uint8Array in some Chromium
+   * revisions. One store at a time keeps peak in-page memory bounded.
+   */
+  async dumpIndexedDBStore(
+    db: string,
+    store: string,
+    maxRows: number
+  ): Promise<{ json: string; count: number; truncated: boolean }> {
+    return this.page.evaluate(
+      async ({ db, store, maxRows }) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const idb = (globalThis as any).indexedDB as IDBFactory;
-        const dbList = await idb.databases();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result: Record<string, any> = {};
 
-        const openDb = (name: string): Promise<IDBDatabase> =>
-          new Promise((resolve, reject) => {
-            const req = idb.open(name);
+        const database: IDBDatabase = await new Promise((resolve, reject) => {
+          const req = idb.open(db);
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = () => reject(req.error);
+          req.onblocked = () => reject(new Error('blocked'));
+        });
+
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const rows: any[] = await new Promise((resolve, reject) => {
+            const tx = database.transaction(store, 'readonly');
+            const os = tx.objectStore(store);
+            // getAll(query, count): count caps rows pulled in a single op,
+            // bounding peak memory without an O(n^2) offset cursor.
+            const req = os.getAll(null, maxRows);
             req.onsuccess = () => resolve(req.result);
             req.onerror = () => reject(req.error);
-            req.onblocked = () => reject(new Error('blocked'));
           });
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const getAll = (store: IDBObjectStore): Promise<any[]> =>
-          new Promise((resolve, reject) => {
-            const req = store.getAll();
-            req.onsuccess = () => resolve(req.result);
-            req.onerror = () => reject(req.error);
-          });
-
-        for (const info of dbList) {
-          if (!info.name) continue;
-          try {
-            const db = await openDb(info.name);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const stores: Record<string, any> = {};
-            for (const storeName of db.objectStoreNames) {
-              try {
-                const tx = db.transaction(storeName, 'readonly');
-                const store = tx.objectStore(storeName);
-                stores[storeName] = await getAll(store);
-              } catch (e) {
-                stores[storeName] = { __error: String(e) };
-              }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const replacer = (_k: string, v: any): unknown => {
+            if (v instanceof Uint8Array || v instanceof Uint8ClampedArray) {
+              const hex = Array.from(v)
+                .map(b => b.toString(16).padStart(2, '0'))
+                .join('');
+              return { __type: 'Uint8Array', hex, length: v.length };
             }
-            db.close();
-            result[info.name] = { version: info.version, stores };
-          } catch (e) {
-            result[info.name] = { __error: String(e) };
-          }
-        }
+            if (v instanceof ArrayBuffer) {
+              const arr = new Uint8Array(v);
+              const hex = Array.from(arr)
+                .map(b => b.toString(16).padStart(2, '0'))
+                .join('');
+              return { __type: 'ArrayBuffer', hex, length: arr.length };
+            }
+            if (typeof v === 'bigint') {
+              return { __type: 'BigInt', value: v.toString() };
+            }
+            return v;
+          };
 
-        // JSON-serialize with binary/BigInt wrappers so the payload round-trips
-        // cleanly. Returning a string (vs the object) also avoids Playwright's
-        // structuredClone choking on Uint8Array in some Chromium revisions.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const replacer = (_k: string, v: any): unknown => {
-          if (v instanceof Uint8Array || v instanceof Uint8ClampedArray) {
-            const hex = Array.from(v)
-              .map(b => b.toString(16).padStart(2, '0'))
-              .join('');
-            return { __type: 'Uint8Array', hex, length: v.length };
-          }
-          if (v instanceof ArrayBuffer) {
-            const arr = new Uint8Array(v);
-            const hex = Array.from(arr)
-              .map(b => b.toString(16).padStart(2, '0'))
-              .join('');
-            return { __type: 'ArrayBuffer', hex, length: arr.length };
-          }
-          if (typeof v === 'bigint') {
-            return { __type: 'BigInt', value: v.toString() };
-          }
-          return v;
-        };
-        return JSON.stringify(result, replacer);
-      });
-    } catch (e) {
-      return JSON.stringify({ __error: e instanceof Error ? e.message : String(e) });
-    }
+          return {
+            json: JSON.stringify(rows, replacer),
+            count: rows.length,
+            truncated: rows.length >= maxRows
+          };
+        } finally {
+          database.close();
+        }
+      },
+      { db, store, maxRows }
+    );
   }
 
   /**

--- a/playwright/e2e/stress/stress.spec.ts
+++ b/playwright/e2e/stress/stress.spec.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { expect, test } from '../fixtures/two-wallets';
+import { streamIndexedDBToFile } from '../helpers/idb-dump';
 
 import { runStressDriver, type StressOptions } from './stress-driver';
 
@@ -269,12 +270,19 @@ test.describe('Stress: random send/claim', () => {
       fs.writeFileSync(path.join(outDir, 'stress-summary.json'), JSON.stringify(summary, null, 2));
 
       // ── Forensic dumps ─────────────────────────────────────────────────
+      // Dumps run SEQUENTIALLY (A then B), never concurrently: an 800-loop run
+      // accumulates enough IndexedDB that serializing both wallets' full DBs at
+      // once tripped the OOM killer on the runner, which killed the Chromium
+      // targets mid-dump and left only a "page closed" placeholder. Sequential
+      // + store-at-a-time streaming keeps peak memory bounded.
+
       // Full chrome.storage.local from both wallets — includes miden_sync_data
       // (pending notes + vault assets), connectivity-issue flag, cached
       // metadata, and anything else the wallet persists. Snapshot of the
       // wallet's exact view-of-world at the moment the assertion runs.
       try {
-        const [storageA, storageB] = await Promise.all([walletA.dumpChromeStorage(), walletB.dumpChromeStorage()]);
+        const storageA = await walletA.dumpChromeStorage();
+        const storageB = await walletB.dumpChromeStorage();
         fs.writeFileSync(
           path.join(outDir, 'chrome-storage-final.json'),
           JSON.stringify({ A: storageA, B: storageB }, null, 2)
@@ -286,13 +294,33 @@ test.describe('Stress: random send/claim', () => {
       // IndexedDB — where the Miden SDK keeps its authoritative state
       // (transactions, notes, accounts, chain MMR). For "did this tx actually
       // commit?" forensics, the SDK's transactions table is the ground truth.
-      // Result is a JSON string (with binary→hex wrappers); wrap per-wallet
-      // keys so both fit in one readable file.
-      try {
-        const [idbA, idbB] = await Promise.all([walletA.dumpIndexedDB(), walletB.dumpIndexedDB()]);
-        fs.writeFileSync(path.join(outDir, 'indexeddb-final.json'), `{"A":${idbA},"B":${idbB}}`);
-      } catch (e) {
-        console.log(`[stress] indexeddb dump failed: ${e instanceof Error ? e.message : String(e)}`);
+      // Streamed one store at a time to a per-wallet file so a slow/large dump
+      // can't OOM the page, and so a failure on one wallet still leaves the
+      // other's file intact. Each call is independently guarded.
+      for (const [label, wallet] of [
+        ['A', walletA],
+        ['B', walletB]
+      ] as const) {
+        const idbPath = path.join(outDir, `indexeddb-final-${label}.json`);
+        try {
+          const res = await streamIndexedDBToFile(wallet, idbPath);
+          console.log(
+            `[stress] indexeddb dump ${label}: ${res.storesDumped} stores, ${res.entriesDumped} entries` +
+              (res.storesFailed ? `, ${res.storesFailed} stores FAILED` : '') +
+              (res.truncatedStores.length ? `, truncated: ${res.truncatedStores.join(',')}` : '')
+          );
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          console.log(`[stress] indexeddb dump ${label} failed: ${message}`);
+          // Leave a labeled marker so the artifact is never silently absent;
+          // the retained profile dir (see two-wallets fixture) is the real
+          // offline-recovery path when the page died mid-dump.
+          try {
+            fs.writeFileSync(idbPath, JSON.stringify({ __error: message }));
+          } catch {
+            // best-effort
+          }
+        }
       }
 
       // Extract pending-tx time series from existing GeneratingTransaction

--- a/scripts/stress-detached.sh
+++ b/scripts/stress-detached.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Detached stress-test runner.
+#
+# Hardened so the archive/notify bookkeeping survives an OOM kill of the test.
+# Previously `<archive>; <notify>` were chained inside the same tmux command,
+# right after `yarn ... | tee`. When the systemd user scope running that tmux
+# command was OOM-killed (SIGKILL to the whole cgroup — uncatchable, so an EXIT
+# trap would not help either), the chain never ran and the daily summary /
+# pending / notify-curl logs silently froze at the prior run.
+#
+# Now the test runs in its own tmux session and writes a `.done` sentinel with
+# its real exit code. A *separate* watcher — a transient `systemd-run --user`
+# service in its own cgroup, immune to the test scope's OOM kill — waits for the
+# session to end, then archives + notifies exactly once, classifying the run as
+# passed / failed / killed (sentinel absent => killed/incomplete).
+#
+# Usage:
+#   scripts/stress-detached.sh [network]        # launch a detached run
+#   scripts/stress-detached.sh __watch ...      # internal: watcher (do not call)
+
+set -euo pipefail
+
+SELF="$(readlink -f "$0")"
+
+# ── Watcher mode (internal) ─────────────────────────────────────────────────
+# Runs in its own cgroup, decoupled from the OOM-prone test scope. Fires once
+# the test session ends, for ANY reason (clean exit, assertion failure, or kill).
+if [[ "${1:-}" == "__watch" ]]; then
+  SESSION="$2"
+  STAMP="$3"
+  LOGFILE="$4"
+  DONE_SENTINEL="$5"
+  NETWORK="$6"
+
+  # 1. Wait for the session to APPEAR (guards the launcher race), bounded.
+  waited=0
+  until tmux has-session -t "$SESSION" 2>/dev/null; do
+    sleep 1
+    waited=$((waited + 1))
+    [[ "$waited" -ge 30 ]] && break
+  done
+
+  # 2. Wait for the session to END (test exited or was killed).
+  while tmux has-session -t "$SESSION" 2>/dev/null; do
+    sleep 10
+  done
+
+  # 3. Classify the outcome. Sentinel present => the test command reached its
+  #    final line (ran to completion); absent => it was killed mid-run (OOM).
+  if [[ -f "$DONE_SENTINEL" ]]; then
+    EXIT_CODE="$(tr -dc '0-9-' <"$DONE_SENTINEL" 2>/dev/null || true)"
+    [[ -z "$EXIT_CODE" ]] && EXIT_CODE="unknown"
+    if [[ "$EXIT_CODE" == "0" ]]; then
+      OUTCOME="passed"
+    else
+      OUTCOME="failed"
+    fi
+  else
+    EXIT_CODE="killed"
+    OUTCOME="killed" # never reached the sentinel write — OOM / crash
+  fi
+
+  # ── do_archive ────────────────────────────────────────────────────────────
+  # >>> KEEP YOUR EXISTING <archive> BODY HERE <<<
+  # It now also runs on OUTCOME=killed, so a lost run still gets recorded.
+  # The artifacts your setup writes (reconstructed from the failure report —
+  # replace with your exact commands):
+  #   - append a JSON line to ~/.claude/stress-summaries/$(date +%Y-%m).jsonl
+  #   - update ~/.claude/stress-summaries/stress-pending.txt
+  # Use the vars: $STAMP $NETWORK $LOGFILE $OUTCOME $EXIT_CODE
+  archive_run() {
+    local month
+    month="$(date +%Y-%m)"
+    local summaries="$HOME/.claude/stress-summaries"
+    mkdir -p "$summaries"
+    # >>> REPLACE the line below with your real summary-line construction <<<
+    printf '{"stamp":"%s","network":"%s","outcome":"%s","exit":"%s","log":"%s"}\n' \
+      "$STAMP" "$NETWORK" "$OUTCOME" "$EXIT_CODE" "$LOGFILE" \
+      >>"$summaries/${month}.jsonl"
+    # >>> REPLACE with your real pending-file update (e.g. drop this stamp) <<<
+    if [[ -f "$summaries/stress-pending.txt" ]]; then
+      grep -v -F "$STAMP" "$summaries/stress-pending.txt" >"$summaries/stress-pending.txt.tmp" 2>/dev/null || true
+      mv -f "$summaries/stress-pending.txt.tmp" "$summaries/stress-pending.txt" 2>/dev/null || true
+    fi
+  }
+
+  # ── do_notify ─────────────────────────────────────────────────────────────
+  # >>> KEEP YOUR EXISTING <notify> BODY HERE <<<
+  # Logs to ~/.claude/stress-summaries/stress-notify-curl.log (per your setup).
+  notify_run() {
+    local notify_log="$HOME/.claude/stress-summaries/stress-notify-curl.log"
+    # >>> REPLACE with your real curl/webhook call; keep the >> log redirect <<<
+    {
+      echo "[$(date -Is)] stress ${STAMP} ${NETWORK} -> ${OUTCOME} (exit=${EXIT_CODE})"
+      # curl -fsS -X POST "$YOUR_WEBHOOK" -d "..." 2>&1
+    } >>"$notify_log" 2>&1 || true
+  }
+
+  # Best-effort, independent: a failure in one must not skip the other.
+  archive_run || true
+  notify_run || true
+  exit 0
+fi
+
+# ── Launcher mode ───────────────────────────────────────────────────────────
+
+NETWORK="${1:-devnet}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+SESSION="stress-${STAMP}"
+WALLET_DIR="$HOME/wallet"
+LOGDIR="${WALLET_DIR}/test-results"
+LOGFILE="${LOGDIR}/stress-${STAMP}.log"
+DONE_SENTINEL="${LOGDIR}/stress-${STAMP}.done"
+RUNNER="${LOGDIR}/stress-${STAMP}.run.sh"
+
+mkdir -p "$LOGDIR"
+
+# >>> KEEP YOUR EXISTING pull + log-header logic HERE <<<
+# (pull origin/main unless SKIP_PULL=1; write commit SHA + STRESS_* env header)
+
+# Generate the per-run test command as its own bash script. Running it through
+# `bash` (not sh) guarantees `source`/`nvm`/`${PIPESTATUS[0]}` work, and the
+# trailing sentinel write captures the REAL test exit code regardless of `tee`.
+cat >"$RUNNER" <<EOF
+#!/usr/bin/env bash
+# No 'set -euo' here: -e would skip the sentinel write when the test fails, and
+# -u breaks nvm's sourcing. PIPESTATUS captures yarn's real exit code regardless.
+source ~/.nvm/nvm.sh
+nvm use 22
+cd "${WALLET_DIR}"
+
+# >>> KEEP YOUR EXISTING STRESS_* ENV + miden-client bin HERE <<<
+export MIDEN_CLIENT_BIN="\$HOME/.cargo/bin/miden-client"
+export E2E_NETWORK="${NETWORK}"
+# export STRESS_NUM_NOTES=... STRESS_LOCK_EVERY=... STRESS_RELOAD_EVERY=... etc.
+
+yarn test:e2e:stress:run 2>&1 | tee -a "${LOGFILE}"
+# Record the test's real exit status; the watcher reads this. Its ABSENCE means
+# the run was killed (OOM) before reaching this line.
+echo "\${PIPESTATUS[0]}" > "${DONE_SENTINEL}"
+EOF
+chmod +x "$RUNNER"
+
+# Launch the test in its own tmux session (NO archive/notify chained here).
+setsid tmux new-session -d -s "$SESSION" "bash '$RUNNER'"
+
+# Launch the decoupled archive/notify watcher in its OWN cgroup so the test
+# scope being OOM-killed cannot take it down. Prefer a transient systemd --user
+# service; fall back to setsid if systemd-run is absent OR fails (e.g. no user
+# D-Bus session under cron). The fallback is guarded so a systemd-run failure
+# never aborts the launcher and leaves the running test without a watcher.
+started_watcher=0
+if command -v systemd-run >/dev/null 2>&1; then
+  if systemd-run --user --quiet --collect \
+    --unit="stress-watch-${STAMP}" \
+    --description="stress archive/notify watcher ${STAMP}" \
+    bash "$SELF" __watch "$SESSION" "$STAMP" "$LOGFILE" "$DONE_SENTINEL" "$NETWORK"; then
+    started_watcher=1
+  fi
+fi
+if [[ "$started_watcher" -eq 0 ]]; then
+  setsid bash "$SELF" __watch "$SESSION" "$STAMP" "$LOGFILE" "$DONE_SENTINEL" "$NETWORK" \
+    </dev/null >>"${LOGDIR}/stress-watch-${STAMP}.log" 2>&1 &
+  disown || true
+fi
+
+echo "Launched stress run '${SESSION}' (network=${NETWORK})."
+echo "  log:      ${LOGFILE}"
+echo "  watcher:  stress-watch-${STAMP} (archive/notify will fire even if the run is OOM-killed)"
+echo "  attach:   tmux attach -t ${SESSION}"


### PR DESCRIPTION
## Problem

The 800-loop stress run hit the systemd OOM killer while dumping both wallets' full IndexedDB **concurrently** at end-of-run. That killed the Chromium targets mid-dump, so `indexeddb-final.json` was just a 163-byte "page closed" placeholder. The same OOM also froze the runner's daily archive/notify bookkeeping, because `<archive>; <notify>` were chained *inside* the killed tmux test command.

Root cause in code: `stress.spec.ts` ran `Promise.all([walletA.dumpIndexedDB(), walletB.dumpIndexedDB()])`, and `dumpIndexedDB()` did `getAll()` on **every** store into one object then one in-page `JSON.stringify` — i.e. both full DBs materialized in-page at once.

## Fix

**Store-at-a-time streaming dump (the actual OOM fix)**
- New `playwright/e2e/helpers/idb-dump.ts`: `streamIndexedDBToFile()` pulls **one store at a time** and streams each to a per-wallet file (`indexeddb-final-A.json` / `-B.json`). Peak memory drops from "both full DBs" to "one store" (capped by `maxRowsPerStore`, default 200k).
- `wallet-page.ts`: replaced monolithic `dumpIndexedDB()` with granular `listIndexedDBStores()` + `dumpIndexedDBStore()` (`IdbDumpSource`).

**Partial progress preserved**
- A store that throws — including the page dying mid-dump — gets an `{"__error": ...}` sentinel and the file is always closed as valid JSON containing every store dumped before the failure. Total-failure path writes a labeled marker so the artifact is never silently absent.

**Failed-run profile dirs retained**
- `two-wallets.ts`: failed tests no longer `rmSync` the `userDataDir`, so the on-disk IndexedDB/LevelDB is recoverable offline when the in-page dump is incomplete.

**Sequential dumps**
- Both chrome.storage and IndexedDB dumps now run sequentially (A then B), never `Promise.all`.

**Runner script (`scripts/stress-detached.sh`) — archive/notify decoupling**
- Hardened so archive/notify survive an OOM kill: the test runs in its own tmux session writing a `.done` sentinel with its real exit code, and archive/notify run from a **separate** watcher (transient `systemd-run --user` service in its own cgroup, immune to the test scope's OOM kill; `setsid` fallback). It fires once the session ends for any reason and classifies passed/failed/killed.
- The `<archive>` / `<notify>` / `STRESS_*` bodies are left as marked `>>> KEEP YOUR EXISTING ... <<<` slots (no secrets committed); these must be filled in before deploying to the runner.

## Verification
- 21/21 streamer logic checks pass, incl. *store-throws-mid-dump -> still valid JSON with before+after stores both preserved*, truncation, empty-store, zero-db.
- `yarn ts` clean on all changed files; Prettier clean; `bash -n` clean on the script.
- Zero `src/` changes -> coverage, ESLint, jest, and the `playwright/tests` E2E job are unaffected.

## Follow-up (runner)
- Splice real archive/notify/STRESS_* bodies into `scripts/stress-detached.sh` and deploy to `~/wallet/scripts/`.
- Add a prune step for retained failed-run profile dirs (they accumulate under `test-results`).