### PR TITLE
chore(release): wallet 1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.15.2 (2026-06-22)
+
+### Features
+
+* [FEATURE][all] **Custom-transaction support for Guardian accounts.** Guardian accounts can now co-sign arbitrary transaction requests, not just sends and note consumption: the multisig client builds a custom proposal from the request bytes, co-signs it through the Guardian, and reconstructs the executable `TransactionRequest` from the Guardian's advice. (#153)
+
+### Changes
+
+* [CHANGE][all] **Guardian now runs on the Miden 0.15 protocol line.** The OpenZeppelin Guardian client packages (`@openzeppelin/miden-multisig-client`, `@openzeppelin/guardian-client`) are pinned to `0.15.0-rc.0` (built against `@miden-sdk/miden-sdk ^0.15.0`), replacing the published `0.14.9` — which targets SDK `0.14.5` and trapped with `RuntimeError: memory access out of bounds` inside `MultisigClient.create()` when run on the wallet's 0.15 SDK (WASM ABI skew between the 0.14 client and the 0.15 SDK). Guardian account creation, note consumption, and sends now work end-to-end on 0.15. **Guardian currently requires devnet:** the hosted devnet Guardian runs the 0.15 server, while the testnet/production Guardian is still on the 0.14 server and is incompatible with the 0.15 client — until OpenZeppelin publishes a 0.15 Guardian server release. (#153)
+* [CHANGE][all] Bumped `@miden-sdk/miden-sdk` and `@miden-sdk/react` from `0.15.1` to `0.15.2` (and the matching `**/@miden-sdk/miden-sdk` resolution pin). `@miden-sdk/vite-plugin` stays at `0.14.11`. (#153)
+
+### Fixes
+
+* [FIX][all] Corrected the devnet Guardian endpoint host (`stg-guardian.openzeppelin.com` → `guardian-stg.openzeppelin.com`); the transposed hostname had no DNS record, so the default devnet Guardian URL never resolved. (#153)
+
 ## 1.15.1 (2026-06-19)
 
 ### Changes

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.miden.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11501001
-        versionName "1.15.1"
+        versionCode 11502001
+        versionName "1.15.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = YQ9XQQJ5ZM;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				INFOPLIST_FILE = App/Info.plist;
@@ -329,7 +329,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.1;
+				MARKETING_VERSION = 1.15.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.miden.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -345,7 +345,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = YQ9XQQJ5ZM;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				INFOPLIST_FILE = App/Info.plist;
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.1;
+				MARKETING_VERSION = 1.15.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.miden.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "private": true,
   "engines": {
     "node": ">=22.0.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Miden Wallet",
-  "version": "1.15.1",
+  "version": "1.15.2",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",


### PR DESCRIPTION
Patch release on top of the guardian integration merge (#153).

## Version bumps
- `package.json` + `public/manifest.json`: 1.15.1 → **1.15.2**
- Android: `versionName 1.15.2`, `versionCode 11502001`
- iOS: `MARKETING_VERSION 1.15.2`, `CURRENT_PROJECT_VERSION 5`

## What's in 1.15.2 (since 1.15.1)
All from #153:
- **Guardian now runs on Miden 0.15** — OZ guardian/multisig client pinned to `0.15.0-rc.0` (built against SDK ^0.15.0), replacing the published `0.14.9` that crashed `MultisigClient.create()` with `memory access out of bounds` on the 0.15 SDK. Create/consume/send work end-to-end.
- **Custom-transaction support for Guardian accounts.**
- `@miden-sdk/miden-sdk` + `@miden-sdk/react` 0.15.1 → **0.15.2**.
- Fixed the devnet Guardian endpoint host (`stg-guardian` → `guardian-stg.openzeppelin.com`).

## ⚠️ Guardian is devnet-only in this release
The hosted devnet Guardian runs the 0.15 server; the testnet/production Guardian is still on the 0.14 server and is incompatible with the 0.15-rc client until OpenZeppelin publishes a 0.15 server. Called out in the CHANGELOG.

No dependency changes vs main (SDK 0.15.2 + OZ rc.0 already landed via #153), so `yarn.lock` is unchanged.