### PR TITLE
fix(e2e): drop colons from guardian/stress test titles (artifact upload)

### DIFF
--- a/playwright/e2e/stress/stress.spec.ts
+++ b/playwright/e2e/stress/stress.spec.ts
@@ -66,7 +66,7 @@ function parseOptions(): StressOptions {
   };
 }
 
-test.describe('Stress: random send/claim', () => {
+test.describe('Stress - random send/claim', () => {
   test.describe.configure({ mode: 'serial' });
 
   // No per-test timeout — the driver's `numNotes` is the stop condition.

--- a/playwright/e2e/tests/guardian-send-consume.spec.ts
+++ b/playwright/e2e/tests/guardian-send-consume.spec.ts
@@ -12,7 +12,7 @@ const GUARDIAN_URL = process.env.GUARDIAN_URL ?? 'http://localhost:3000';
  * full ECDSA chain — wallet signs, guardian co-signs, multisig verifies on-chain
  * — which is the path unit tests can only mock.
  */
-test.describe('Guardian account: consume + send', () => {
+test.describe('Guardian account - consume + send', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('guardian wallet A funds, consumes notes, and sends to wallet B', async ({


### PR DESCRIPTION
## Problem
After #288 enabled the guardian E2E against the hosted 0.15 endpoint, **Chrome Guardian E2E (devnet)** went red on `main` — but the **test passed** (`✓ guardian wallet A funds, consumes notes, and sends to wallet B`). The failure is the `Upload artifacts` step:

```
##[error]The path for one of the files in artifact is not valid:
  ...guardian-send-consume.spec.ts-Guardian_account:_consume_+_send-.../checkpoints.json.
  Contains the following character: Colon :
```

Playwright bakes the `describe` title into the artifact path, and `actions/upload-artifact@v4` rejects paths containing a colon. It only surfaced now because the test finally runs to completion (the old `v0.14.9` job died before producing artifacts).

## Fix
Remove the colons from the two `describe` titles that have them:
- `'Guardian account: consume + send'` → `'Guardian account - consume + send'`
- `'Stress: random send/claim'` → `'Stress - random send/claim'` (same latent issue; the stress suite writes the same colon-path artifacts)

No code depends on these titles — the guardian config uses file-based `testMatch` and there are no `-g` title filters.

Unblocks `chrome-guardian-gate` going green on main.