### PR TITLE
fix(ios-e2e): recover wedged CoreSimulatorService in the per-test path

### DIFF
--- a/playwright/e2e/ios/fixtures/two-simulators.ts
+++ b/playwright/e2e/ios/fixtures/two-simulators.ts
@@ -15,7 +15,7 @@ import type {
   SnapshotCaps,
 } from '../../harness/types';
 import { MidenCli, resolveCliPath } from '../../helpers/miden-cli';
-import { CdpBridge, type CdpSession } from '../helpers/cdp-bridge';
+import { CdpBridge, type CdpSession, isCdpNoPagesError } from '../helpers/cdp-bridge';
 import { IosWalletPage } from '../helpers/ios-wallet-page';
 import { isSimctlTimeoutError, SimulatorControl } from '../helpers/simulator-control';
 
@@ -186,7 +186,11 @@ async function setupBothWallets(
   envConfig: EnvironmentConfig,
   timeline: TimelineRecorder
 ): Promise<{ instanceA: SimWalletInstance; instanceB: SimWalletInstance }> {
-  const MAX_ATTEMPTS = 2;
+  // 3 attempts = up to 2 daemon-restart recoveries. The macos-26 wedge has been
+  // observed to survive a single recovery, so give it one more shot before
+  // failing the test (each wedged attempt fails fast at its simctl/CDP timeout,
+  // not the 15-min test timeout, so the extra attempt is cheap).
+  const MAX_ATTEMPTS = 3;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     let instanceA: SimWalletInstance | undefined;
     let instanceB: SimWalletInstance | undefined;
@@ -200,14 +204,19 @@ async function setupBothWallets(
       // Drop any half-open CDP sockets from this attempt before recovering.
       await instanceA?.cdp.close().catch(() => undefined);
       await instanceB?.cdp.close().catch(() => undefined);
-      if (isSimctlTimeoutError(err) && attempt < MAX_ATTEMPTS) {
+      // Both signatures point at the same wedged macos-26 sim subsystem: a
+      // hung `simctl` call, or webinspectord exposing no WebViews (CDP blind).
+      // recoverSimSubsystem fixes both (restart CoreSimulatorService + relaunch
+      // Simulator.app so webinspectord re-exposes WebViews + re-boot devices).
+      if ((isSimctlTimeoutError(err) || isCdpNoPagesError(err)) && attempt < MAX_ATTEMPTS) {
         timeline.emit({
           category: 'test_lifecycle',
           severity: 'warn',
           message:
-            `[sim-recovery] ${err.message} — CoreSimulatorService looks wedged; ` +
-            `restarting it + re-booting both devices, then retrying wallet setup ` +
-            `(attempt ${attempt + 1}/${MAX_ATTEMPTS})`,
+            `[sim-recovery] ${err.message} — sim subsystem looks wedged ` +
+            `(simctl hang or no inspectable WebViews); restarting ` +
+            `CoreSimulatorService + re-booting both devices, then retrying wallet ` +
+            `setup (attempt ${attempt + 1}/${MAX_ATTEMPTS})`,
         });
         await SimulatorControl.recoverSimSubsystem([udidA, udidB]);
         continue;

--- a/playwright/e2e/ios/fixtures/two-simulators.ts
+++ b/playwright/e2e/ios/fixtures/two-simulators.ts
@@ -17,7 +17,7 @@ import type {
 import { MidenCli, resolveCliPath } from '../../helpers/miden-cli';
 import { CdpBridge, type CdpSession } from '../helpers/cdp-bridge';
 import { IosWalletPage } from '../helpers/ios-wallet-page';
-import { SimulatorControl } from '../helpers/simulator-control';
+import { isSimctlTimeoutError, SimulatorControl } from '../helpers/simulator-control';
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -172,6 +172,54 @@ async function launchSimWalletInstance(
 }
 
 /**
+ * Launch both wallet instances, recovering from a wedged CoreSimulatorService.
+ * If a per-wallet `simctl` op blocks to its timeout (the macos-26 daemon-wedge
+ * signature), restart the sim subsystem and retry the whole pair once — the
+ * daemon restart drops both sims, so any partial state from this attempt is
+ * discarded and both wallets are re-launched fresh.
+ */
+async function setupBothWallets(
+  simA: SimulatorControl,
+  udidA: string,
+  simB: SimulatorControl,
+  udidB: string,
+  envConfig: EnvironmentConfig,
+  timeline: TimelineRecorder
+): Promise<{ instanceA: SimWalletInstance; instanceB: SimWalletInstance }> {
+  const MAX_ATTEMPTS = 2;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    let instanceA: SimWalletInstance | undefined;
+    let instanceB: SimWalletInstance | undefined;
+    try {
+      // Sequential within an attempt: parallel simctl install/launch across two
+      // sims can deadlock CoreSimulatorService on cold macos-26 runners.
+      instanceA = await launchSimWalletInstance(simA, udidA, envConfig, timeline, 'A');
+      instanceB = await launchSimWalletInstance(simB, udidB, envConfig, timeline, 'B');
+      return { instanceA, instanceB };
+    } catch (err) {
+      // Drop any half-open CDP sockets from this attempt before recovering.
+      await instanceA?.cdp.close().catch(() => undefined);
+      await instanceB?.cdp.close().catch(() => undefined);
+      if (isSimctlTimeoutError(err) && attempt < MAX_ATTEMPTS) {
+        timeline.emit({
+          category: 'test_lifecycle',
+          severity: 'warn',
+          message:
+            `[sim-recovery] ${err.message} — CoreSimulatorService looks wedged; ` +
+            `restarting it + re-booting both devices, then retrying wallet setup ` +
+            `(attempt ${attempt + 1}/${MAX_ATTEMPTS})`,
+        });
+        await SimulatorControl.recoverSimSubsystem([udidA, udidB]);
+        continue;
+      }
+      throw err;
+    }
+  }
+  // The loop body always returns or throws; this satisfies the type checker.
+  throw new Error('setupBothWallets: exhausted recovery attempts');
+}
+
+/**
  * Build platform-neutral SnapshotCaps for an iOS wallet. Mirrors
  * buildChromeSnapshotCaps in two-wallets.ts — the harness sees a uniform
  * surface.
@@ -274,11 +322,11 @@ export const test = base.extend<TwoSimulatorFixtures>({
     const simA = new SimulatorControl();
     const simB = new SimulatorControl();
 
-    // Sequential: parallel simctl install/launch across two sims can deadlock
-    // CoreSimulatorService on cold macos-26 runners (observed 14+ min silent
-    // hangs in CI). The shared `_simPair` fixture still consolidates teardown.
-    const instanceA = await launchSimWalletInstance(simA, udidA, envConfig, timeline, 'A');
-    const instanceB = await launchSimWalletInstance(simB, udidB, envConfig, timeline, 'B');
+    // Launch both wallets, recovering from a wedged CoreSimulatorService (the
+    // macos-26 daemon-wedge that hangs simctl mid-suite) by restarting the sim
+    // subsystem and retrying the pair. The shared `_simPair` fixture still
+    // consolidates teardown.
+    const { instanceA, instanceB } = await setupBothWallets(simA, udidA, simB, udidB, envConfig, timeline);
     steps.registerSnapshotCaps('A', buildIosSnapshotCaps(instanceA.walletPage, ''));
     steps.registerSnapshotCaps('B', buildIosSnapshotCaps(instanceB.walletPage, ''));
 

--- a/playwright/e2e/ios/helpers/cdp-bridge.ts
+++ b/playwright/e2e/ios/helpers/cdp-bridge.ts
@@ -233,11 +233,7 @@ export class CdpBridge {
     }
     if (!pages || pages.length === 0) {
       await rd.disconnect();
-      throw new Error(
-        `CdpBridge: no pages found for bundleId=${bundleId} on udid=${udid} ` +
-          `within ${SELECT_APP_TIMEOUT}ms. Is the app running and built with ` +
-          `isInspectable=true?`
-      );
+      throw new CdpNoPagesError(bundleId, udid, SELECT_APP_TIMEOUT);
     }
 
     // Page id is "<appKey>.<pageNum>" — selectPage takes them split.
@@ -344,4 +340,32 @@ async function detectIOSVersion(udid: string): Promise<string> {
   }
   // Fallback — recent default
   return '26.3';
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when webinspectord_sim never exposes the app's WebView within
+ * SELECT_APP_TIMEOUT after a fresh launch. On macos-26 CI runners this is a
+ * symptom of a wedged CoreSimulator / webinspectord subsystem — the same
+ * daemon-wedge that also hangs `simctl`. Callers catch this (alongside
+ * SimctlTimeoutError) to trigger `recoverSimSubsystem` and retry, rather than
+ * burning the whole test timeout.
+ */
+export class CdpNoPagesError extends Error {
+  constructor(
+    public readonly bundleId: string,
+    public readonly udid: string,
+    public readonly timeoutMs: number
+  ) {
+    super(
+      `CdpBridge: no pages found for bundleId=${bundleId} on udid=${udid} ` +
+        `within ${timeoutMs}ms. Is the app running and built with isInspectable=true?`
+    );
+    this.name = 'CdpNoPagesError';
+  }
+}
+
+export function isCdpNoPagesError(err: unknown): err is CdpNoPagesError {
+  return err instanceof CdpNoPagesError;
 }

--- a/playwright/e2e/ios/helpers/simulator-control.ts
+++ b/playwright/e2e/ios/helpers/simulator-control.ts
@@ -214,6 +214,42 @@ export class SimulatorControl {
     }
     return out;
   }
+
+  /**
+   * Recover a wedged CoreSimulator subsystem mid-suite. On macos-26 CI runners
+   * the CoreSimulatorService daemon intermittently stops responding, after
+   * which every `simctl` call blocks until its timeout — and Playwright's retry
+   * fails identically because nothing restarts the daemon between attempts.
+   * Force launchd to respawn a fresh daemon, relaunch Simulator.app so
+   * webinspectord_sim re-exposes WebViews (CDP is blind otherwise), then
+   * re-boot the devices so the caller can retry. Mirrors the cold-boot
+   * `ensure_bootable` recovery in e2e-blockchain.yml, reachable per-test.
+   */
+  static async recoverSimSubsystem(udids: string[]): Promise<void> {
+    try {
+      // -9 because a wedged daemon won't honor a graceful signal; launchd
+      // respawns it on the next simctl/CoreSimulator call.
+      await execFileAsync('sudo', ['killall', '-9', 'com.apple.CoreSimulator.CoreSimulatorService'], {
+        timeout: 30_000,
+      });
+    } catch {
+      // Non-zero if the process was already gone (or sudo unavailable off CI) —
+      // the daemon respawns on the next simctl call regardless.
+    }
+    await sleep(5_000);
+    // webinspectord_sim only exposes WebViews while Simulator.app is running;
+    // killing the daemon tears it down, so bring it back before re-booting.
+    try {
+      await execFileAsync('open', ['-a', 'Simulator'], { timeout: 30_000 });
+    } catch {
+      // Best-effort — boot below still works for non-CDP simctl ops.
+    }
+    await sleep(5_000);
+    const sim = new SimulatorControl();
+    for (const udid of udids) {
+      await sim.ensureBooted(udid);
+    }
+  }
 }
 
 // ── Internals ───────────────────────────────────────────────────────────────
@@ -222,8 +258,25 @@ export class SimulatorControl {
 // `simctl install` / `launch` against an unhealthy simulator hangs
 // indefinitely, silently eating the whole 15-minute test timeout with no
 // attribution. Failing in 3 minutes with the command named turns that into
-// a diagnosable error (and lets the CI-level retry actually retry).
+// a diagnosable error (and lets the per-test recovery + CI retry actually
+// kick in — see SimulatorControl.recoverSimSubsystem).
 const SIMCTL_TIMEOUT_MS = 180_000;
+
+/**
+ * A `simctl` call that blocked until SIMCTL_TIMEOUT_MS. On macos-26 this is
+ * the signature of a wedged CoreSimulatorService daemon — callers catch this
+ * specific type to trigger recoverSimSubsystem rather than failing outright.
+ */
+export class SimctlTimeoutError extends Error {
+  constructor(public readonly command: string) {
+    super(`simctl timed out after ${SIMCTL_TIMEOUT_MS}ms: simctl ${command}`);
+    this.name = 'SimctlTimeoutError';
+  }
+}
+
+export function isSimctlTimeoutError(err: unknown): err is SimctlTimeoutError {
+  return err instanceof SimctlTimeoutError;
+}
 
 async function execSimctl(args: string[]): Promise<{ stdout: string; stderr: string }> {
   try {
@@ -231,7 +284,7 @@ async function execSimctl(args: string[]): Promise<{ stdout: string; stderr: str
   } catch (err) {
     const e = err as Error & { killed?: boolean; signal?: string };
     if (e.killed || e.signal === 'SIGTERM') {
-      throw new Error(`simctl timed out after ${SIMCTL_TIMEOUT_MS}ms: simctl ${args.join(' ')}`);
+      throw new SimctlTimeoutError(args.join(' '));
     }
     throw err;
   }


### PR DESCRIPTION
## Root cause
The persistent **Mobile E2E (devnet)** failures are a macos-26 **CoreSimulatorService daemon wedge mid-suite**. When it wedges, every `simctl` call (`terminate`/`uninstall`/`install`/`launch`) blocks until its 180s timeout.

The cold-boot workflow step already recovers a wedged daemon (`killall -9 CoreSimulatorService` → `open -a Simulator` → reboot), but the **per-test** `launchSimWalletInstance` path had **no equivalent** — so a mid-suite wedge failed the test, and Playwright's retry failed identically because nothing restarted the daemon between attempts. The `CdpBridge: no pages found … isInspectable=true` error is a *downstream symptom* (the app never came up because `simctl` was wedged), not the cause.

**Evidence** (same cause, different verb each run): `92b24ebbd` hung on `simctl install`; `f61e4309d` hung on `simctl terminate`. Both failed identically on retry. This is a *different* layer than the build-find-device flake #285 fixed (build passes now) — it was hidden behind that one until #285 unblocked the build.

## Fix
- `execSimctl` now throws a typed `SimctlTimeoutError` on the 180s timeout.
- The fixture catches it and runs `SimulatorControl.recoverSimSubsystem` — `killall -9 CoreSimulatorService` → `open -a Simulator` (so `webinspectord_sim` re-exposes WebViews) → re-boot both devices — then retries the whole wallet-pair setup once (the daemon restart drops both sims, so partial state is discarded). Mirrors the proven cold-boot recovery, reachable per-test.

## Verification
The wedge is **nondeterministic and CI-runner-specific** — not reproducible locally. Verifying via `workflow_dispatch` runs of e2e-blockchain on this branch (devnet). tsc passes; `playwright/` isn't covered by the `eslint src` lint gate, and the diff stays consistent with the file's existing style.