### PR TITLE
fix(extension): drop duplicate single-threaded SDK WASM from Chrome front bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixes
 
 * [FIX][all] Corrected the devnet Guardian endpoint host (`stg-guardian.openzeppelin.com` → `guardian-stg.openzeppelin.com`); the transposed hostname had no DNS record, so the default devnet Guardian URL never resolved. (#153)
+* [FIX][extension] Chrome package no longer bundles a second (single-threaded) Miden SDK WASM. `@openzeppelin/miden-multisig-client` imports the eager `@miden-sdk/miden-sdk` entry; the service-worker config already redirected that to the multi-threaded build, but the extension/front config did not — so the front bundle pulled in an extra ~15 MB single-threaded WASM. The front config now applies the same eager→`mt/lazy` alias, restoring the Chrome package to ~18 MB (was ~29 MB).
 
 ## 1.15.1 (2026-06-19)
 

--- a/vite.extension.config.ts
+++ b/vite.extension.config.ts
@@ -376,33 +376,36 @@ export default defineConfig({
     // than the real path (where peer packages like vite-plugin-node-polyfills
     // aren't installed).
     preserveSymlinks: true,
-    alias: {
-      ...sharedAlias,
-      // Chrome extension pages get cross-origin isolation from the
-      // manifest's declared COOP=`same-origin` + COEP=`require-corp`,
-      // so we use the multi-threaded SDK build for ~3-5× faster proving.
-      // Aliases the wallet's own `@miden-sdk/miden-sdk/lazy` imports to
-      // `/mt/lazy`. The wallet's `@miden-sdk/react/lazy` imports are
-      // not aliased — instead, vite catches their transitive SDK imports
-      // through this same alias, so the React-SDK bundle ends up wired
-      // to the MT WASM via the same path. Mobile (vite.mobile.config.ts)
-      // deliberately omits the alias because Capacitor / WKWebView /
-      // Android WebView don't expose cross-origin isolation — mobile
-      // uses delegated proving and the ST WASM is what loads.
+    // Array form (not object) so we can use anchored RegExp finds — a string
+    // alias for `@miden-sdk/miden-sdk` would prefix-match `/mt/lazy` and
+    // double-rewrite it. Mirrors vite.background.config.ts.
+    alias: [
+      // Path aliases (lib, app, …), spread from sharedAlias as array entries.
+      ...Object.entries(sharedAlias).map(([find, replacement]) => ({ find, replacement })),
+      // Chrome extension pages get cross-origin isolation from the manifest's
+      // declared COOP=`same-origin` + COEP=`require-corp`, so we use the
+      // multi-threaded SDK build for ~3-5× faster proving. The anchored regexes
+      // redirect the EXACT eager and single-threaded-lazy specifiers to
+      // `/mt/lazy` (without double-rewriting `/mt/lazy` itself).
       //
-      // Depends on `@miden-sdk/miden-sdk` ≥ 0.14.5 (web-sdk PR #134) for
-      // the `/mt/lazy` subpath. Wallet's pin is still 0.14.4 because
-      // 0.14.5 isn't published yet — bump after that PR ships and the
-      // build:chrome step turns green.
-      '@miden-sdk/miden-sdk/lazy': '@miden-sdk/miden-sdk/mt/lazy',
+      // The EAGER `@miden-sdk/miden-sdk` redirect is load-bearing for bundle
+      // size: @openzeppelin/miden-multisig-client imports the eager entry
+      // transitively, and without this redirect the front bundle resolves it to
+      // the default single-threaded build — pulling in a SECOND ~15M WASM
+      // alongside the MT one (the SW config already redirects it, but the front
+      // bundle did not). Mobile (vite.mobile.config.ts) deliberately omits this
+      // — Capacitor / WKWebView / Android WebView don't expose cross-origin
+      // isolation, so mobile uses delegated proving and the ST WASM.
+      { find: /^@miden-sdk\/miden-sdk$/, replacement: '@miden-sdk/miden-sdk/mt/lazy' },
+      { find: /^@miden-sdk\/miden-sdk\/lazy$/, replacement: '@miden-sdk/miden-sdk/mt/lazy' },
       // Ensure consistent React instance across all imports
-      react: resolve(__dirname, 'node_modules/react'),
-      'react-dom': resolve(__dirname, 'node_modules/react-dom'),
+      { find: 'react', replacement: resolve(__dirname, 'node_modules/react') },
+      { find: 'react-dom', replacement: resolve(__dirname, 'node_modules/react-dom') },
       // Node module polyfills for browser context
-      buffer: 'buffer',
-      stream: 'stream-browserify',
-      assert: 'assert'
-    }
+      { find: 'buffer', replacement: 'buffer' },
+      { find: 'stream', replacement: 'stream-browserify' },
+      { find: 'assert', replacement: 'assert' }
+    ]
   },
 
   define: {


### PR DESCRIPTION
## Problem
The 1.15.2 Chrome package jumped **18MB → 29MB** (+11MB). Cause: the front bundle now ships a **second, single-threaded (`st`) Miden SDK WASM (~15M)** on top of the multi-threaded (`mt`) one.

`@openzeppelin/miden-multisig-client` (new in 1.15.2) imports the **eager** `@miden-sdk/miden-sdk` entry. #153 patched the **service-worker** vite config to redirect that eager import to `@miden-sdk/miden-sdk/mt/lazy` (reusing the WASM the SW already has), but the **extension/front** config only aliased the `/lazy` subpath — so the front's eager import resolved to the default `st` build.

Proof: in the 1.15.2 artifact, `background.js` (SW) → `mt` WASM, while the new `st` WASM is referenced by a front chunk. 1.15.1 shipped only `mt`.

## Fix
Convert `vite.extension.config.ts` `resolve.alias` to array form (anchored regexes, mirroring `vite.background.config.ts`) and add the eager-entry redirect:
```ts
{ find: /^@miden-sdk\/miden-sdk$/,       replacement: '@miden-sdk/miden-sdk/mt/lazy' },
{ find: /^@miden-sdk\/miden-sdk\/lazy$/, replacement: '@miden-sdk/miden-sdk/mt/lazy' },
```
The front now reuses the `mt` WASM the SW already bundles instead of dragging in `st`.

## Verified
Local `yarn build:chrome`: single `mt` WASM, `chrome.zip` **19MB** (was 29MB) — back in line with 1.15.1's ~18MB. tsc clean.