### PR TITLE
fix(mobile): fix splash hang from eager @miden-sdk TLA; add guardian iOS E2E

### DIFF
--- a/docs/superpowers/specs/2026-06-24-mobile-guardian-e2e-design.md
+++ b/docs/superpowers/specs/2026-06-24-mobile-guardian-e2e-design.md
@@ -88,3 +88,34 @@ iterate on any guardian-on-mobile bug it surfaces.
 
 - No `mobile-guardian` CI gate job; no testnet variant. Added only if the devnet
   verify passes.
+
+## Outcome (2026-06-24)
+
+Verify-first surfaced a **deterministic regression that broke the entire iOS E2E
+suite**, not just guardian:
+
+- **Symptom:** every iOS spec failed at `pollForSelector(onboarding-welcome)` —
+  the app launched but hung on the splash screen; React never mounted (CDP
+  showed `#root` empty, no `__TEST_STORE__`, zero testids).
+- **Root cause:** `@openzeppelin/miden-multisig-client` (the guardian client,
+  which entered the mobile bundle with #153) imports the **eager**
+  `@miden-sdk/miden-sdk` entry = `dist/st/eager.js`, whose line 35 is a top-level
+  `await getWasmOrThrow()`. The SDK's own comments warn this TLA hangs in
+  WKWebView/Capacitor. The hung await blocked module completion → React never
+  mounted → splash forever. Mobile last worked 2026-06-12, before #153.
+- **Why the first fix (`resolve.alias` eager→/lazy) failed:** `@miden-sdk/vite-plugin`
+  (`enforce: pre`) installs its own `^@miden-sdk/miden-sdk$` alias that rewrites
+  the bare specifier to the package directory (→ `exports['.']` → eager) and wins
+  the alias array. A diagnostic build proved the import still landed on `eager.js`.
+- **The fix (`vite.mobile.config.ts`):** a first-listed `enforce: pre` plugin
+  (`miden-sdk-eager-to-lazy`) with a `resolveId` hook that intercepts **both** the
+  bare specifier and the rewritten package-dir path, redirecting to `/lazy`
+  (`dist/st/index.js`, no TLA). ST not MT — WKWebView has no SharedArrayBuffer.
+- **Verified on devnet sims:** React mounts (`#root` populated, `__TEST_STORE__`
+  present); `guardian-send-consume.ios` passes end-to-end — A consumes 1000 via
+  the guardian consume-proposal, sends 500 to B via the guardian send-proposal,
+  B receives 500. **Guardian works on mobile.** The fix also un-breaks the
+  standard iOS specs (they shared the same hang).
+
+The TLA fix is logically a separate concern from the guardian test (it fixes the
+whole mobile suite + the shipped app) and is a candidate for its own PR.

--- a/docs/superpowers/specs/2026-06-24-mobile-guardian-e2e-design.md
+++ b/docs/superpowers/specs/2026-06-24-mobile-guardian-e2e-design.md
@@ -25,35 +25,50 @@ attributable reason that tells us what's broken about guardian-on-mobile.
 
 ## Key facts grounding the design
 
-- The **create** flow's `select-recovery-method` screen only *picks* Guardian vs
-  private — there is **no guardian-URL input** there (URL entry exists only in
-  the import flow and Settings). So a created guardian wallet uses the **network
-  default** endpoint. On devnet that default is `guardian-stg.openzeppelin.com`,
-  which is verified working with the 0.15 client. → the helper does **not** need
-  to inject a URL (avoids the async Capacitor-Preferences-over-CDP problem).
-- The iOS fixture `two-simulators` already provides two wallets (A, B) + a
-  `midenCli`, mirroring chrome's `two-wallets` — the same spec shape ports over.
-- The iOS CDP bridge `eval` is synchronous (`execute_script`); the helper must
-  rely on UI-driven steps + selector polling, not async in-page promises.
+- **Mobile was already implicitly guardian.** iOS `createNewWallet` uses the
+  `__test_skip_onboarding` bypass in `Welcome.tsx`, which skips the
+  `select-recovery-method` screen and falls through to the component's default
+  `walletType` — which is **`WalletType.Guardian`**. So every bypass-created
+  iOS wallet was a guardian account (`vault.ts` branches on `WalletType.Guardian`).
+- `WalletType.OffChain` is "fully private"; `WalletType.Guardian` is the
+  guardian (co-signed) type. A created guardian wallet uses the **network
+  default** guardian endpoint (devnet → `guardian-stg.openzeppelin.com`,
+  verified working), so the helper needs **no URL injection**.
+- The iOS fixture `two-simulators` provides two wallets (A, B) + `midenCli`,
+  mirroring chrome's `two-wallets`. iOS divergence: `getBalance` doesn't count
+  pending notes, so wallets claim explicitly before balance checks, and
+  `claimAllNotes` takes the custom `faucetId` for synthetic-metadata injection.
+- The iOS CDP bridge `eval` is synchronous (`execute_script`); the helper drives
+  the bypass + polls conditions, not async in-page promises.
 
 ## Components
 
-1. **`IosWalletPage.createGuardianWallet(password?)`** — mirrors
-   `createNewWallet`, but after tapping "Create a new wallet" it selects the
-   **Guardian** option on the `select-recovery-method` screen, then proceeds
-   through seed-phrase → verify → password → Ready. Returns `{ address, seedPhrase }`.
-   Uses the devnet default guardian endpoint (no URL injection).
+1. **`src/app/pages/Welcome.tsx`** — the `__test_skip_onboarding` bypass now
+   reads a `walletType` query param and `setWalletType`: no param →
+   **`OffChain` (private)**, `walletType=guardian` → `Guardian`. Gated entirely
+   by the existing test bypass; production onboarding is unchanged. This flips
+   the bypass default to private (so `createNewWallet` matches chrome and the
+   non-guardian iOS specs no longer implicitly depend on a guardian backend) and
+   enables explicit guardian creation.
 
-2. **`playwright/e2e/ios/tests/guardian-send-consume.ios.spec.ts`** — ports the
-   chrome `guardian-send-consume` spec onto the `two-simulators` fixture:
-   wallet A guardian-backed, B standard; `midenCli` deploys faucet + funds A; A
-   consumes its notes; A sends to B; assert B balance > 0. Guardian-width waits
-   (≥180s) for the extra co-sign HTTP round-trips, matching the chrome spec.
+2. **`IosWalletPage`** — `createNewWallet` → private (default); new
+   **`createGuardianWallet(password?)`** → bypass with `walletType=guardian`.
+   Both delegate to a private `createWalletViaBypass(password, recovery)` (wider
+   Ready timeout for the guardian co-sign round-trips). Returns `{ address, seedPhrase }`.
 
-3. **`playwright.ios.guardian.config.ts`** — extends `playwright.ios.config.ts`,
-   `testMatch: '**/guardian-*.ios.spec.ts'`; the base ios config adds a
-   `testIgnore` for guardian specs so the standard run is unaffected. New
-   `test:e2e:mobile:guardian:run` script (mirrors `test:e2e:mobile:run`).
+3. **`playwright/e2e/ios/tests/guardian-send-consume.ios.spec.ts`** — ports the
+   chrome `guardian-send-consume` spec onto `two-simulators`: A guardian, B
+   private; `midenCli` deploys faucet + funds A; A consumes (claim); A sends to
+   B; B claims; assert B balance > 0. ≥180s waits for co-sign round-trips.
+
+4. **`playwright.ios.guardian.config.ts`** — extends `playwright.ios.config.ts`,
+   `testMatch: '**/guardian-*.ios.spec.ts'`; the base ios config adds
+   `testIgnore: '**/guardian-*.ios.spec.ts'` so the standard run is unaffected.
+   New `test:e2e:mobile:guardian:run` script.
+
+**Side effect (intended):** the existing iOS specs now exercise the **private**
+path instead of being implicitly guardian — aligning mobile with chrome and
+removing the basic tests' accidental guardian-backend dependency.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-06-24-mobile-guardian-e2e-design.md
+++ b/docs/superpowers/specs/2026-06-24-mobile-guardian-e2e-design.md
@@ -1,0 +1,75 @@
+# Mobile (iOS) Guardian E2E — verify-first design
+
+**Date:** 2026-06-24
+**Branch:** `wiktor/mobile-guardian-e2e`
+**Status:** approved design, pre-implementation
+
+## Problem / goal
+
+The mobile (iOS) E2E suite does not exercise Guardian at all — `IosWalletPage`
+only has `createNewWallet` (no recovery option), and the import test
+deliberately picks a public account "so we don't need a guardian backend".
+Chrome has a full guardian path (`createGuardianWallet` helper +
+`guardian-send-consume.spec.ts` + `playwright.guardian.config.ts` + CI gate).
+
+Guardian has **never run on mobile** (Capacitor/WKWebView, single-threaded SDK,
+delegated proving). The goal is **verify-first**: build a mobile guardian
+create→fund→consume→send E2E mirroring chrome's, and run it to find out whether
+guardian works on mobile. CI gating is explicitly deferred.
+
+## Definition of done
+
+`guardian-send-consume.ios.spec.ts` runs against devnet + the hosted devnet
+guardian and either (a) passes end-to-end, or (b) fails with a clear,
+attributable reason that tells us what's broken about guardian-on-mobile.
+
+## Key facts grounding the design
+
+- The **create** flow's `select-recovery-method` screen only *picks* Guardian vs
+  private — there is **no guardian-URL input** there (URL entry exists only in
+  the import flow and Settings). So a created guardian wallet uses the **network
+  default** endpoint. On devnet that default is `guardian-stg.openzeppelin.com`,
+  which is verified working with the 0.15 client. → the helper does **not** need
+  to inject a URL (avoids the async Capacitor-Preferences-over-CDP problem).
+- The iOS fixture `two-simulators` already provides two wallets (A, B) + a
+  `midenCli`, mirroring chrome's `two-wallets` — the same spec shape ports over.
+- The iOS CDP bridge `eval` is synchronous (`execute_script`); the helper must
+  rely on UI-driven steps + selector polling, not async in-page promises.
+
+## Components
+
+1. **`IosWalletPage.createGuardianWallet(password?)`** — mirrors
+   `createNewWallet`, but after tapping "Create a new wallet" it selects the
+   **Guardian** option on the `select-recovery-method` screen, then proceeds
+   through seed-phrase → verify → password → Ready. Returns `{ address, seedPhrase }`.
+   Uses the devnet default guardian endpoint (no URL injection).
+
+2. **`playwright/e2e/ios/tests/guardian-send-consume.ios.spec.ts`** — ports the
+   chrome `guardian-send-consume` spec onto the `two-simulators` fixture:
+   wallet A guardian-backed, B standard; `midenCli` deploys faucet + funds A; A
+   consumes its notes; A sends to B; assert B balance > 0. Guardian-width waits
+   (≥180s) for the extra co-sign HTTP round-trips, matching the chrome spec.
+
+3. **`playwright.ios.guardian.config.ts`** — extends `playwright.ios.config.ts`,
+   `testMatch: '**/guardian-*.ios.spec.ts'`; the base ios config adds a
+   `testIgnore` for guardian specs so the standard run is unaffected. New
+   `test:e2e:mobile:guardian:run` script (mirrors `test:e2e:mobile:run`).
+
+## Verification
+
+Run **locally on this Mac** (single-tenant → avoids the shared-runner
+CoreSimulator flakiness): `yarn test:e2e:mobile:build` once, boot the sim pair,
+then `E2E_NETWORK=devnet yarn test:e2e:mobile:guardian:run`. Read the result;
+iterate on any guardian-on-mobile bug it surfaces.
+
+## Risks / unknowns
+
+- **Guardian-on-mobile is unverified** — the run may fail and reveal a real bug
+  (delegated-proving + guardian co-sign, or st-SDK guardian path). That is the
+  intended discovery.
+- Local run requires Xcode + iOS 26 simulators on this Mac (confirm before build).
+
+## Out of scope (deferred)
+
+- No `mobile-guardian` CI gate job; no testnet variant. Added only if the devnet
+  verify passes.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:e2e:mobile:build": "cross-env MIDEN_E2E_TEST=true MIDEN_NETWORK=${E2E_NETWORK:-testnet} yarn mobile:sync && xcodebuild -project ios/App/App.xcodeproj -scheme App -destination 'generic/platform=iOS Simulator' -configuration Debug -derivedDataPath ios/App/build build",
     "test:e2e:mobile": "yarn test:e2e:mobile:build && playwright test --config playwright.ios.config.ts",
     "test:e2e:mobile:run": "playwright test --config playwright.ios.config.ts",
+    "test:e2e:mobile:guardian:run": "playwright test --config playwright.ios.guardian.config.ts",
     "test:e2e:mobile:testnet": "cross-env E2E_NETWORK=testnet yarn test:e2e:mobile",
     "test:e2e:mobile:devnet": "cross-env E2E_NETWORK=devnet yarn test:e2e:mobile",
     "test:e2e:mobile:localhost": "cross-env E2E_NETWORK=localhost yarn test:e2e:mobile",

--- a/playwright.ios.config.ts
+++ b/playwright.ios.config.ts
@@ -9,6 +9,9 @@ import { defineConfig } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './playwright/e2e/ios/tests',
+  // Guardian specs run via playwright.ios.guardian.config.ts (dedicated run);
+  // keep them out of the standard iOS suite.
+  testIgnore: '**/guardian-*.ios.spec.ts',
   timeout: 900_000, // 15 min per test — WASM prove on simulator is slow (~60-90s per consume)
   expect: {
     timeout: 60_000,

--- a/playwright.ios.guardian.config.ts
+++ b/playwright.ios.guardian.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+import base from './playwright.ios.config';
+
+// Same harness as the iOS E2E config, but runs ONLY the guardian specs (which
+// the base iOS config ignores). Mirrors playwright.guardian.config.ts on the
+// Chrome side. Run with: yarn test:e2e:mobile:guardian:run (devnet uses the
+// network default guardian endpoint, guardian-stg).
+export default defineConfig({
+  ...base,
+  testIgnore: undefined,
+  testMatch: '**/guardian-*.ios.spec.ts',
+});

--- a/playwright/e2e/ios/helpers/ios-wallet-page.ts
+++ b/playwright/e2e/ios/helpers/ios-wallet-page.ts
@@ -105,23 +105,48 @@ export class IosWalletPage implements WalletPage {
   // ── Onboarding ────────────────────────────────────────────────────────────
 
   /**
-   * Bypass the seed-phrase flow via the wallet's official test hook, then
-   * tap "Get started" on the confirmation screen and wait for the store to
-   * reach Ready. Mirrors the Chrome `createNewWallet` contract.
+   * Create a fully-private (OffChain) wallet via the wallet's official test
+   * hook, then tap "Get started" on the confirmation screen and wait for the
+   * store to reach Ready. Mirrors the Chrome `createNewWallet` contract.
    */
   async createNewWallet(password: string = DEFAULT_PASSWORD): Promise<{ address: string; seedPhrase: string[] }> {
+    return this.createWalletViaBypass(password, 'private');
+  }
+
+  /**
+   * Create a Guardian (co-signed) wallet via the same onboarding bypass,
+   * passing `walletType=guardian` so `registerWallet` builds a guardian
+   * account. Uses the network-default guardian endpoint (devnet →
+   * guardian-stg). Mirrors the Chrome `createGuardianWallet` contract.
+   */
+  async createGuardianWallet(password: string = DEFAULT_PASSWORD): Promise<{ address: string; seedPhrase: string[] }> {
+    return this.createWalletViaBypass(password, 'guardian');
+  }
+
+  /**
+   * Bypass the seed-phrase flow via the wallet's official test hook
+   * (`__test_skip_onboarding`), selecting the wallet type via the
+   * `walletType` query param the bypass reads. After the navigation, the
+   * welcome screen auto-jumps to the confirmation step (random seed already
+   * generated, password set from the query param); tapping "Get started" then
+   * runs `registerWallet()`.
+   */
+  private async createWalletViaBypass(
+    password: string,
+    recovery: 'private' | 'guardian'
+  ): Promise<{ address: string; seedPhrase: string[] }> {
     // Welcome screen must be visible (fixture guarantees this on cold launch).
     await this.pollForSelector('[data-testid="onboarding-welcome"]', 30_000);
 
-    // Trigger Welcome.tsx's official test bypass via URL params. After the
-    // navigation, the welcome screen auto-jumps to the confirmation step
-    // (random seed already generated, password set from the query param);
-    // tapping "Get started" then runs registerWallet().
     const passwordEnc = encodeURIComponent(password);
+    // Guardian account creation does extra HTTP round-trips to co-sign with the
+    // guardian, so it needs a wider readiness window than a private wallet.
+    const readyTimeoutMs = recovery === 'guardian' ? 180_000 : 120_000;
     await this.cdp.eval(
       `var u = new URL(location.href); ` +
         `u.searchParams.set('__test_skip_onboarding', '1'); ` +
         `u.searchParams.set('password', '${passwordEnc}'); ` +
+        (recovery === 'guardian' ? `u.searchParams.set('walletType', 'guardian'); ` : '') +
         `location.href = u.toString(); ` +
         `return null;`
     );
@@ -148,13 +173,15 @@ export class IosWalletPage implements WalletPage {
         `if (!s) return false; ` +
         `var st = s.getState(); ` +
         `return st && (st.status === 2 || st.status === 'Ready') && !!st.currentAccount;`,
-      120_000
+      readyTimeoutMs
     );
 
     const address = await this.cdp.eval<string>(
       `var s = window.__TEST_STORE__.getState(); ` + `return (s.currentAccount && s.currentAccount.publicKey) || '';`
     );
-    if (!address) throw new Error('IosWalletPage.createNewWallet: no currentAccount.publicKey after Ready');
+    if (!address) {
+      throw new Error(`IosWalletPage.createWalletViaBypass(${recovery}): no currentAccount.publicKey after Ready`);
+    }
 
     // The bypass synthesizes the seed phrase internally — we don't read it
     // back. Specs that need a real seed should use importWallet().

--- a/playwright/e2e/ios/tests/guardian-send-consume.ios.spec.ts
+++ b/playwright/e2e/ios/tests/guardian-send-consume.ios.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '../fixtures/two-simulators';
+
+/**
+ * iOS port of the Chrome guardian-send-consume spec. Wallet A is Guardian-backed
+ * (created via the onboarding bypass with walletType=guardian → the network
+ * default guardian endpoint, which on devnet is guardian-stg). It is funded,
+ * consumes its incoming notes (guardian consume-proposal path), and sends to a
+ * standard wallet B (guardian send-proposal path). Both flows drive the full
+ * co-sign chain — wallet signs, guardian co-signs, multisig verifies on-chain —
+ * in the mobile WKWebView (single-threaded SDK + delegated proving), which the
+ * Chrome guardian spec can't cover.
+ *
+ * iOS divergences from the Chrome spec (same as the other *.ios specs):
+ *  - getBalance doesn't count pending notes, so each wallet claims explicitly
+ *    before its balance is checked.
+ *  - claimAllNotes is passed the custom faucetId so the iOS POM can pre-inject
+ *    synthetic metadata (the SDK's metadata RPC fails for this faucet layout).
+ */
+test.describe('Guardian account - consume + send', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('guardian wallet A funds, consumes notes, and sends to wallet B', async ({
+    walletA,
+    walletB,
+    midenCli,
+    steps,
+    timeline,
+  }) => {
+    let addressA: string;
+    let addressB: string;
+    let faucetId: string;
+
+    await steps.step('create_wallets', async () => {
+      // A is Guardian-backed (uses the network default guardian endpoint);
+      // B is a standard private wallet acting as the send recipient.
+      const a = await walletA.createGuardianWallet();
+      const b = await walletB.createNewWallet();
+      addressA = a.address;
+      addressB = b.address;
+    });
+
+    await steps.step('deploy_and_fund', async () => {
+      await midenCli.init();
+      faucetId = await midenCli.createFaucet();
+      expect(faucetId).toBeTruthy();
+      await midenCli.mint(addressA!, 100_000_000_000, 'public');
+      await midenCli.sync();
+    });
+
+    await steps.step(
+      'consume_notes_guardian_a',
+      async () => {
+        // Routes through generateGuardianTransaction → createConsumeNotesProposal.
+        await walletA.claimAllNotes(180_000, [faucetId!]);
+      },
+      {
+        captureStateFrom: [{ target: walletA, label: 'A' }],
+      }
+    );
+
+    await steps.step(
+      'verify_balance_guardian_a',
+      async () => {
+        const balance = await walletA.waitForBalanceAbove(0, 180_000, timeline);
+        expect(balance).toBeGreaterThan(0);
+      },
+      {
+        captureStateFrom: [{ target: walletA, label: 'A' }],
+      }
+    );
+
+    await steps.step(
+      'send_guardian_a_to_b',
+      async () => {
+        // Routes through generateGuardianTransaction → createSendProposal.
+        await walletA.sendTokens({
+          recipientAddress: addressB!,
+          amount: '500',
+          tokenSymbol: 'TST',
+          isPrivate: false,
+        });
+      },
+      {
+        captureStateFrom: [{ target: walletA, label: 'A' }],
+      }
+    );
+
+    await steps.step('claim_wallet_b', async () => {
+      await walletB.claimAllNotes(180_000, [faucetId!]);
+    });
+
+    await steps.step(
+      'verify_receipt_wallet_b',
+      async () => {
+        const balance = await walletB.waitForBalanceAbove(0, 180_000, timeline);
+        expect(balance).toBeGreaterThan(0);
+      },
+      {
+        captureStateFrom: [
+          { target: walletA, label: 'A' },
+          { target: walletB, label: 'B' },
+        ],
+      }
+    );
+  });
+});

--- a/src/app/pages/Welcome.tsx
+++ b/src/app/pages/Welcome.tsx
@@ -103,9 +103,18 @@ const Welcome: FC = () => {
     const skipViaGlobal = (globalThis as any).__TEST_SKIP_ONBOARDING === true;
     if (!skipViaParam && !skipViaGlobal) return;
 
-    console.log('[Welcome] Test bypass: setting up seed + password');
+    // Wallet type for the bypass: explicit `walletType=guardian` creates a
+    // Guardian (co-signed) account; anything else creates a fully-private
+    // (OffChain) account. The default is intentionally NOT the component's
+    // Guardian default — the bypass otherwise inherits it, which silently makes
+    // every bypass-created wallet guardian-backed. Defaulting to OffChain
+    // matches the Chrome E2E's private default and keeps non-guardian specs
+    // independent of a guardian backend.
+    const bypassWalletType = params.get('walletType') === 'guardian' ? WalletType.Guardian : WalletType.OffChain;
+    console.log(`[Welcome] Test bypass: setting up seed + password, walletType=${bypassWalletType}`);
     const testSeed = generateMnemonic(128).split(' ');
     const testPassword = params.get('password') || 'password1';
+    setWalletType(bypassWalletType);
     setSeedPhrase(testSeed);
     setPassword(testPassword);
     setOnboardingType(OnboardingType.Create);

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -14,6 +14,24 @@ const pkg = require('./package.json');
 
 export default defineConfig({
   plugins: [
+    {
+      name: 'miden-sdk-eager-to-lazy',
+      enforce: 'pre',
+      async resolveId(id, importer) {
+        // @openzeppelin/miden-multisig-client imports the bare @miden-sdk/miden-sdk,
+        // which @miden-sdk/vite-plugin's alias rewrites to the package DIRECTORY
+        // (→ exports['.'] = dist/st/eager.js, a top-level `await loadWasm()` that
+        // hangs at module init inside WKWebView/Capacitor — the app never mounts).
+        // That alias runs before this hook, so we match BOTH the bare specifier
+        // and the rewritten directory path, and redirect to the lazy entry
+        // (identical API, no top-level await; callers already await readiness).
+        // Mobile is single-threaded (no SAB), so /lazy (st), not /mt/lazy.
+        if (id === '@miden-sdk/miden-sdk' || /[\\/]node_modules[\\/]@miden-sdk[\\/]miden-sdk$/.test(id)) {
+          return this.resolve('@miden-sdk/miden-sdk/lazy', importer, { skipSelf: true });
+        }
+        return null;
+      }
+    },
     midenVitePlugin({
       rpcProxyTarget:
         process.env.MIDEN_NETWORK === 'devnet' ? 'https://rpc.devnet.miden.io' : 'https://rpc.testnet.miden.io'
@@ -141,6 +159,11 @@ export default defineConfig({
   },
 
   resolve: {
+    // NOTE: the eager→lazy @miden-sdk/miden-sdk redirect is done by the
+    // `miden-sdk-eager-to-lazy` plugin above (resolveId), NOT here. A
+    // resolve.alias entry can't win: @miden-sdk/vite-plugin installs its own
+    // `^@miden-sdk/miden-sdk$` alias (→ package dir → eager) that takes
+    // precedence in the alias array.
     alias: {
       lib: resolve(__dirname, 'src/lib'),
       app: resolve(__dirname, 'src/app'),


### PR DESCRIPTION
## Summary

Two related changes, discovered together while building a mobile guardian E2E:

1. **`fix(mobile)`: the mobile app hangs on the splash screen on launch** — a deterministic regression, not the "flaky E2E" it was mistaken for. **Very likely affects the shipped mobile app**, not just tests.
2. **`test(ios-e2e)`: explicit private/guardian wallet creation + a guardian iOS E2E spec**, mirroring the Chrome guardian test (the original ask).

## The bug (fix(mobile))

`@openzeppelin/miden-multisig-client` / `@openzeppelin/guardian-client` import the **eager** `@miden-sdk/miden-sdk` entry (`dist/st/eager.js`), whose module body ends in a top-level `await getWasmOrThrow()`. In WKWebView/Capacitor that top-level await never settles, so the entry module never finishes executing → **React never mounts → the app is stuck on the splash screen.** The SDK's own `eager.js` comments warn this TLA hangs in Capacitor and say to import `/lazy` instead. The wallet's own code already uses `/lazy`; the OZ guardian client is the only eager importer.

These imports are **static** (`src/lib/miden/guardian/*.ts`, `src/lib/miden/activity/transactions.ts`) and `vite.mobile.config` uses `inlineDynamicImports: true`, so the eager entry lands in the **boot bundle** → the app hangs on launch. Regressed when the guardian client entered the mobile bundle. This is what made the entire iOS E2E suite fail at `pollForSelector(onboarding-welcome)` — read as flaky infra, but it's deterministic (failed 3/3 + 2/2, single-tenant).

### Why `resolve.alias` can't fix it

`@miden-sdk/vite-plugin` (`enforce: pre`) installs its own `^@miden-sdk/miden-sdk$` alias that rewrites the bare specifier to the package **directory** (→ `exports['.']` → eager) and wins the alias array; vite's alias plugin also runs before user `resolveId` hooks. So the fix is a **first-listed `enforce: pre` plugin** (`miden-sdk-eager-to-lazy`) whose `resolveId` matches **both** the bare specifier and the rewritten package-dir path and redirects to `@miden-sdk/miden-sdk/lazy` (`dist/st/index.js` — identical API, no top-level await). Mobile is single-threaded (no `SharedArrayBuffer` in WKWebView) → `/lazy` (st), not `/mt/lazy`. (Chrome SW/extension solve the same eager-import problem but redirect to `/mt/lazy`; mobile was the missing third config.)

## The guardian iOS E2E (test(ios-e2e))

- The iOS onboarding **bypass** (`Welcome.tsx` `__test_skip_onboarding`) silently inherited the component's default `walletType = Guardian`, so every iOS `createNewWallet` was implicitly guardian-backed. The bypass now reads a `walletType` query param → default **`OffChain` (private)**, `walletType=guardian` → `Guardian`. Gated entirely by the test hook; production onboarding unchanged.
- `IosWalletPage`: `createNewWallet` → private (matches Chrome); new `createGuardianWallet` → guardian.
- `guardian-send-consume.ios.spec.ts` + `playwright.ios.guardian.config.ts` + base-config `testIgnore` + `test:e2e:mobile:guardian:run`.

## Verification (devnet simulators)

- React mounts again (`#root` populated, `__TEST_STORE__` present, testids render).
- **`guardian-send-consume.ios` passes end-to-end:** A consumes **1000** via the guardian consume-proposal, sends **500** to B via the guardian send-proposal, B receives 500 — i.e. the full wallet-signs → guardian-co-signs → multisig-verifies chain works in the mobile WKWebView. **Guardian works on mobile.**
- Standard iOS spec (`mint-and-balance`) passes again.

## Known residual (out of scope here)

A **secondary, intermittent** onboarding flake remains (a standard run failed attempt 1, passed on retry) — the pre-existing macOS-simulator issue, distinct from the TLA hang. Retries recover it; true 0% needs the dedicated-runner work. The guardian spec is **not yet CI-gated** (verify-first); wiring it into `e2e-blockchain.yml` is a follow-up now that it passes.

Design/notes: `docs/superpowers/specs/2026-06-24-mobile-guardian-e2e-design.md`.
