### PR TITLE
ci(mobile): add Mobile Guardian E2E gate (devnet + testnet, retries)

### DIFF
--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -735,3 +735,372 @@ jobs:
           fi
           echo "Mobile E2E: both networks failed or were skipped."
           exit 1
+
+  # --- iOS Simulator: Guardian --------------------------------------------
+  # Same iOS harness as mobile-{devnet,testnet} but runs ONLY the guardian spec
+  # (playwright.ios.guardian.config.ts). No GUARDIAN_URL: the mobile guardian
+  # wallet uses the network DEFAULT guardian endpoint (devnet ->
+  # guardian-stg.openzeppelin.com, testnet -> guardian.openzeppelin.com), which
+  # in-app onboarding selects automatically. Gated separately (mobile-guardian-
+  # gate) so a guardian outage never blocks the standard mobile gate.
+  mobile-guardian-devnet:
+    name: Mobile Guardian E2E (devnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    # macos-26 matches build-mobile.yml — required for iOS 26 SDK symbols
+    # used by dapp-browser's WKWebViewController.
+    runs-on: macos-26
+    # ~40 min setup (CLI compile on cache miss + iOS build + sim cold boot)
+    # plus a single guardian spec with up to 2 retries. Generous ceiling that
+    # matches the standard mobile jobs so a passing build is never guillotined.
+    timeout-minutes: 130
+    env:
+      E2E_NETWORK: devnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          # Decoupled from the JS SDK version — read the CLI pin from
+          # package.json. `midenClientCliGit` ({url, rev}) takes precedence
+          # over `midenClientCliVersion` and is used while the target
+          # miden-client line is unreleased on crates.io (the 0.15 series
+          # ships from the repo's `next` branch only). See
+          # playwright/e2e/helpers/miden-cli.ts for the matching local-dev
+          # path.
+          GIT_URL=$(node -p "require('./package.json').midenClientCliGit?.url ?? ''")
+          GIT_REV=$(node -p "require('./package.json').midenClientCliGit?.rev ?? ''")
+          VERSION=$(node -p "require('./package.json').midenClientCliVersion")
+          if [[ -z "$GIT_URL" && (-z "$VERSION" || "$VERSION" == "undefined") ]]; then
+            echo "::error::neither midenClientCliGit nor midenClientCliVersion present in package.json"
+            exit 1
+          fi
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          elif [[ -n "$GIT_URL" ]]; then
+            echo "Installing miden-client-cli from ${GIT_URL}@${GIT_REV:0:8}..."
+            cargo install miden-client-cli --git "$GIT_URL" --rev "$GIT_REV" --locked
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
+
+      # CDP bridge (appium-remote-debugger) requires Simulator.app GUI to be
+      # running — headless simctl boots don't expose webinspectord. Ignore
+      # exit status because `open -a` returns 0 even if already open.
+      - name: Launch Simulator.app
+        run: open -a Simulator || true
+
+      # Fresh-create + boot of custom simulators hangs multi-minute then
+      # errors on macos-26 runners. Pin the test harness to preinstalled
+      # Xcode sims by writing .device-pair.json before globalSetup reads it.
+      - name: Pin test pair to preinstalled simulators
+        shell: bash
+        run: |
+          list_json=$(xcrun simctl list devices --json)
+          UDID_A=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17" and .isAvailable) ]
+            | first | .udid // empty')
+          UDID_B=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17 Pro" and .isAvailable) ]
+            | first | .udid // empty')
+          if [[ -z "$UDID_A" || -z "$UDID_B" ]]; then
+            echo "Missing preinstalled sim. A='$UDID_A'  B='$UDID_B'"
+            echo "Full device list:"
+            xcrun simctl list devices
+            exit 1
+          fi
+          mkdir -p test-results-ios
+          printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
+          echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
+
+      # Kick the cold boot off NOW so it overlaps the ~25-minute app build.
+      # First boot of an iOS 26 runtime on a cold runner takes many minutes
+      # (dyld shared-cache build); booting only in playwright's globalSetup
+      # left the suite racing a half-booted simulator, where simctl
+      # install/launch hang for the full test timeout. `simctl boot` is
+      # asynchronous — globalSetup's bootstatus gate later confirms
+      # readiness, which by then is long since done.
+      - name: Pre-boot simulators (async, overlaps build)
+        shell: bash
+        run: |
+          # On a cold runner CoreSimulatorService may not respond ("Unable
+          # to boot the Simulator. launchd failed to respond",
+          # SimLaunchHostService code 4) — retry with backoff. If retries
+          # exhaust, the service is wedged, and a wedged CoreSimulatorService
+          # breaks MORE than booting: xcodebuild stops seeing any simulator
+          # destinations, so the build step would fail 25 minutes later
+          # anyway (observed). Restart the service once; if the subsystem
+          # still can't boot, fail the job HERE — minutes in, clearly
+          # attributed, and cheap to rerun.
+          UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
+          UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
+          boot_with_retry() {
+            local udid="$1"
+            for attempt in 1 2 3 4; do
+              state=$(xcrun simctl list devices | grep "$udid" | grep -o '(Booted)\|(Shutdown)\|(Booting)' || true)
+              if [[ "$state" == "(Booted)" || "$state" == "(Booting)" ]]; then
+                echo "$udid already $state"
+                return 0
+              fi
+              if xcrun simctl boot "$udid"; then
+                echo "$udid boot issued (attempt $attempt)"
+                return 0
+              fi
+              echo "boot attempt $attempt for $udid failed; retrying in 20s"
+              sleep 20
+            done
+            return 1
+          }
+          ensure_bootable() {
+            local udid="$1"
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "CoreSimulatorService appears wedged; restarting it"
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+            sleep 15
+            open -a Simulator || true
+            sleep 10
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "::error::simulator subsystem unusable on this runner (boot of $udid failed after CoreSimulatorService restart)"
+            return 1
+          }
+          ensure_bootable "$UDID_A"
+          ensure_bootable "$UDID_B"
+          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
+
+      # The iOS app is built for a GENERIC simulator destination
+      # (generic/platform=iOS Simulator) — see the test:e2e:mobile:build
+      # script. A build doesn't need a concrete booted device, and the
+      # generic destination resolves to the "Any iOS Simulator Device"
+      # placeholder even when Xcode's IDE-layer CoreSimulator goes blind to
+      # concrete sims on macos-26 runners (the failure mode that a
+      # name=iPhone 17 destination hit here — xcodebuild listed zero concrete
+      # destinations and failed with "Unable to find a device"). This is the
+      # same approach build-mobile.yml's release iOS build already uses. The
+      # pinned sims are still pre-booted above for the test-run phase, which
+      # reaches them via simctl by UDID, independent of xcodebuild.
+
+      - name: Build iOS app
+        run: yarn test:e2e:mobile:build
+
+      - name: Run Guardian E2E (mobile, devnet)
+        # --retries=2 absorbs the residual onboarding flake + flaky CDP on macos-26
+        # runners. Each fixture retries install → launch → CDP connect from
+        # scratch, so a transient webinspectord hiccup doesn't fail the run.
+        # Config stays at retries: 0 for fast local dev feedback.
+        run: yarn playwright test --config playwright.ios.guardian.config.ts --retries=2
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-guardian-e2e-devnet-${{ github.run_id }}
+          path: test-results-ios/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  mobile-guardian-testnet:
+    name: Mobile Guardian E2E (testnet)
+    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'testnet'
+    runs-on: macos-26
+    # ~40 min setup (CLI compile on cache miss + iOS build + sim cold boot)
+    # plus a single guardian spec with up to 2 retries. Generous ceiling that
+    # matches the standard mobile jobs so a passing build is never guillotined.
+    timeout-minutes: 130
+    env:
+      E2E_NETWORK: testnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache miden-client-cli
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/miden-client
+          key: miden-client-cli-${{ runner.os }}-${{ hashFiles('package.json') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install miden-client-cli
+        shell: bash
+        run: |
+          # Decoupled from the JS SDK version — read the CLI pin from
+          # package.json. `midenClientCliGit` ({url, rev}) takes precedence
+          # over `midenClientCliVersion` and is used while the target
+          # miden-client line is unreleased on crates.io (the 0.15 series
+          # ships from the repo's `next` branch only). See
+          # playwright/e2e/helpers/miden-cli.ts for the matching local-dev
+          # path.
+          GIT_URL=$(node -p "require('./package.json').midenClientCliGit?.url ?? ''")
+          GIT_REV=$(node -p "require('./package.json').midenClientCliGit?.rev ?? ''")
+          VERSION=$(node -p "require('./package.json').midenClientCliVersion")
+          if [[ -z "$GIT_URL" && (-z "$VERSION" || "$VERSION" == "undefined") ]]; then
+            echo "::error::neither midenClientCliGit nor midenClientCliVersion present in package.json"
+            exit 1
+          fi
+          if [[ -x "$HOME/.cargo/bin/miden-client" ]]; then
+            echo "miden-client already present from cache:"
+            "$HOME/.cargo/bin/miden-client" --version || true
+          elif [[ -n "$GIT_URL" ]]; then
+            echo "Installing miden-client-cli from ${GIT_URL}@${GIT_REV:0:8}..."
+            cargo install miden-client-cli --git "$GIT_URL" --rev "$GIT_REV" --locked
+          else
+            echo "Installing miden-client-cli@${VERSION}..."
+            cargo install miden-client-cli --version "$VERSION"
+          fi
+
+      - name: Launch Simulator.app
+        run: open -a Simulator || true
+
+      - name: Pin test pair to preinstalled simulators
+        shell: bash
+        run: |
+          list_json=$(xcrun simctl list devices --json)
+          UDID_A=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17" and .isAvailable) ]
+            | first | .udid // empty')
+          UDID_B=$(echo "$list_json" | jq -r '
+            [ .devices | to_entries[] | select(.key | test("SimRuntime.iOS-")) |
+              .value[] | select(.name == "iPhone 17 Pro" and .isAvailable) ]
+            | first | .udid // empty')
+          if [[ -z "$UDID_A" || -z "$UDID_B" ]]; then
+            echo "Missing preinstalled sim. A='$UDID_A'  B='$UDID_B'"
+            echo "Full device list:"
+            xcrun simctl list devices
+            exit 1
+          fi
+          mkdir -p test-results-ios
+          printf '{"udidA":"%s","udidB":"%s"}\n' "$UDID_A" "$UDID_B" > test-results-ios/.device-pair.json
+          echo "Wrote .device-pair.json: A=$UDID_A  B=$UDID_B"
+
+      # Kick the cold boot off NOW so it overlaps the ~25-minute app build.
+      # First boot of an iOS 26 runtime on a cold runner takes many minutes
+      # (dyld shared-cache build); booting only in playwright's globalSetup
+      # left the suite racing a half-booted simulator, where simctl
+      # install/launch hang for the full test timeout. `simctl boot` is
+      # asynchronous — globalSetup's bootstatus gate later confirms
+      # readiness, which by then is long since done.
+      - name: Pre-boot simulators (async, overlaps build)
+        shell: bash
+        run: |
+          # On a cold runner CoreSimulatorService may not respond ("Unable
+          # to boot the Simulator. launchd failed to respond",
+          # SimLaunchHostService code 4) — retry with backoff. If retries
+          # exhaust, the service is wedged, and a wedged CoreSimulatorService
+          # breaks MORE than booting: xcodebuild stops seeing any simulator
+          # destinations, so the build step would fail 25 minutes later
+          # anyway (observed). Restart the service once; if the subsystem
+          # still can't boot, fail the job HERE — minutes in, clearly
+          # attributed, and cheap to rerun.
+          UDID_A=$(jq -r .udidA test-results-ios/.device-pair.json)
+          UDID_B=$(jq -r .udidB test-results-ios/.device-pair.json)
+          boot_with_retry() {
+            local udid="$1"
+            for attempt in 1 2 3 4; do
+              state=$(xcrun simctl list devices | grep "$udid" | grep -o '(Booted)\|(Shutdown)\|(Booting)' || true)
+              if [[ "$state" == "(Booted)" || "$state" == "(Booting)" ]]; then
+                echo "$udid already $state"
+                return 0
+              fi
+              if xcrun simctl boot "$udid"; then
+                echo "$udid boot issued (attempt $attempt)"
+                return 0
+              fi
+              echo "boot attempt $attempt for $udid failed; retrying in 20s"
+              sleep 20
+            done
+            return 1
+          }
+          ensure_bootable() {
+            local udid="$1"
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "CoreSimulatorService appears wedged; restarting it"
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+            sleep 15
+            open -a Simulator || true
+            sleep 10
+            if boot_with_retry "$udid"; then return 0; fi
+            echo "::error::simulator subsystem unusable on this runner (boot of $udid failed after CoreSimulatorService restart)"
+            return 1
+          }
+          ensure_bootable "$UDID_A"
+          ensure_bootable "$UDID_B"
+          xcrun simctl list devices | grep -E "$UDID_A|$UDID_B" || true
+
+      # The iOS app is built for a GENERIC simulator destination
+      # (generic/platform=iOS Simulator) — see the test:e2e:mobile:build
+      # script. A build doesn't need a concrete booted device, and the
+      # generic destination resolves to the "Any iOS Simulator Device"
+      # placeholder even when Xcode's IDE-layer CoreSimulator goes blind to
+      # concrete sims on macos-26 runners (the failure mode that a
+      # name=iPhone 17 destination hit here — xcodebuild listed zero concrete
+      # destinations and failed with "Unable to find a device"). This is the
+      # same approach build-mobile.yml's release iOS build already uses. The
+      # pinned sims are still pre-booted above for the test-run phase, which
+      # reaches them via simctl by UDID, independent of xcodebuild.
+
+      - name: Build iOS app
+        run: yarn test:e2e:mobile:build
+
+      - name: Run Guardian E2E (mobile, testnet)
+        # --retries=2 absorbs the residual onboarding flake + flaky CDP on macos-26
+        # runners. Each fixture retries install → launch → CDP connect from
+        # scratch, so a transient webinspectord hiccup doesn't fail the run.
+        # Config stays at retries: 0 for fast local dev feedback.
+        run: yarn playwright test --config playwright.ios.guardian.config.ts --retries=2
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-guardian-e2e-testnet-${{ github.run_id }}
+          path: test-results-ios/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  mobile-guardian-gate:
+    name: Mobile Guardian E2E Gate
+    needs: [mobile-guardian-devnet, mobile-guardian-testnet]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require at least one network to pass
+        shell: bash
+        env:
+          DEVNET_RESULT: ${{ needs.mobile-guardian-devnet.result }}
+          TESTNET_RESULT: ${{ needs.mobile-guardian-testnet.result }}
+        run: |
+          echo "devnet=$DEVNET_RESULT  testnet=$TESTNET_RESULT"
+          if [[ "$DEVNET_RESULT" == "success" || "$TESTNET_RESULT" == "success" ]]; then
+            echo "Mobile Guardian E2E: at least one network passed."
+            exit 0
+          fi
+          echo "Mobile Guardian E2E: both networks failed or were skipped."
+          exit 1


### PR DESCRIPTION
## Summary

Adds CI coverage for the mobile guardian E2E (added in #293), closing the asymmetry with Chrome (which already has `chrome-guardian-{devnet,testnet,gate}`).

Three new jobs in `e2e-blockchain.yml`, mirroring the chrome-guardian pattern:
- **`mobile-guardian-devnet`** / **`mobile-guardian-testnet`** — same iOS harness as `mobile-{devnet,testnet}` (sim pinning, async pre-boot, generic-destination build), but run **only** the guardian spec via `playwright.ios.guardian.config.ts`.
- **`mobile-guardian-gate`** — `needs` both, `if: always()`, requires **at least one network to pass** (so a guardian-backend or single-network outage never red-bars main).

## Decisions

- **`--retries=2` (3 attempts)** — the guardian suite is a single long spec, and mobile onboarding still has a **residual intermittent flake** on macos-26 runners (separate from the TLA bug fixed in #293; that one was deterministic). A failed attempt fails fast at onboarding, so the extra retry is cheap, and the gate tolerates one network failing.
- **No `GUARDIAN_URL`** (unlike the chrome jobs) — the mobile guardian wallet uses the **network-default** guardian endpoint (devnet → `guardian-stg.openzeppelin.com`, testnet → `guardian.openzeppelin.com`), which in-app onboarding selects automatically.

## Verification

- Additive only — **369 insertions, 0 deletions**; existing jobs untouched.
- `actionlint` clean (exit 0); YAML parses.
- The guardian spec itself was verified end-to-end on devnet sims in #293 (A consumes 1000, sends 500 to B via the guardian co-sign path).

## Note on when these first run

`e2e-blockchain.yml` triggers on **push to `main`** (and `workflow_dispatch`), **not** on pull requests — so these jobs don't run on this PR; they first execute on the push to `main` after merge. (Can be exercised pre-merge via `workflow_dispatch` on the branch if desired, but that runs the full matrix.)
