### PR TITLE
fix(mobile): iOS release archive targets SPM project + export-compliance flag

### DIFF
--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -248,20 +248,57 @@ Output locations:
 
 ### iOS
 
+**Production App Store identity** (differs from the repo defaults, which are for
+e2e/dev):
+
+| | Repo default (e2e/dev) | App Store production |
+|---|---|---|
+| Bundle ID | `com.miden.wallet` | **`com.midenfi.wallet`** |
+| Team | `YQ9XQQJ5ZM` | **`QT9F8G4KW7`** (current publishing team) |
+| Provisioning profile | — | "midenwallet" (App Store, `com.midenfi.wallet`) |
+
+The production identity is applied as **local, uncommitted overrides** at build
+time — set `PRODUCT_BUNDLE_IDENTIFIER` + `DEVELOPMENT_TEAM` in
+`ios/App/App.xcodeproj/project.pbxproj` and `teamID` in
+`ios/App/ExportOptions.plist`, then **revert after building**. Don't commit them;
+the repo stays on the dev defaults so e2e keeps working.
+
+Prerequisites: Apple Developer membership for the publishing team, the Apple
+Distribution cert + the App Store provisioning profile in the keychain, and Xcode
+signed into that team (Settings → Accounts).
+
 ```bash
-# 1. Update ExportOptions.plist with your Team ID
-# Edit ios/App/ExportOptions.plist
-
-# 2. Build release archive
-yarn mobile:ios:release
-
-# 3. Export for App Store (requires valid signing)
-yarn mobile:ios:export
+# 1. Apply the production identity overrides (bundle id + team) — see table above.
+# 2. Build the signed Release archive (testnet; mainnet RPC is still a placeholder).
+#    NOTE: this project uses Swift Package Manager, not CocoaPods — the archive
+#    builds against App.xcodeproj (there is no App.xcworkspace).
+E2E_NETWORK= MIDEN_NETWORK=testnet yarn mobile:ios:release
 ```
+
+Upload (pick one):
+- **Xcode Organizer (GUI, recommended for account-based auth):** open
+  `ios/App/build/MidenWallet.xcarchive` → Distribute App → App Store Connect →
+  Upload (uses the signed-in Xcode account).
+- **Headless:** `yarn mobile:ios:export` (ExportOptions: `app-store-connect`,
+  `destination: upload`) — needs an App Store Connect API key configured, not
+  just the Xcode account.
+
+Export compliance: the app uses standard algorithms (AES-GCM, PBKDF2, SHA-256 via
+Web Crypto). `ITSAppUsesNonExemptEncryption` is set to `false` in
+`ios/App/App/Info.plist`, so the App Store upload does not re-prompt for the
+encryption/France questionnaire.
+
+Common upload errors:
+- *"PLA Update available" / "No profiles for com.midenfi.wallet were found"* — the
+  **Program License Agreement needs accepting** at developer.apple.com/account
+  (account holder). Both errors clear once it's accepted.
 
 Output locations:
 - Archive: `ios/App/build/MidenWallet.xcarchive`
 - Export: `ios/App/build/export/`
+
+> TODO: the "What's New" copy above is stale (last updated for 1.14.4) — refresh
+> per release before submitting.
 
 Alternatively, open Xcode and use Product > Archive for a GUI workflow.
 

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSFaceIDUsageDescription</key>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mobile:android:release:apk": "yarn mobile:sync && cd android && ./gradlew assembleRelease && echo 'APK created at: android/app/build/outputs/apk/release/app-release.apk'",
     "mobile:android:keystore": "keytool -genkey -v -keystore android/app/miden-release.keystore -alias miden -keyalg RSA -keysize 2048 -validity 10000",
     "mobile:ios:set-version": "cd ios/App && xcrun agvtool new-marketing-version $(node -p \"require('../../package.json').version\") && xcrun agvtool next-version -all",
-    "mobile:ios:release": "yarn mobile:sync && yarn mobile:ios:set-version && xcodebuild -workspace ios/App/App.xcworkspace -scheme App -configuration Release -archivePath ios/App/build/MidenWallet.xcarchive archive && echo 'Archive created at: ios/App/build/MidenWallet.xcarchive'",
+    "mobile:ios:release": "yarn mobile:sync && yarn mobile:ios:set-version && xcodebuild -project ios/App/App.xcodeproj -scheme App -configuration Release -archivePath ios/App/build/MidenWallet.xcarchive -allowProvisioningUpdates archive && echo 'Archive created at: ios/App/build/MidenWallet.xcarchive'",
     "mobile:ios:export": "xcodebuild -exportArchive -archivePath ios/App/build/MidenWallet.xcarchive -exportPath ios/App/build/export -exportOptionsPlist ios/App/ExportOptions.plist",
     "zip": "ts-node --project ./tsconfig-utility.json ./utility/buildZip.ts",
     "test": "jest",


### PR DESCRIPTION
## Summary

Repo fixes extracted from doing the first 1.15.2 iOS App Store build (the build itself — bundle-id/team overrides, the IPA — stays local and is **not** in this PR).

1. **`mobile:ios:release` was broken for this project.** It hardcoded `-workspace ios/App/App.xcworkspace`, but the project migrated to **Swift Package Manager** (`ios/App/CapApp-SPM`) — there is no `App.xcworkspace`, so the archive failed with *"App.xcworkspace does not exist."* Changed to `-project ios/App/App.xcodeproj` (matching the working e2e build) and added `-allowProvisioningUpdates`.

2. **`ITSAppUsesNonExemptEncryption=false` in `Info.plist`.** The app uses only standard published encryption (AES-GCM, PBKDF2, SHA-256 via Web Crypto) — no proprietary crypto; the blockchain bits (Falcon signatures, RPO/Poseidon hashes) are authentication/integrity, not encryption. Pinning this stops the App Store from re-prompting for the encryption/France export questionnaire on every upload.

3. **`STORE_LISTING.md` iOS section** now documents the production identity (`com.midenfi.wallet` + publishing team + the App Store profile), the corrected build/upload recipe (SPM, Organizer GUI upload), and the *"PLA Update available / no profiles"* gotcha (accept the Program License Agreement). Also flags the stale "What's New" copy (still 1.14.4).

## Not in this PR (intentionally)

- The production **bundle ID (`com.midenfi.wallet`) + team (`QT9F8G4KW7`) + version bump** are applied as **local build-time overrides** — the repo deliberately stays on `com.miden.wallet` / dev defaults so e2e keeps working. Documented in STORE_LISTING.md.
- Signing keystore / certs — never committed (gitignored).

## Note

The `ITSAppUsesNonExemptEncryption=false` value reflects a standard-encryption / mass-market export self-classification. That's a compliance call owned outside this PR; this change just records the decision so builds don't re-prompt.