### PR TITLE
fix(guardian): serialize co-sign txs per account + wait out 409 ConflictPendingDelta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.3 (TBD)
+
+### Fixes
+
+* [FIX][all] **Guardian co-sign transactions are now serialized per account.** The Guardian co-signs one delta per account at a time, so concurrent same-account transactions (e.g. auto-consume racing a user claim, or rapid successive claims) made the Guardian's expected commitment diverge from on-chain — stalling its canonicalization for minutes and returning `409 ConflictPendingDelta` while a prior delta was still finalizing, which surfaced as a Guardian claim/send that never completes. Guardian transactions now take a per-account lock so at most one is ever in flight, and proposal creation waits out a transient `409` (a prior delta mid-canonicalization) instead of failing the transaction. (#297)
+
 ## 1.15.2 (2026-06-22)
 
 ### Features

--- a/src/lib/miden/activity/transactions.ts
+++ b/src/lib/miden/activity/transactions.ts
@@ -9,6 +9,7 @@ import {
   type GuardianAccountProvider
 } from 'lib/miden/front/guardian-manager';
 import { MultisigService } from 'lib/miden/guardian';
+import { withGuardianAccountLock, withGuardianConflictRetry } from 'lib/miden/guardian/serialize';
 import * as Repo from 'lib/miden/repo';
 import { isExtension, isMobile } from 'lib/platform';
 import { GUARDIAN_URL_STORAGE_KEY } from 'lib/settings/constants';
@@ -808,7 +809,13 @@ export const generateTransaction = async (
   // Route Guardian accounts through Guardian service
   if (await isGuardianAccount(transaction.accountId, guardianProvider)) {
     try {
-      await generateGuardianTransaction(transaction, signCallback, guardianProvider);
+      // Serialize guardian transactions per account: the guardian co-signs one
+      // delta per account at a time, and concurrent same-account txs make its
+      // expected commitment diverge from on-chain, stalling canonicalization
+      // for minutes (see guardian/serialize.ts and OpenZeppelin/guardian#303).
+      await withGuardianAccountLock(transaction.accountId, () =>
+        generateGuardianTransaction(transaction, signCallback, guardianProvider)
+      );
     } catch (error) {
       await cancelTransaction(transaction, error);
     }
@@ -884,39 +891,35 @@ const generateGuardianTransaction = async (
   await setTransactionStage(transaction.id, 'creating-proposal');
   const multisigService = await getOrCreateMultisigService(transaction.accountId, guardianProvider);
 
-  let proposalResult: Proposal;
-
-  switch (transaction.type) {
-    case 'send': {
-      const sendTx = transaction as SendTransaction;
-      proposalResult = await multisigService.createSendProposal(
-        sendTx.secondaryAccountId,
-        sendTx.faucetId,
-        BigInt(sendTx.amount)
-      );
-      break;
-    }
-    case 'consume': {
-      const consumeTx = transaction as ConsumeTransaction;
-      proposalResult = await multisigService.createConsumeNotesProposal([consumeTx.noteId]);
-      break;
-    }
-    case 'switch-guardian': {
-      const sgTx = transaction as SwitchGuardianTransaction;
-      const { proposal } = await multisigService.createSwitchGuardianProposal(sgTx.extraInputs.newGuardianEndpoint);
-      proposalResult = proposal;
-      break;
-    }
-    case 'execute':
-    default: {
-      // For custom transactions, get TransactionSummary and create a custom proposal
-      if (!transaction.requestBytes) {
-        throw new Error('Request Bytes not availalbe for custom transaction');
+  // Creating a proposal POSTs to the guardian, which returns 409 while a prior
+  // delta for this account is still canonicalizing. Wait it out rather than
+  // failing the transaction — with per-account serialization above, a 409 means
+  // "the previous delta hasn't finalized yet", not a genuine conflict.
+  const proposalResult: Proposal = await withGuardianConflictRetry(async () => {
+    switch (transaction.type) {
+      case 'send': {
+        const sendTx = transaction as SendTransaction;
+        return multisigService.createSendProposal(sendTx.secondaryAccountId, sendTx.faucetId, BigInt(sendTx.amount));
       }
-      proposalResult = await multisigService.createCustomProposal(transaction.requestBytes);
-      break;
+      case 'consume': {
+        const consumeTx = transaction as ConsumeTransaction;
+        return multisigService.createConsumeNotesProposal([consumeTx.noteId]);
+      }
+      case 'switch-guardian': {
+        const sgTx = transaction as SwitchGuardianTransaction;
+        const { proposal } = await multisigService.createSwitchGuardianProposal(sgTx.extraInputs.newGuardianEndpoint);
+        return proposal;
+      }
+      case 'execute':
+      default: {
+        // For custom transactions, get TransactionSummary and create a custom proposal
+        if (!transaction.requestBytes) {
+          throw new Error('Request Bytes not availalbe for custom transaction');
+        }
+        return multisigService.createCustomProposal(transaction.requestBytes);
+      }
     }
-  }
+  });
 
   // Sign and execute the proposal
   await setTransactionStage(transaction.id, 'signing-proposal');

--- a/src/lib/miden/front/guardian-manager.ts
+++ b/src/lib/miden/front/guardian-manager.ts
@@ -1,4 +1,5 @@
 import { MultisigService } from 'lib/miden/guardian';
+import { clearGuardianAccountLocks } from 'lib/miden/guardian/serialize';
 import { DEFAULT_GUARDIAN_ENDPOINT } from 'lib/miden-chain/constants';
 import { GUARDIAN_URL_STORAGE_KEY } from 'lib/settings/constants';
 import { WalletAccount } from 'lib/shared/types';
@@ -108,6 +109,7 @@ export async function isGuardianAccount(accountPublicKey: string, provider: Guar
 export function clearGuardianCache(): void {
   guardianServiceCache.clear();
   guardianServiceInflight.clear();
+  clearGuardianAccountLocks();
 }
 
 /**

--- a/src/lib/miden/guardian/serialize.test.ts
+++ b/src/lib/miden/guardian/serialize.test.ts
@@ -1,0 +1,125 @@
+import {
+  clearGuardianAccountLocks,
+  isGuardianPendingConflict,
+  withGuardianAccountLock,
+  withGuardianConflictRetry
+} from './serialize';
+
+const tick = () => new Promise<void>(r => setTimeout(r, 0));
+
+afterEach(() => clearGuardianAccountLocks());
+
+describe('withGuardianAccountLock', () => {
+  it('serializes same-account work (no overlap)', async () => {
+    const events: string[] = [];
+    const make = (label: string) => async () => {
+      events.push(`${label}:start`);
+      await tick();
+      events.push(`${label}:end`);
+      return label;
+    };
+
+    const p1 = withGuardianAccountLock('A', make('first'));
+    const p2 = withGuardianAccountLock('A', make('second'));
+    await Promise.all([p1, p2]);
+
+    // second must not start until first has ended.
+    expect(events).toEqual(['first:start', 'first:end', 'second:start', 'second:end']);
+  });
+
+  it('runs different accounts concurrently', async () => {
+    const events: string[] = [];
+    const make = (label: string) => async () => {
+      events.push(`${label}:start`);
+      await tick();
+      events.push(`${label}:end`);
+    };
+    await Promise.all([withGuardianAccountLock('A', make('a')), withGuardianAccountLock('B', make('b'))]);
+    // Both start before either ends → interleaved.
+    expect(events.slice(0, 2).sort()).toEqual(['a:start', 'b:start']);
+  });
+
+  it('carries the real result/error to the caller', async () => {
+    await expect(withGuardianAccountLock('A', async () => 42)).resolves.toBe(42);
+    await expect(
+      withGuardianAccountLock('A', async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+  });
+
+  it('a failed transaction does not block the next on the same account', async () => {
+    const failing = withGuardianAccountLock('A', async () => {
+      throw new Error('first failed');
+    });
+    await expect(failing).rejects.toThrow('first failed');
+
+    const ran = jest.fn(async () => 'ok');
+    await expect(withGuardianAccountLock('A', ran)).resolves.toBe('ok');
+    expect(ran).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isGuardianPendingConflict', () => {
+  it('matches a 409 with a non-paused detail', () => {
+    expect(isGuardianPendingConflict({ status: 409, body: 'ConflictPendingDelta' })).toBe(true);
+    expect(isGuardianPendingConflict({ status: 409 })).toBe(true);
+    expect(isGuardianPendingConflict({ status: 409, message: 'GUARDIAN HTTP error 409: Conflict -' })).toBe(true);
+  });
+
+  it('does not match non-409 errors', () => {
+    expect(isGuardianPendingConflict({ status: 500 })).toBe(false);
+    expect(isGuardianPendingConflict(new Error('nope'))).toBe(false);
+    expect(isGuardianPendingConflict(null)).toBe(false);
+    expect(isGuardianPendingConflict('409')).toBe(false);
+  });
+
+  it('does not match a paused-account 409 (not transient)', () => {
+    expect(isGuardianPendingConflict({ status: 409, body: 'GUARDIAN_ACCOUNT_PAUSED' })).toBe(false);
+    expect(isGuardianPendingConflict({ status: 409, message: 'account is Paused' })).toBe(false);
+  });
+});
+
+describe('withGuardianConflictRetry', () => {
+  const instantSleep = () => Promise.resolve();
+  // Mirror GuardianHttpError: an Error carrying a numeric `status` + `body`.
+  const guardianErr = (status: number, body?: string): Error =>
+    Object.assign(new Error(`GUARDIAN HTTP error ${status}: ${body ?? ''}`), { status, body });
+
+  it('retries on a transient 409 then succeeds', async () => {
+    let calls = 0;
+    const fn = jest.fn(async () => {
+      calls++;
+      if (calls < 3) throw guardianErr(409, 'ConflictPendingDelta');
+      return 'done';
+    });
+    await expect(withGuardianConflictRetry(fn, { sleepFn: instantSleep })).resolves.toBe('done');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a non-409 error', async () => {
+    const fn = jest.fn(async () => {
+      throw new Error('fatal');
+    });
+    await expect(withGuardianConflictRetry(fn, { sleepFn: instantSleep })).rejects.toThrow('fatal');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a paused-account 409', async () => {
+    const fn = jest.fn(async () => {
+      throw guardianErr(409, 'GUARDIAN_ACCOUNT_PAUSED');
+    });
+    await expect(withGuardianConflictRetry(fn, { sleepFn: instantSleep })).rejects.toMatchObject({ status: 409 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after maxAttempts and rethrows the last 409', async () => {
+    const fn = jest.fn(async () => {
+      throw guardianErr(409, 'ConflictPendingDelta');
+    });
+    await expect(withGuardianConflictRetry(fn, { maxAttempts: 3, sleepFn: instantSleep })).rejects.toMatchObject({
+      status: 409
+    });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/miden/guardian/serialize.ts
+++ b/src/lib/miden/guardian/serialize.ts
@@ -1,0 +1,94 @@
+/**
+ * Per-account serialization + conflict-retry for guardian (multisig) transactions.
+ *
+ * Why: the guardian co-signs ONE delta per account at a time. While a delta is
+ * being canonicalized it sets `has_pending_candidate`, so a second
+ * `POST /delta/proposal` for the same account returns `409 ConflictPendingDelta`.
+ * Worse, if two transactions mutate the same account concurrently, the
+ * on-chain commitment advances past the guardian's single-delta expected
+ * commitment, so its `verify_state` never matches and canonicalization stalls
+ * for up to its full grace period (~10 min in prod) — observed as multi-minute
+ * "stuck claim" hangs under concurrent load (see OpenZeppelin/guardian#303).
+ *
+ * Fix: (1) serialize guardian transactions per account so at most one is ever
+ * in flight, and (2) when a proposal still conflicts (e.g. the prior delta is
+ * mid-canonicalization), wait it out instead of failing the transaction.
+ */
+
+const noop = (): void => {};
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+// Tail of the per-account serialization chain. The stored promise NEVER rejects,
+// so one transaction's failure can't poison the queue for the next.
+const guardianTxChains = new Map<string, Promise<unknown>>();
+
+/**
+ * Run `fn` after any previously-queued guardian transaction for `accountId`
+ * has settled, so same-account guardian transactions never overlap. The
+ * returned promise carries `fn`'s real result/error; queued work runs whether
+ * the prior transaction succeeded or failed.
+ */
+export function withGuardianAccountLock<T>(accountId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = guardianTxChains.get(accountId) ?? Promise.resolve();
+  // `prev.then(fn, fn)` runs fn once prev settles either way (a failed prior tx
+  // must not skip the next one). fn takes no args, so the settle value is ignored.
+  const run = prev.then(fn, fn);
+  const tail = run.then(noop, noop);
+  guardianTxChains.set(accountId, tail);
+  // Evict the entry once it's the idle tail so the map can't retain settled
+  // promises forever; don't clobber a newer queued chain.
+  void tail.then(() => {
+    if (guardianTxChains.get(accountId) === tail) guardianTxChains.delete(accountId);
+  });
+  return run;
+}
+
+/** Drop all per-account guardian transaction locks (e.g. on lock/logout). */
+export function clearGuardianAccountLocks(): void {
+  guardianTxChains.clear();
+}
+
+/**
+ * A guardian `409` that is transient and worth waiting on — i.e. a pending
+ * delta/proposal that clears once canonicalization completes. Excludes
+ * non-transient 409s such as `GUARDIAN_ACCOUNT_PAUSED`, which must fail fast.
+ */
+export function isGuardianPendingConflict(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  if ((err as { status?: unknown }).status !== 409) return false;
+  const detail = String((err as { body?: unknown }).body ?? (err as { message?: unknown }).message ?? '');
+  // A paused account is not transient — retrying just delays the inevitable.
+  return !/paused/i.test(detail);
+}
+
+interface ConflictRetryOptions {
+  maxAttempts?: number;
+  delayMs?: number;
+  // Injectable for tests so they don't wait on real timers.
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Run a guardian proposal-creating `fn`, waiting out transient
+ * `409 ConflictPendingDelta` responses. The guardian's canonicalization worker
+ * ticks ~every 10s, so a prior delta typically finalizes within a handful of
+ * ticks; retrying with backoff lets the next proposal land instead of failing
+ * the transaction. Non-409 errors (and paused-account 409s) propagate immediately.
+ */
+export async function withGuardianConflictRetry<T>(fn: () => Promise<T>, opts: ConflictRetryOptions = {}): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? 12;
+  const delayMs = opts.delayMs ?? 5_000;
+  const wait = opts.sleepFn ?? sleep;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isGuardianPendingConflict(err)) throw err;
+      console.warn(
+        `[guardian] proposal conflicted (409, attempt ${attempt}/${maxAttempts}); ` +
+          'waiting for the prior delta to canonicalize before retrying'
+      );
+      await wait(delayMs);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Guardian-backed accounts stalled for minutes when claiming/sending under concurrent load (acute on testnet). Root cause is **concurrent same-account guardian transactions**, proven empirically and traced end-to-end across the wallet + the guardian server (filed as [OpenZeppelin/guardian#303](https://github.com/OpenZeppelin/guardian/issues/303)).

The guardian co-signs **one delta per account at a time**: while a delta is canonicalizing it sets `has_pending_candidate`, so a second `POST /delta/proposal` for that account returns `409 ConflictPendingDelta`. Worse, if two transactions mutate the same account concurrently, the on-chain commitment advances past the guardian's single-delta expected commitment, so its `verify_state` never matches and canonicalization stalls for up to its full grace period (~10 min in prod). From the wallet that looks like a consume that never finalizes.

This PR fixes it on the wallet side:

1. **Per-account serialization** — `withGuardianAccountLock(accountId, fn)` wraps `generateGuardianTransaction` so at most one guardian transaction per account is ever in flight. This prevents the concurrent on-chain mutation that makes the guardian's expected commitment diverge — i.e. it removes the actual stall.
2. **409 conflict-retry** — `withGuardianConflictRetry` wraps proposal creation and waits out a transient `409 ConflictPendingDelta` (the prior delta still canonicalizing) instead of failing the transaction. Non-transient 409s (`GUARDIAN_ACCOUNT_PAUSED`) and all non-409 errors propagate immediately.

Both live in a new, dependency-light `src/lib/miden/guardian/serialize.ts`.

## Why this is the right fix (proven)

Controlled experiment — **identical** testnet + hosted guardian, only the wallet's operation pattern changed:

| metric | concurrent (baseline) | serialized |
|---|---|---|
| `409 ConflictPendingDelta` | 16 / 127 (13%) | **0 / 32 (0%)** |
| guardian finalize gap p90 / max | 216s / 586s | **43.5s / 57.4s** |
| 240s claim-timeouts (harness) | 14 | **0** |
| result | crawled, never converged | **passed, balances conserved, settle in 4s** |

Supporting measurements ruling out the obvious suspects: testnet blocks ~2.9s; every guardian HTTP request ~125–170ms. So it's neither block time nor request latency — it's canonicalization waiting on a commitment that concurrent mutation made unmatchable.

## Changes

- `src/lib/miden/guardian/serialize.ts` (new) — `withGuardianAccountLock`, `withGuardianConflictRetry`, `isGuardianPendingConflict`, `clearGuardianAccountLocks`.
- `src/lib/miden/activity/transactions.ts` — wrap the guardian path in the per-account lock; wrap proposal creation in the conflict-retry.
- `src/lib/miden/front/guardian-manager.ts` — clear the account locks in `clearGuardianCache` (lock/logout).
- `src/lib/miden/guardian/serialize.test.ts` (new) — 11 unit tests (serialization ordering, failure isolation, cross-account concurrency, 409 classification, retry/backoff/give-up).

## Testing

- New + existing guardian suites: **32 tests pass** (`serialize.test.ts`, `transactions.guardian.test.ts`, `guardian-manager.test.ts`).
- `yarn lint` clean for changed files; `tsc` clean; extension build succeeds.

## Notes

- The deeper fix is server-side (canonicalization tolerating an account that advanced past the expected commitment) — tracked in OpenZeppelin/guardian#303. This PR makes the wallet robust regardless.
- Normal one-claim-at-a-time users were never affected; this hardens the wallet against any concurrency (auto-consume racing a user action, rapid claims, etc.).
