### PR TITLE
fix(e2e): traverse new ChooseGuardian step in guardian create flow

### DIFF
--- a/playwright/e2e/helpers/wallet-page.ts
+++ b/playwright/e2e/helpers/wallet-page.ts
@@ -461,6 +461,19 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
         .click();
     }
     await this.page.getByRole('button', { name: /continue/i }).click();
+
+    if (options.recovery === 'guardian') {
+      // #303 inserted a "Choose your Guardian" step between the recovery-method
+      // screen and confirmation. The create flow is preset-only (no custom-URL
+      // field); the guardian E2E targets the OpenZeppelin endpoint, which is the
+      // default-selected provider, so accept the default and continue. Selecting
+      // the provider persists its endpoint to guardian_url_setting (the OZ
+      // endpoint here matches the seed above) before "Get Started" creates the
+      // account.
+      const chooseGuardian = this.page.getByTestId('onboarding-choose-guardian');
+      await chooseGuardian.waitFor({ timeout: 15_000 });
+      await chooseGuardian.getByRole('button', { name: /continue/i }).click();
+    }
   }
 
   /**


### PR DESCRIPTION
## What
#303 inserted a new **ChooseGuardian** screen into guardian-wallet create onboarding, but the (main-only) guardian E2E helper `selectCreateRecoveryMethod` still walked straight from the recovery-method screen to the "Your wallet is ready" confirmation. As a result the flow stalled on the new screen and the guardian E2E timed out on `main` after the #303 merge (both `Chrome Guardian E2E (devnet)` and `(testnet)`).

This teaches the helper to traverse the new step: accept the default-selected provider (OpenZeppelin — which matches the E2E's `GUARDIAN_URL` and the seeded `guardian_url_setting`) and Continue.

## Why it's safe / verified
- Test-harness-only change (`playwright/e2e/helpers/wallet-page.ts`); no product code touched.
- Verified end-to-end: dispatched `E2E Blockchain` (network=devnet) on this branch → **`Chrome Guardian E2E (devnet): success`** (run 28527659633). devnet is all the `chrome-guardian-gate` needs ("at least one network"); testnet stays a documented expected-red (its OZ guardian is still 0.14).

Restores `main` E2E to green after #303.