### PR TITLE
fix(e2e): refresh balances before final stress conservation snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [FIX][build] `MIDEN_NETWORK=localhost` (the E2E localnet build token) now resolves to the `localnet` wallet network instead of throwing in `getRpcEndpoint()`.
 * [FIX][all] Switching a Guardian operator now actually moves the account to the new endpoint (front-end persists the per-account endpoint through the backend, guardian sync waits out canonicalization instead of re-registering the old operator every ~3s, and the settings screen reads the current endpoint reactively).
+* [FIX][ci] **Stress-test conservation check no longer reports phantom "notes lost".** The final balance was measured with the non-invasive `quickBalanceSnapshot()` (which never calls `fetchBalances`) while the initial baseline used `getBalance()` (which does). The settle loop's `triggerSync()` auto-consumes pending notes, moving their value out of `miden_sync_data.notes` and into the account vault — but the stale Zustand `balances` the snapshot reads never picked that value up, so every note consumed during settle dropped out of `totalReportable` and strict conservation failed with a negative whole-token delta (a harness accounting artifact, not a real loss). The settle loop now refreshes the balance projection (`refreshBalances()`) before snapshotting, matching how the initial baseline is measured.
 
 ## 1.15.3 (2026-06-27)
 

--- a/playwright/e2e/helpers/wallet-page.ts
+++ b/playwright/e2e/helpers/wallet-page.ts
@@ -82,6 +82,12 @@ export interface ChromeWalletPageApi extends WalletPage, IdbDumpSource {
     latestTxId?: string;
     error?: string;
   }>;
+  /**
+   * Refresh the Zustand `balances` projection from the account vault so a
+   * subsequent quickBalanceSnapshot() reflects freshly-consumed notes. See the
+   * implementation for why the stress settle loop needs this.
+   */
+  refreshBalances(): Promise<void>;
   /** Full dump of chrome.storage.local — end-of-run forensic snapshot. */
   dumpChromeStorage(): Promise<Record<string, unknown>>;
   // getGuardianAuthInfo is declared on the shared WalletPage interface (above)
@@ -554,12 +560,19 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
    *   - does not require the Explore page to be visible
    *
    * Reads straight from the Zustand store + `chrome.storage.local`:
-   *   - `balance` = consumed vault assets (matches getBalance's first source)
+   *   - `balance` = consumed vault assets, as last projected into the store
    *   - `pendingNotes` = full list of claimable notes (id + amount)
-   *   - `totalReportable` = balance + Σ pendingNotes — matches getBalance()
+   *   - `totalReportable` = balance + Σ pendingNotes
    *   - `pendingTxCount` / `lastTxId` = wallet's recent outgoing transactions
    *
    * Safe to call every op: measured at ~50 ms per wallet.
+   *
+   * CAVEAT: because it skips `fetchBalances`, the `balance` half is only as
+   * fresh as the store's last projection. A note that has been consumed but
+   * not yet re-fetched into `state.balances` is in neither `balance` nor
+   * `pendingNotes`, so `totalReportable` transiently under-counts. Callers that
+   * need an authoritative total (e.g. a conservation assertion) must call
+   * refreshBalances() first — unlike getBalance(), which refreshes internally.
    */
   async quickBalanceSnapshot(): Promise<{
     balance: number;
@@ -853,6 +866,37 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
     } catch (e) {
       console.log(`[WalletPage.getBalance] Error: ${e}`);
       return 0;
+    }
+  }
+
+  /**
+   * Refresh the Zustand `balances` projection from the account vault — the same
+   * `state.fetchBalances` call getBalance() makes, but without navigating or
+   * waiting, so it's cheap enough for the stress settle loop to call each poll.
+   *
+   * Why this exists: quickBalanceSnapshot() is deliberately non-invasive and
+   * never calls `fetchBalances`, so its `balance` half can be stale. The stress
+   * settle loop's triggerSync() fires PROCESS_TRANSACTIONS_REQUEST, which
+   * auto-consumes pending notes: a consumed note leaves `miden_sync_data.notes`
+   * (dropping out of the snapshot's fresh `pendingSum`) but its value only
+   * lands in `state.balances` after a `fetchBalances`. Without this refresh the
+   * consumed value is counted in neither bucket, so `totalReportable`
+   * under-counts and strict conservation reports a phantom loss. Calling this
+   * before the final snapshot makes it authoritative — matching the initial
+   * baseline, which uses getBalance() and so refreshes the same way.
+   */
+  async refreshBalances(): Promise<void> {
+    try {
+      await this.page.evaluate(async () => {
+        const store = (window as any).__TEST_STORE__;
+        const state = store?.getState?.();
+        if (state?.currentAccount?.publicKey && state.fetchBalances) {
+          await state.fetchBalances(state.currentAccount.publicKey, state.assetsMetadata || {});
+        }
+      });
+    } catch {
+      // Best-effort: a failed refresh leaves the prior balance in place and the
+      // settle loop retries on its next poll.
     }
   }
 

--- a/playwright/e2e/stress/stress.spec.ts
+++ b/playwright/e2e/stress/stress.spec.ts
@@ -179,6 +179,14 @@ test.describe('Stress - random send/claim', () => {
       const settleStart = Date.now();
       while (Date.now() - settleStart < SETTLE_DEADLINE_MS) {
         await Promise.all([walletA.triggerSync(), walletB.triggerSync()]);
+        // triggerSync's PROCESS_TRANSACTIONS_REQUEST auto-consumes pending
+        // notes, moving their value out of `miden_sync_data.notes` and into the
+        // account vault. Refresh the Zustand `balances` projection from that
+        // vault before snapshotting so consumed value lands in `totalReportable`
+        // — the initial baseline (getBalance) refreshes the same way. Without
+        // this, every note consumed during settle drops out of the total and
+        // strict conservation reports a phantom loss (see refreshBalances()).
+        await Promise.all([walletA.refreshBalances(), walletB.refreshBalances()]);
         // Read full snapshot so we can log *what's* pending if settle gets stuck.
         const [snapA, snapB] = await Promise.all([walletA.quickBalanceSnapshot(), walletB.quickBalanceSnapshot()]);
         finalA = snapA.totalReportable;


### PR DESCRIPTION
## Problem

The stress suite's **strict balance-conservation** assertion intermittently fails with a negative, whole-token delta:

```
Error: balance conservation violated by -310; notes lost
```

This is a **harness accounting artifact, not a real loss** — the tokens are in the receiver's vault the whole time; the harness just stops counting them.

## Root cause

The two endpoints of the conservation check are measured by **different code paths**, and only one refreshes the balance it reads:

- **Initial** baseline (`stress.spec.ts`) uses `walletA.getBalance()`, which **calls `state.fetchBalances(...)` first** — fresh Zustand `state.balances`.
- **Final** total uses `quickBalanceSnapshot().totalReportable`, which is deliberately non-invasive and **never calls `fetchBalances`** — it reads whatever `state.balances` happens to hold.

`totalReportable = balance (stale Zustand) + pendingSum (fresh from miden_sync_data.notes)`.

The settle loop calls `triggerSync()` every poll, which fires `PROCESS_TRANSACTIONS_REQUEST` and **auto-consumes** pending notes. A consumed note **leaves `miden_sync_data.notes`** (so it drops out of the fresh `pendingSum`) but its value **only lands in `state.balances` after a `fetchBalances`** — which the settle loop never called. So every note consumed during settle is counted in **neither** bucket, and the final total under-counts:

```
consumed note:  pendingSum ↓ (fresh)   balance — (stale, never refreshed)
                → totalReportable drops → finalTotal < initialTotal → phantom "notes lost"
```

## Why the signature matches (and rules out the alternatives)

From reproductions in `stress-logs/`:

| Signature | Observed | Implication |
|---|---|---|
| Delta sign | always **negative** | under-count on the **final** side |
| Initial balances | **exact** (e.g. 3000/3000) | initial path is correct; bug is 100% on the final measurement |
| Delta magnitude | **whole integers** (−11, −59, −310…), grows with note count | rules out float-rounding (would be ~1e-7) |
| Passing runs | many hit delta **exactly 0** | rules out network fees (would never conserve); confirms a timing/refresh race |
| Asymmetry | e.g. B −301, A −9 | whichever wallet consumed more during settle loses more |

## Fix

Refresh the Zustand `balances` projection from the vault (`refreshBalances()`) **before** the final snapshot, so consumed value is reflected — matching how the initial baseline is measured. New `refreshBalances()` factors out the exact `fetchBalances` call `getBalance()` already makes, minus the navigation/wait so it's cheap to call each settle poll. The strict `expect(delta).toBe(0)` is kept exact (no tolerance band — real losses are whole tokens, so a band would mask them).

Also documents the staleness caveat on `quickBalanceSnapshot()` (its doc previously claimed it "matches getBalance()", which is what set the trap).

## Scope / risk

Test-harness only (`playwright/e2e/**`). No product code. Not covered by `yarn lint` (scans `src`) or any e2e typecheck gate.

## Verification

Surfaced by the `stress-20260702-131802` run (the `wallet-tracing` "trace-testnet" worktree). The fix is argued from the data flow and corroborated by the local reproductions above; I could **not** run the full stress E2E locally (needs two Chrome wallets + live testnet + cargo). Please run the stress spec on testnet to confirm the phantom loss is gone.

Discriminating check baked into the design: re-measuring the final total via a `fetchBalances`-refreshing path drives `delta → 0` iff the tokens were always in the vault (accounting bug); a delta that survives the refresh would be a genuine stuck-note loss.
