### PR TITLE
fix: default custom-transaction proposal label to snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+* [FIX][all] **Custom (`execute`) dApp transactions work again.** The internal custom-proposal label defaulted to `'custom transaction'`, which the updated `@openzeppelin/miden-multisig-client` rejects (`proposalType '…' must be lowercase snake_case`), so every dApp custom transaction failed with a `WalletTransactionError`. The default is now the valid `'custom_transaction'`.
 * [FIX][build] `MIDEN_NETWORK=localhost` (the E2E localnet build token) now resolves to the `localnet` wallet network instead of throwing in `getRpcEndpoint()`.
 * [FIX][all] Switching a Guardian operator now actually moves the account to the new endpoint (front-end persists the per-account endpoint through the backend, guardian sync waits out canonicalization instead of re-registering the old operator every ~3s, and the settings screen reads the current endpoint reactively).
 

--- a/src/lib/miden/guardian/index.ts
+++ b/src/lib/miden/guardian/index.ts
@@ -223,8 +223,12 @@ export class MultisigService {
   /**
    * Create a custom transaction proposal from a serialized transaction request.
    * This is used for 'execute' type transactions.
+   *
+   * `proposalType` is a free-form label that @openzeppelin/miden-multisig-client
+   * validates as lowercase snake_case (`[a-z0-9_]`) and rejects if it collides
+   * with a built-in type — so the default must be snake_case, not `'custom transaction'`.
    */
-  async createCustomProposal(requestBytes: Uint8Array, proposalType: string = 'custom transaction'): Promise<Proposal> {
+  async createCustomProposal(requestBytes: Uint8Array, proposalType: string = 'custom_transaction'): Promise<Proposal> {
     return await withWasmClientLock(() => this.multisig.createCustomProposal(requestBytes, proposalType));
   }
 


### PR DESCRIPTION
## Problem

dApp **custom** transactions (submitted via `@miden-sdk/miden-wallet-adapter` with `TransactionType.Custom`) fail on Guardian accounts with:

```
WalletTransactionError: Error: proposalType 'custom transaction' must be lowercase snake_case ([a-z0-9_]): no spaces, hyphens, or other characters
```

## Root cause

The wallet's `MultisigService.createCustomProposal` in `src/lib/miden/guardian/index.ts` defaulted `proposalType` to `'custom transaction'` — which contains a **space**. Its sole caller (`src/lib/miden/activity/transactions.ts:1255`, the `execute`/custom case) invokes it with only `requestBytes`, so that default is always used.

`@openzeppelin/miden-multisig-client@0.15.0-rc.0` validates the label against `/^[a-z0-9_]+$/` (and rejects the built-in set `add_signer, remove_signer, change_threshold, update_procedure_threshold, switch_guardian, consume_notes, p2id, custom`). The space fails the regex, so every custom transaction throws. The adapter's `CustomTransaction` type has no `proposalType` field, so dApps cannot override it — the wallet default is the only value in play. The wallet's default string was written before the package enforced snake_case; bumping the dependency turned it into a hard failure.

## Fix

Change the default from `'custom transaction'` to the valid `'custom_transaction'` (passes the regex, not a built-in), plus a comment documenting the constraint so it doesn't regress.

## Verification

- Reviewed against the exact pinned package: extracted `@openzeppelin/miden-multisig-client@0.15.0-rc.0` (tarball shasum matches `yarn.lock`) and ran both strings through the real validation — `'custom transaction'` → rejected, `'custom_transaction'` → accepted.
- No other caller, test, or fixture depends on the old string. The one unit test (`guardian/index.test.ts`) passes an explicit label via a mock and is unaffected.
- The library normalizes `proposalType` to `'custom'` internally and stores the label in `rawProposalType`, so nothing downstream keys off the exact string.

## Scope / follow-ups (not in this PR)

- **Meaningful per-dApp labels:** the label is currently a hardcoded generic default and is discarded into `rawProposalType`. If we want dApp custom transactions to carry a descriptive label (activity display / auditing), thread a caller-supplied label from the adapter → `back/dapp.ts` → `transactions.ts` → this method. Tracked separately.
- **Routing question:** this path only fires for Guardian accounts (`generateTransaction` routes on `isGuardianAccount`). A separate question — whether a non-Guardian ("public") account's custom transaction should ever reach the Guardian proposal flow — is being investigated independently and is out of scope here.
