### PR TITLE
fix: signBytes word-signing for Guardian accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.5 (TBD)
+
+### Fixes
+
+* [FIX][all] **`window.miden.signBytes` now works for Guardian accounts.** A Guardian account's signing key lives under the secure-hot-key facade (keyed by `hotPublicKey`), while `connect` hands the dApp the signer *commitment* — so the dApp sign path (`vault.signData`) looked the key up under the commitment, found nothing, and threw `INVALID_PARAMS: Some storage item not found` immediately after the user approved the signature. `signData` now routes `word`-kind requests for Guardian accounts through the hot (secure-hot-key) signing path, resolved via the request's `sourceAccountId`, so external-multisig / Guardian `/configure` signer registration can obtain the account's ECDSA signature. Plain (non-Guardian) accounts are unchanged.
+
 ## 1.15.4 (2026-07-04)
 
 ### Features

--- a/src/lib/miden/back/dapp.ts
+++ b/src/lib/miden/back/dapp.ts
@@ -441,7 +441,12 @@ const generatePromisifySign = async (
         if (confirmReq.confirmed) {
           try {
             let signature = await withUnlocked(async ({ vault }) => {
-              const signDataResult = await vault.signData(req.sourcePublicKey, req.payload, req.kind);
+              const signDataResult = await vault.signData(
+                req.sourcePublicKey,
+                req.payload,
+                req.kind,
+                req.sourceAccountId
+              );
               return signDataResult;
             });
             resolve({

--- a/src/lib/miden/back/vault.gaps.test.ts
+++ b/src/lib/miden/back/vault.gaps.test.ts
@@ -9,6 +9,7 @@
  *   - `tryHardwareUnlock` success path (returns a Vault)
  */
 
+import { u8ToB64 } from 'lib/shared/helpers';
 import * as Passworder from 'lib/miden/passworder';
 import { WalletType } from 'screens/onboarding/types';
 
@@ -197,6 +198,67 @@ describe('Vault instance signWord', () => {
     expect(sig).toBe('0xaabbcc');
     expect(mockWordFromHex).toHaveBeenCalledWith('0xdeadbeef');
     expect(mockSign).toHaveBeenCalled();
+  });
+});
+
+describe('Vault instance signData — Guardian account (word kind)', () => {
+  const GUARDIAN_ADDR = 'mtst1-guardian-addr';
+
+  async function seedGuardianVault(): Promise<Vault> {
+    const vault = await seedVault('pw', {
+      accounts: [
+        {
+          publicKey: GUARDIAN_ADDR,
+          name: 'Guardian 1',
+          isPublic: false,
+          type: WalletType.Guardian,
+          // 3-key model: the signing key lives under the secure-hot-key facade,
+          // keyed by hotPublicKey — NOT under the commitment the dApp resolves.
+          hotPublicKey: 'hotpub-123',
+          coldPublicKey: 'coldpub-456'
+        } as any
+      ],
+      currentPk: GUARDIAN_ADDR
+    });
+    const vaultKey = (vault as any).vaultKey as CryptoKey;
+    // Hot ciphertext stored under hotPublicKey, matching persistGuardianKeys.
+    await encryptAndSaveMany([[keys.accAuthSecretKey('hotpub-123'), '0a0b0c']], vaultKey);
+    return vault;
+  }
+
+  it('signs a word digest via the hot key when routed by accountId', async () => {
+    const vault = await seedGuardianVault();
+
+    // The 32-byte digest the dApp passes to signBytes(kind: 'word'), base64-encoded.
+    const data = u8ToB64(new Uint8Array(32).fill(0xab));
+    // The commitment the dApp received at connect — deliberately NOT a stored key,
+    // so the default accAuthSecretKey(commitment) lookup would miss.
+    const commitment = 'deadbeef'.repeat(8);
+
+    const sig = await vault.signData(commitment, data, 'word', GUARDIAN_ADDR);
+
+    // Hot path signs via secure-hot-key: mock sign() → [0xff,0xaa,0xbb,0xcc],
+    // slice(1) → [0xaa,0xbb,0xcc], returned as base64 (ECDSA sig, no scheme byte).
+    expect(sig).toBe(u8ToB64(new Uint8Array([0xaa, 0xbb, 0xcc])));
+    // Signed the exact word it was handed, via the hot (secure-hot-key) path.
+    expect(mockWordFromHex).toHaveBeenCalledWith(`0x${'ab'.repeat(32)}`);
+  });
+
+  it('still uses the default key path for a non-Guardian account when accountId is passed', async () => {
+    const addr = 'mtst1-plain';
+    const commitment = 'cafe'.repeat(16); // 32 bytes
+    const vault = await seedVault('pw', {
+      accounts: [{ publicKey: addr, name: 'Plain', isPublic: true, type: WalletType.OnChain } as any],
+      currentPk: addr
+    });
+    const vaultKey = (vault as any).vaultKey as CryptoKey;
+    await encryptAndSaveMany([[keys.accAuthSecretKey(commitment), '01020304']], vaultKey);
+
+    const data = u8ToB64(new Uint8Array(32).fill(0x11));
+    const sig = await vault.signData(commitment, data, 'word', addr);
+
+    // Default path returns the FULL serialized signature (with the scheme byte).
+    expect(sig).toBe(u8ToB64(new Uint8Array([0xff, 0xaa, 0xbb, 0xcc])));
   });
 });
 

--- a/src/lib/miden/back/vault.gaps.test.ts
+++ b/src/lib/miden/back/vault.gaps.test.ts
@@ -244,6 +244,28 @@ describe('Vault instance signData — Guardian account (word kind)', () => {
     expect(mockWordFromHex).toHaveBeenCalledWith(`0x${'ab'.repeat(32)}`);
   });
 
+  it('throws a clear error for a Guardian account whose device (hot) key is not active yet', async () => {
+    const addr = 'mtst1-guardian-pending';
+    const vault = await seedVault('pw', {
+      accounts: [
+        {
+          publicKey: addr,
+          name: 'Guardian pending',
+          isPublic: false,
+          type: WalletType.Guardian,
+          // Recovered Guardian account pending device-key activation: cold key
+          // only, no hot key to sign arbitrary digests with yet.
+          coldPublicKey: 'coldpub-only',
+          requiresHotKeyRotation: true
+        } as any
+      ],
+      currentPk: addr
+    });
+    const data = u8ToB64(new Uint8Array(32).fill(0x22));
+
+    await expect(vault.signData('some-commitment', data, 'word', addr)).rejects.toThrow(/device key/i);
+  });
+
   it('still uses the default key path for a non-Guardian account when accountId is passed', async () => {
     const addr = 'mtst1-plain';
     const commitment = 'cafe'.repeat(16); // 32 bytes

--- a/src/lib/miden/back/vault.ts
+++ b/src/lib/miden/back/vault.ts
@@ -1067,6 +1067,15 @@ export class Vault {
     // signWord (hot path) so dApp `signBytes` works for Guardian signers. Keyed off
     // `accountId` (the request's sourceAccountId) since the commitment alone can't be
     // mapped back to the stored hotPublicKey.
+    //
+    // Only `word`-kind is routed here: signing a raw digest with the hot key is the
+    // Guardian-signer registration use case. `signingInputs` (full transaction) for a
+    // Guardian account goes through the multisig co-sign flow, not this path.
+    //
+    // Note the return shape differs by account type: the default path below returns the
+    // full serialized `Signature` (with the 1-byte scheme tag); the Guardian path returns
+    // the raw ECDSA signature with the tag stripped (`signWord`/`signHotDigest` slice it),
+    // matching what the guardian client / `/configure` verify.
     if (signKind === 'word' && accountId) {
       const account = (await this.fetchAccounts()).find(acc => acc.publicKey === accountId);
       if (account?.hotPublicKey) {
@@ -1074,6 +1083,14 @@ export class Vault {
         const sigHex = await this.signWord(account.hotPublicKey, wordHex);
         const sigBytes = new Uint8Array(Buffer.from(sigHex.startsWith('0x') ? sigHex.slice(2) : sigHex, 'hex'));
         return u8ToB64(sigBytes);
+      }
+      if (account?.coldPublicKey) {
+        // Guardian account with no active hot key (e.g. recovered via seed phrase,
+        // `requiresHotKeyRotation`): there is no device key to sign a digest with yet.
+        // Surface that clearly instead of the opaque keystore-miss this fix removes.
+        throw new PublicError(
+          'This Guardian account has no active device key to sign with. Activate the device key in the wallet, then try again.'
+        );
       }
     }
 

--- a/src/lib/miden/back/vault.ts
+++ b/src/lib/miden/back/vault.ts
@@ -26,7 +26,7 @@ import { DEFAULT_GUARDIAN_ENDPOINT } from 'lib/miden-chain/constants';
 import { isDesktop, isMobile } from 'lib/platform';
 import * as secureHotKey from 'lib/secure-hot-key';
 import { GUARDIAN_URL_STORAGE_KEY } from 'lib/settings/constants';
-import { b64ToU8, u8ToB64 } from 'lib/shared/helpers';
+import { b64ToU8, bytesToHex, u8ToB64 } from 'lib/shared/helpers';
 import { AuthScheme, WalletAccount, WalletSettings } from 'lib/shared/types';
 import { WalletType } from 'screens/onboarding/types';
 
@@ -1058,7 +1058,25 @@ export class Vault {
 
   async authorize(_sendTransaction: SendTransaction) {}
 
-  async signData(publicKey: string, data: string, signKind: SignKind): Promise<string> {
+  async signData(publicKey: string, data: string, signKind: SignKind, accountId?: string): Promise<string> {
+    // Guardian accounts keep their (ECDSA) signing key under the secure-hot-key
+    // facade — stored by `hotPublicKey`, not under accAuthSecretKeyStrgKey(commitment)
+    // that the default path below reads. `resolvePublicKeyCommitments` hands the dApp
+    // the signer *commitment* at connect, so the default lookup misses and throws
+    // "Some storage item not found". Route word-signing for such accounts through
+    // signWord (hot path) so dApp `signBytes` works for Guardian signers. Keyed off
+    // `accountId` (the request's sourceAccountId) since the commitment alone can't be
+    // mapped back to the stored hotPublicKey.
+    if (signKind === 'word' && accountId) {
+      const account = (await this.fetchAccounts()).find(acc => acc.publicKey === accountId);
+      if (account?.hotPublicKey) {
+        const wordHex = `0x${bytesToHex(b64ToU8(data))}`;
+        const sigHex = await this.signWord(account.hotPublicKey, wordHex);
+        const sigBytes = new Uint8Array(Buffer.from(sigHex.startsWith('0x') ? sigHex.slice(2) : sigHex, 'hex'));
+        return u8ToB64(sigBytes);
+      }
+    }
+
     const secretKey = await fetchAndDecryptOneWithLegacyFallBack<string>(
       accAuthSecretKeyStrgKey(publicKey),
       this.vaultKey


### PR DESCRIPTION
## Problem

`window.miden.signBytes(digest, 'word')` fails for **Guardian accounts** with `INVALID_PARAMS: Some storage item not found`, thrown immediately after the user approves the signature popup. Reported when a dApp registers an external multisig with the wallet as a signer (Guardian `/configure` requires the wallet to sign a 32-byte auth digest).

## Root cause

The dApp sign path resolves to `vault.signData` (`dapp.ts`), which looked the private key up with a single flat store read:

```ts
fetchAndDecryptOneWithLegacyFallBack(accAuthSecretKeyStrgKey(publicKey), …)  // vault.ts
```

For a **plain** account this works — the key is stored under its commitment, which is what `signBytes` looks up (verified: a fresh plain account signs fine). But a **Guardian** account keeps its ECDSA signing key under the secure-hot-key facade, stored by `hotPublicKey` (not the commitment), while `resolvePublicKeyCommitments` hands the dApp the signer **commitment** at connect. So the lookup misses → `"Some storage item not found"`.

Regular Guardian transactions (send/claim) work because they sign through `signWord`/the guardian signer path, which has the cold/hot routing. Only the dApp `signBytes`/`signData` path was never wired for Guardian accounts.

## Fix

`signData` now routes `word`-kind requests for Guardian accounts through `signWord` (the hot / secure-hot-key path), resolving the account by the request's `sourceAccountId`. Returns the account's ECDSA signature (base64), so external-multisig / Guardian `/configure` signer registration works. Plain accounts are unchanged (they still take the default path — regression-guarded by test).

## Tests

- `vault.gaps.test.ts` — new RED test reproduced the exact `"Some storage item not found"` throw for a Guardian account; now green (signs via the hot key).
- Regression guard: plain account with `accountId` still uses the default path (full serialized signature).
- Full `vault` + `dapp` suites: 283/283 pass.
