### PR TITLE
chore(release): wallet 1.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.5 (2026-07-04)
+
+### Fixes
+
+* [FIX][all] **`window.miden.signBytes` now works for Guardian accounts.** A Guardian account's signing key lives under the secure-hot-key facade (keyed by `hotPublicKey`), while `connect` hands the dApp the signer *commitment* — so the dApp sign path (`vault.signData`) looked the key up under the commitment, found nothing, and threw `INVALID_PARAMS: Some storage item not found` immediately after the user approved the signature. `signData` now routes `word`-kind requests for Guardian accounts through the hot (secure-hot-key) signing path, resolved via the request's `sourceAccountId`, so external-multisig / Guardian `/configure` signer registration can obtain the account's ECDSA signature. Plain (non-Guardian) accounts are unchanged.
+
 ## 1.15.4 (2026-07-04)
 
 ### Features
@@ -8,7 +14,6 @@
 
 ### Fixes
 
-* [FIX][all] **`window.miden.signBytes` now works for Guardian accounts.** A Guardian account's signing key lives under the secure-hot-key facade (keyed by `hotPublicKey`), while `connect` hands the dApp the signer *commitment* — so the dApp sign path (`vault.signData`) looked the key up under the commitment, found nothing, and threw `INVALID_PARAMS: Some storage item not found` immediately after the user approved the signature. `signData` now routes `word`-kind requests for Guardian accounts through the hot (secure-hot-key) signing path, resolved via the request's `sourceAccountId`, so external-multisig / Guardian `/configure` signer registration can obtain the account's ECDSA signature. Plain (non-Guardian) accounts are unchanged.
 * [FIX][all] **Custom (`execute`) dApp transactions work again.** The internal custom-proposal label defaulted to `'custom transaction'`, which the updated `@openzeppelin/miden-multisig-client` rejects (`proposalType '…' must be lowercase snake_case`), so every dApp custom transaction failed with a `WalletTransactionError`. The default is now the valid `'custom_transaction'`.
 * [FIX][build] `MIDEN_NETWORK=localhost` (the E2E localnet build token) now resolves to the `localnet` wallet network instead of throwing in `getRpcEndpoint()`.
 * [FIX][all] Switching a Guardian operator now actually moves the account to the new endpoint (front-end persists the per-account endpoint through the backend, guardian sync waits out canonicalization instead of re-registering the old operator every ~3s, and the settings screen reads the current endpoint reactively).

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.miden.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11504001
-        versionName "1.15.4"
+        versionCode 11505001
+        versionName "1.15.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.4;
+				MARKETING_VERSION = 1.15.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.miden.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -365,7 +365,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.4;
+				MARKETING_VERSION = 1.15.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.miden.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "private": true,
   "engines": {
     "node": ">=22.0.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Miden Wallet",
-  "version": "1.15.4",
+  "version": "1.15.5",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",


### PR DESCRIPTION
Release **wallet 1.15.5** — ships the Guardian `signBytes` fix as a clean new version.

The original 1.15.4 shipped with `window.miden.signBytes` broken for Guardian accounts and is being yanked; the fix ships as 1.15.5.

- Version `1.15.4` → `1.15.5` (package.json, manifest.json, android versionName + versionCode `11505001`, ios MARKETING_VERSION ×2)
- CHANGELOG: Guardian `signBytes` fix moved into a new `## 1.15.5` section
