### PR TITLE
fix: signBytes returns full serialized Signature for Guardian accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Changelog
 
-## 1.15.6 (TBD)
-
-### Fixes
-
-* [FIX][all] **`window.miden.signBytes` returns a full serialized `Signature` for Guardian accounts, so Guardian `/configure` accepts it.** 1.15.5 made `signBytes` produce a signature for Guardian accounts, but returned the ECDSA signature with its scheme-tag byte already stripped (`signWord`/`signHotDigest` slice it off). `@openzeppelin/miden-multisig-client`'s `MidenWalletSigner` strips the leading tag byte itself (`signBytes(...).slice(1)`), so it dropped a real signature byte and Guardian rejected the 64-byte result with `Authentication failed: Failed to deserialize ECDSA signature: unexpected end of file`. `signData` now re-prepends the ECDSA scheme tag so `signBytes` returns the full 66-byte serialized `Signature` — matching the plain-account path and what `MidenWalletSigner` expects (it re-strips the tag to the 65-byte raw signature Guardian verifies).
-
 ## 1.15.5 (2026-07-04)
 
 ### Fixes
 
-* [FIX][all] **`window.miden.signBytes` now works for Guardian accounts.** A Guardian account's signing key lives under the secure-hot-key facade (keyed by `hotPublicKey`), while `connect` hands the dApp the signer *commitment* — so the dApp sign path (`vault.signData`) looked the key up under the commitment, found nothing, and threw `INVALID_PARAMS: Some storage item not found` immediately after the user approved the signature. `signData` now routes `word`-kind requests for Guardian accounts through the hot (secure-hot-key) signing path, resolved via the request's `sourceAccountId`, so external-multisig / Guardian `/configure` signer registration can obtain the account's ECDSA signature. Plain (non-Guardian) accounts are unchanged.
+* [FIX][all] **`window.miden.signBytes` now works for Guardian accounts** (external-multisig / Guardian `/configure` signer registration). A Guardian account's signing key lives under the secure-hot-key facade (keyed by `hotPublicKey`), while `connect` hands the dApp the signer *commitment* — so the dApp sign path (`vault.signData`) looked the key up under the commitment, found nothing, and threw `INVALID_PARAMS: Some storage item not found` immediately after the user approved the signature. `signData` now routes `word`-kind requests for Guardian accounts through the hot (secure-hot-key) ECDSA signing path, resolved via the request's `sourceAccountId`, and returns the full serialized `Signature` that Guardian `/configure` accepts — matching the plain-account path and `@openzeppelin/miden-multisig-client`'s `MidenWalletSigner`, which strips the leading scheme-tag byte itself to recover the raw ECDSA signature Guardian verifies. Plain (non-Guardian) accounts are unchanged.
 
 ## 1.15.4 (2026-07-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.6 (TBD)
+
+### Fixes
+
+* [FIX][all] **`window.miden.signBytes` returns a full serialized `Signature` for Guardian accounts, so Guardian `/configure` accepts it.** 1.15.5 made `signBytes` produce a signature for Guardian accounts, but returned the ECDSA signature with its scheme-tag byte already stripped (`signWord`/`signHotDigest` slice it off). `@openzeppelin/miden-multisig-client`'s `MidenWalletSigner` strips the leading tag byte itself (`signBytes(...).slice(1)`), so it dropped a real signature byte and Guardian rejected the 64-byte result with `Authentication failed: Failed to deserialize ECDSA signature: unexpected end of file`. `signData` now re-prepends the ECDSA scheme tag so `signBytes` returns the full 66-byte serialized `Signature` — matching the plain-account path and what `MidenWalletSigner` expects (it re-strips the tag to the 65-byte raw signature Guardian verifies).
+
 ## 1.15.5 (2026-07-04)
 
 ### Fixes

--- a/src/lib/miden/back/vault.gaps.test.ts
+++ b/src/lib/miden/back/vault.gaps.test.ts
@@ -9,7 +9,7 @@
  *   - `tryHardwareUnlock` success path (returns a Vault)
  */
 
-import { u8ToB64 } from 'lib/shared/helpers';
+import { b64ToU8, u8ToB64 } from 'lib/shared/helpers';
 import * as Passworder from 'lib/miden/passworder';
 import { WalletType } from 'screens/onboarding/types';
 
@@ -237,9 +237,14 @@ describe('Vault instance signData — Guardian account (word kind)', () => {
 
     const sig = await vault.signData(commitment, data, 'word', GUARDIAN_ADDR);
 
-    // Hot path signs via secure-hot-key: mock sign() → [0xff,0xaa,0xbb,0xcc],
-    // slice(1) → [0xaa,0xbb,0xcc], returned as base64 (ECDSA sig, no scheme byte).
-    expect(sig).toBe(u8ToB64(new Uint8Array([0xaa, 0xbb, 0xcc])));
+    // signBytes must return the FULL serialized Signature (scheme tag + raw sig), matching the
+    // default path and what @openzeppelin's MidenWalletSigner expects — it strips the leading tag
+    // byte itself before handing the raw ECDSA signature to Guardian. `signWord`/`signHotDigest`
+    // strip that tag (mock sign() → [0xff,0xaa,0xbb,0xcc], slice(1) → [0xaa,0xbb,0xcc]); signData
+    // re-prepends the ECDSA scheme tag (0x01) so the returned bytes deserialize as a full Signature.
+    const returned = b64ToU8(sig);
+    expect(returned[0]).toBe(0x01); // ECDSA Signature scheme tag
+    expect(Array.from(returned.slice(1))).toEqual([0xaa, 0xbb, 0xcc]); // raw sig after MidenWalletSigner strips the tag
     // Signed the exact word it was handed, via the hot (secure-hot-key) path.
     expect(mockWordFromHex).toHaveBeenCalledWith(`0x${'ab'.repeat(32)}`);
   });

--- a/src/lib/miden/back/vault.ts
+++ b/src/lib/miden/back/vault.ts
@@ -1085,7 +1085,10 @@ export class Vault {
     // strip the tag, so re-prepend it here; otherwise the consumer strips a real signature byte and
     // Guardian rejects the 64-byte result with "unexpected end of file". Guardian hot keys are
     // always ECDSA (`secureHotKey.generateHotKey` → `AuthSecretKey.ecdsaWithRNG`), whose serialized
-    // `Signature` scheme tag is `0x01`.
+    // `Signature` scheme tag is `0x01`. (On mobile the raw sig comes from the native SE/StrongBox
+    // plugin as `r||s||v`, not an SDK `serialize()`, so this reconstruction is valid for the
+    // tag-stripping consumer — Guardian — but isn't guaranteed to round-trip through the SDK's
+    // `Signature.deserialize`.)
     if (signKind === 'word' && accountId) {
       const account = (await this.fetchAccounts()).find(acc => acc.publicKey === accountId);
       if (account?.hotPublicKey) {

--- a/src/lib/miden/back/vault.ts
+++ b/src/lib/miden/back/vault.ts
@@ -130,6 +130,12 @@ const accountsStrgKey = createStorageKey(StorageEntity.Accounts);
 const settingsStrgKey = createStorageKey(StorageEntity.Settings);
 const ownMnemonicStrgKey = createStorageKey(StorageEntity.OwnMnemonic);
 
+// Leading byte of a serialized SDK `Signature` for the ECDSA (secp256k1) scheme. Guardian hot
+// keys are always ECDSA, and `signHotDigest`/`signWord` strip this tag; signData re-prepends it so
+// `signBytes` returns a full serialized `Signature`. Verified against `@miden-sdk/miden-sdk` 0.15.2
+// (`AuthSecretKey.ecdsaWithRNG(...).sign(word).serialize()[0] === 0x01`).
+const ECDSA_SIGNATURE_SCHEME_TAG = 0x01;
+
 const insertKeyCallbackWrapper = (passKey: CryptoKey) => {
   return async (key: Uint8Array, secretKey: Uint8Array) => {
     const pubKeyHex = Buffer.from(key).toString('hex');
@@ -1072,17 +1078,24 @@ export class Vault {
     // Guardian-signer registration use case. `signingInputs` (full transaction) for a
     // Guardian account goes through the multisig co-sign flow, not this path.
     //
-    // Note the return shape differs by account type: the default path below returns the
-    // full serialized `Signature` (with the 1-byte scheme tag); the Guardian path returns
-    // the raw ECDSA signature with the tag stripped (`signWord`/`signHotDigest` slice it),
-    // matching what the guardian client / `/configure` verify.
+    // `signBytes` returns the FULL serialized `Signature` (scheme tag + signature), exactly like
+    // the default path below (`signature.serialize()`). Consumers strip the tag themselves —
+    // notably @openzeppelin's `MidenWalletSigner.signWord`, which does `signBytes(...).slice(1)`
+    // before handing the raw ECDSA signature to Guardian's `/configure`. `signWord`/`signHotDigest`
+    // strip the tag, so re-prepend it here; otherwise the consumer strips a real signature byte and
+    // Guardian rejects the 64-byte result with "unexpected end of file". Guardian hot keys are
+    // always ECDSA (`secureHotKey.generateHotKey` → `AuthSecretKey.ecdsaWithRNG`), whose serialized
+    // `Signature` scheme tag is `0x01`.
     if (signKind === 'word' && accountId) {
       const account = (await this.fetchAccounts()).find(acc => acc.publicKey === accountId);
       if (account?.hotPublicKey) {
         const wordHex = `0x${bytesToHex(b64ToU8(data))}`;
         const sigHex = await this.signWord(account.hotPublicKey, wordHex);
-        const sigBytes = new Uint8Array(Buffer.from(sigHex.startsWith('0x') ? sigHex.slice(2) : sigHex, 'hex'));
-        return u8ToB64(sigBytes);
+        const rawEcdsaSig = new Uint8Array(Buffer.from(sigHex.startsWith('0x') ? sigHex.slice(2) : sigHex, 'hex'));
+        const fullSignature = new Uint8Array(rawEcdsaSig.length + 1);
+        fullSignature[0] = ECDSA_SIGNATURE_SCHEME_TAG;
+        fullSignature.set(rawEcdsaSig, 1);
+        return u8ToB64(fullSignature);
       }
       if (account?.coldPublicKey) {
         // Guardian account with no active hot key (e.g. recovered via seed phrase,


### PR DESCRIPTION
## Problem

Follow-up to #316 (Guardian `signBytes`, shipped in 1.15.5). A dApp registering an external multisig via `ms.registerOnGuardian()` got a signature from the wallet, but Guardian's `/configure` rejected it:

```
401 Unauthorized
"Authentication failed: Signature verification failed: Failed to deserialize ECDSA signature: unexpected end of file"
```

## Root cause

`@openzeppelin/miden-multisig-client`'s **`MidenWalletSigner.signWord`** does `signBytes(bytes, 'word').slice(1)` — it strips the leading SDK `Signature` scheme-tag byte **itself**, expecting `signBytes` to return the **full serialized `Signature`** (matching the SDK's `EcdsaSigner`, which sends `serialize().slice(1)` = 65 bytes to Guardian).

But `signData` returned the ECDSA signature with the tag **already stripped** (`signWord`/`signHotDigest` do `serialize().slice(1)`). So `MidenWalletSigner` stripped a **real signature byte**, producing a 64-byte signature → Guardian's 65-byte-recoverable-ECDSA deserializer hit EOF.

Verified against `@miden-sdk/miden-sdk` 0.15.2: ECDSA `serialize()` = 66 bytes, tag `0x01`; `MidenWalletSigner(signBytes = full serialize).slice(1)` reproduces `EcdsaSigner`'s output byte-for-byte.

The reporter's own trace nailed it: a *varying* first byte (`0x9e`, `0xb5`, `0x80`) was being dropped inside the signer's `signWord` — i.e. `r[0]`, not the constant tag.

## Fix

`signData` re-prepends the ECDSA scheme tag (`0x01`) to reconstruct the full 66-byte serialized `Signature`, so `signBytes` returns the full serialization — matching the plain-account path and the `MidenWalletSigner` contract. `MidenWalletSigner` then re-strips the tag to the 65-byte raw signature Guardian verifies.

## Tests

- `vault.gaps.test.ts`: the Guardian `signBytes` test now asserts the returned bytes are a full `Signature` (tag `0x01` + raw sig), and that stripping the tag (as `MidenWalletSigner` does) yields the raw ECDSA signature.
- Full vault + dapp suites: 284/284 pass; typecheck clean.
