### PR TITLE
fix: eslint import order in vault.gaps.test.ts

### DIFF
--- a/src/lib/miden/back/vault.gaps.test.ts
+++ b/src/lib/miden/back/vault.gaps.test.ts
@@ -9,8 +9,8 @@
  *   - `tryHardwareUnlock` success path (returns a Vault)
  */
 
-import { b64ToU8, u8ToB64 } from 'lib/shared/helpers';
 import * as Passworder from 'lib/miden/passworder';
+import { b64ToU8, u8ToB64 } from 'lib/shared/helpers';
 import { WalletType } from 'screens/onboarding/types';
 
 import { PublicError } from './defaults';


### PR DESCRIPTION
Fixes the `Run ESLint` failure in **Build Production** on `main` (red since #316 / commit 2524f839).

`eslint src --max-warnings 0` flagged one warning: in `vault.gaps.test.ts`, the `lib/shared/helpers` import I added in #316 was placed before `lib/miden/passworder`, violating `import/order`. Reordered so `lib/miden/passworder` comes first.

Verified locally: `eslint --max-warnings 0` on the file is clean; matches the single warning CI reported (`✖ 1 problem`).