### PR TITLE
ci: add README coverage badge (shields.io endpoint)

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,64 @@
+name: Coverage Badge
+
+# Publishes the Jest line-coverage % to coverage.json on the orphan `badges`
+# branch so shields.io renders a live badge in README.md. Runs only after a
+# push to main. No external service login required — shields.io reads the JSON
+# directly from raw.githubusercontent.com. The `badges` branch is an orphan
+# holding only the endpoint JSON; nothing merges back into main.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  coverage-badge:
+    name: Publish coverage badge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - name: Install
+        # Plain `yarn install` (no --frozen-lockfile) mirrors the proven pr.yml
+        # coverage job, tolerating any latent lockfile drift on a first run.
+        run: yarn install --network-timeout 600000
+      - name: Run coverage
+        run: yarn test:coverage
+      - name: Compose shields.io endpoint JSON
+        id: badge
+        run: |
+          set -euo pipefail
+          pct=$(node -e 'process.stdout.write(Number(require("./coverage/coverage-summary.json").total.lines.pct).toFixed(1))')
+          int=$(printf '%.0f' "$pct")
+          color=red
+          if [ "$int" -ge 80 ]; then color=yellow; fi
+          if [ "$int" -ge 90 ]; then color=brightgreen; fi
+          if [ "$int" -ge 95 ]; then color=green; fi
+          printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}\n' "$pct" "$color" > /tmp/coverage.json
+          echo "Line coverage: ${pct}%"
+          echo "pct=${pct}" >> "$GITHUB_OUTPUT"
+      - name: Publish to `badges` branch
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin badges > /dev/null 2>&1; then
+            git fetch origin badges
+            git checkout badges
+          else
+            git checkout --orphan badges
+            git rm -rf . > /dev/null 2>&1 || true
+          fi
+          cp /tmp/coverage.json coverage.json
+          git add coverage.json
+          if git diff --cached --quiet; then
+            echo "Badge JSON unchanged"
+          else
+            git commit -m "chore: coverage badge -> ${{ steps.badge.outputs.pct }}%"
+            git push origin badges
+          fi

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![build](https://github.com/0xMiden/miden-wallet/actions/workflows/production-branch.yml/badge.svg)](https://github.com/0xMiden/miden-wallet/actions/workflows/production-branch.yml)
 [![build](https://github.com/0xMiden/miden-wallet/actions/workflows/build-desktop.yml/badge.svg)](https://github.com/0xMiden/miden-wallet/actions/workflows/build-desktop.yml)
 [![build](https://github.com/0xMiden/miden-wallet/actions/workflows/build-mobile.yml/badge.svg)](https://github.com/0xMiden/miden-wallet/actions/workflows/build-mobile.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/0xMiden/wallet/badges/coverage.json)](https://github.com/0xMiden/wallet/actions/workflows/coverage-badge.yml)
 
 A secure, cross-platform wallet for the [Miden](https://miden.xyz) blockchain. Available as a browser extension, desktop application, and mobile app.
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -29,6 +29,9 @@ export default {
     '/src/lib/mobile/faucet-webview\\.ts$',
     '/packages/dapp-browser/'
   ],
+  // 'json-summary' emits coverage/coverage-summary.json, consumed by the
+  // coverage-badge workflow to publish the README shields.io badge.
+  coverageReporters: ['json-summary', 'text-summary', 'lcov'],
   coverageThreshold: {
     global: {
       branches: 95,


### PR DESCRIPTION
Adds a live **coverage badge** to the README, using the same mechanism as `web-sdk`.

## How it works
- **`jest.config.ts`**: adds `coverageReporters: ['json-summary', 'text-summary', 'lcov']` so `yarn test:coverage` emits `coverage/coverage-summary.json`.
- **`.github/workflows/coverage-badge.yml`** (new): on **push to `main`**, runs `yarn test:coverage`, composes a shields.io *endpoint* JSON from the line-coverage %, and publishes it to `coverage.json` on an orphan **`badges`** branch. No external service (Codecov/Coveralls) — shields.io reads the JSON straight from `raw.githubusercontent.com`.
- **`README.md`**: `![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/0xMiden/wallet/badges/coverage.json)`.

## Notes
- The badge renders once the workflow runs on `main` after this merges (it needs to create the `badges` branch + `coverage.json` first). Until then shields.io shows "coverage: invalid" — expected, self-heals on the first `main` run.
- Color thresholds match web-sdk: <80 red, ≥80 yellow, ≥90 brightgreen, ≥95 green. The repo's 95% gate means it should render **green**.
- The `badges` branch is an orphan holding only the endpoint JSON; nothing merges back to `main`.
- Trivial CI/docs change → `no changelog`.
