### PR TITLE
docs(privacy): add dedicated Face ID / biometric data section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [FIX][devnet] **Restored the devnet developer (wrench) badge on the icon.** The v0 UI revamp (#248) rebranded the devnet icon to the plain Bread "B" and dropped the wrench badge, so devnet builds again looked identical to production. `public/misc/logo-devnet*.png` (234/128/48/40/32/16) now re-add the Advanced Settings / Developer wrench glyph in a white circle with a thin `#7286A0` ring, overlapping the B's bottom-right, so a devnet build is distinguishable at a glance. Wiring is unchanged — `vite.extension.config.ts` already swaps `logo-white-bg*` → `logo-devnet*` for `MIDEN_NETWORK=devnet` (manifest icons, action icon, and tab favicon).
 
+### Docs
+
+* [DOCS][all] **Privacy policy: added a dedicated Face ID / biometric data section.** Clarifies that the app collects, stores, shares, and retains no face or fingerprint data — biometric matching happens entirely in the device's Secure Enclave / hardware keystore and the app only ever receives a pass/fail result. Added in response to an iOS App Review request; the hosted policy at https://0xmiden.github.io/wallet/privacy/ is the source the Resolution Center reply quotes.
+
 ## 1.15.6 (2026-07-09)
 
 ### Features

--- a/docs/privacy/index.md
+++ b/docs/privacy/index.md
@@ -5,7 +5,7 @@ permalink: /privacy/
 
 # Miden Wallet — Privacy Policy
 
-_Last updated: 2026-05-28_
+_Last updated: 2026-07-20_
 
 Miden Wallet ("the App") is a non-custodial cryptocurrency wallet for the Miden blockchain, published by Miden.
 
@@ -19,6 +19,20 @@ For transparency about how the App functions on your device (this is not data we
 
 - Your wallet's seed phrase, private keys, account names, transaction history, and balances are generated and held **only** on your device, encrypted at rest using your device's secure enclave (Android Keystore / iOS Secure Enclave) when biometric protection is enabled.
 - This information never leaves your device unless **you** explicitly export it via the in-app "Export Wallet" function.
+
+## Biometric authentication (Face ID, Touch ID, Fingerprint)
+
+The App offers **optional** biometric unlock using your device's built-in authentication — Face ID or Touch ID on iOS, fingerprint or face authentication on Android.
+
+**The App does not collect, access, receive, store, transmit, or share any face data, fingerprint data, or other biometric data.**
+
+Biometric matching is performed entirely by your device's operating system inside secure hardware (Apple's Secure Enclave / Android's hardware-backed keystore). Your biometric templates are created, stored, and managed solely by iOS/Android and are never made available to the App. When you unlock with biometrics, the App receives only a yes/no result indicating whether authentication succeeded — it never receives any biometric data itself.
+
+- **What we collect:** No face or fingerprint data. None is ever transmitted off your device; we operate no servers that could receive it.
+- **How it is used:** A successful biometric check causes your device's operating system to release a wallet-unlock key held in secure hardware, allowing the App to decrypt your local wallet without you typing your password. This happens entirely on-device.
+- **Sharing / third parties:** None. No biometric data exists in the App to share.
+- **Storage:** No biometric data is stored by the App. Your biometric templates remain solely under your operating system's control in secure hardware.
+- **Retention / deletion:** The App retains no biometric data. You manage your enrolled biometrics in your device's system settings. Disabling biometric unlock in the App, or uninstalling the App, removes the App's on-device unlock key and has no effect on and no access to your OS-level biometric enrollment.
 
 ## Network traffic
 


### PR DESCRIPTION
## Why

App Review flagged the iOS submission (com.miden.bread) asking for detailed information about how the app uses **face data**. The app collects **no** face data — Face ID is used only for local authentication via Apple's `LocalAuthentication` framework (the biometric match happens in the Secure Enclave; the app receives only a pass/fail). But the current privacy policy only mentions biometrics in passing, so there was no quotable section to point Apple at.

This adds a dedicated **"Biometric authentication (Face ID, Touch ID, Fingerprint)"** section to `docs/privacy/index.md` that explicitly states no biometric data is collected, used, shared, stored, or retained, so the Resolution Center reply can quote it directly.

## Publishing

Served by GitHub Pages from `/docs` on `main` → live at https://0xmiden.github.io/wallet/privacy/ ~1–2 min after merge. **This must be live before replying to App Review** (the reviewer may click the URL).

## Notes

- Also bumps `_Last updated_` to 2026-07-20.
- Purely additive; no wording changed elsewhere.