### PR TITLE
fix(onboarding): render highlight tags in side-panel "Wallet is ready" title; bump 1.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 1.15.7 (TBD)
+## 1.15.7 (2026-07-20)
 
 ### Fixes
 
+* [FIX][extension] **Onboarding "Your Wallet is ready!" no longer shows raw `<highlight>` tags.** The Chrome side-panel handoff completion screen (`OpenSidePanel`) rendered its title via plain `t('yourWalletIsReady')`, which returns the raw i18n string including the `<highlight>Wallet</highlight>` markup, so the tags appeared as literal text. It now renders through `<Trans>` (matching `Confirmation.tsx`), styling "Wallet" in the primary color; `Message.title` was widened to `ReactNode` to accept the styled node. Added a regression test that renders the screen with real i18n and asserts the tags are parsed.
 * [FIX][devnet] **Restored the devnet developer (wrench) badge on the icon.** The v0 UI revamp (#248) rebranded the devnet icon to the plain Bread "B" and dropped the wrench badge, so devnet builds again looked identical to production. `public/misc/logo-devnet*.png` (234/128/48/40/32/16) now re-add the Advanced Settings / Developer wrench glyph in a white circle with a thin `#7286A0` ring, overlapping the B's bottom-right, so a devnet build is distinguishable at a glance. Wiring is unchanged — `vite.extension.config.ts` already swaps `logo-white-bg*` → `logo-devnet*` for `MIDEN_NETWORK=devnet` (manifest icons, action icon, and tab favicon).
 
 ### Docs

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.miden.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11506001
-        versionName "1.15.6"
+        versionCode 11507001
+        versionName "1.15.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -344,7 +344,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.6;
+				MARKETING_VERSION = 1.15.7;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.miden.bread;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -369,7 +369,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.6;
+				MARKETING_VERSION = 1.15.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.miden.bread;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "private": true,
   "engines": {
     "node": ">=22.0.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bread",
-  "version": "1.15.6",
+  "version": "1.15.7",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",

--- a/src/app/pages/OpenSidePanel.test.tsx
+++ b/src/app/pages/OpenSidePanel.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+
+import i18n from 'i18next';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import OpenSidePanel from './OpenSidePanel';
+import en from '../../../public/_locales/en/en.json';
+
+// Regression test for the onboarding "Your <highlight>Wallet</highlight> is
+// ready!" bug: this completion screen used to render the title via plain
+// `t('yourWalletIsReady')`, which returns the raw string with `<highlight>`
+// markup. Because `t()` does not parse i18n tags, the tags showed up as
+// literal text. The fix renders the title through `<Trans>` (matching
+// Confirmation.tsx), so `<highlight>` becomes a styled <span>.
+//
+// The test deliberately uses the REAL react-i18next + Message components and
+// seeds a real i18n instance from the production en.json, so it exercises the
+// actual tag parsing rather than a stand-in.
+
+jest.mock('app/atoms/Spinner/Spinner', () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+jest.mock('app/icons/v2', () => ({
+  Icon: () => null,
+  IconName: { Success: 'Success' }
+}));
+
+jest.mock('components/Button', () => ({
+  Button: () => null
+}));
+
+jest.mock('lib/extension/side-panel-handoff', () => ({
+  closeOnboardingTab: jest.fn(),
+  openSidePanelToWallet: jest.fn()
+}));
+
+jest.mock('lib/miden/front', () => ({
+  useMidenContext: () => ({ ready: true })
+}));
+
+jest.mock('lib/woozie', () => ({
+  navigate: jest.fn()
+}));
+
+describe('OpenSidePanel - ready state', () => {
+  let testRoot: ReturnType<typeof createRoot> | null = null;
+  let testContainer: HTMLDivElement | null = null;
+  let testI18n: typeof i18n;
+
+  beforeAll(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(async () => {
+    testI18n = i18n.createInstance();
+    await testI18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      interpolation: { escapeValue: false, prefix: '$', suffix: '$' },
+      resources: { en: { translation: en } }
+    });
+  });
+
+  afterEach(async () => {
+    if (testRoot) {
+      await act(async () => {
+        testRoot!.unmount();
+      });
+      testRoot = null;
+    }
+    if (testContainer) {
+      testContainer.remove();
+      testContainer = null;
+    }
+  });
+
+  const render = async () => {
+    testContainer = document.createElement('div');
+    testRoot = createRoot(testContainer);
+    await act(async () => {
+      testRoot!.render(
+        <I18nextProvider i18n={testI18n}>
+          <OpenSidePanel />
+        </I18nextProvider>
+      );
+    });
+  };
+
+  it('renders the ready title without leaking <highlight> markup', async () => {
+    await render();
+
+    const heading = testContainer!.querySelector('h1');
+    expect(heading?.textContent).toBe('Your Wallet is ready!');
+    // The literal tag would only appear if the string were rendered via plain t().
+    expect(testContainer!.textContent).not.toContain('<highlight>');
+  });
+
+  it('styles the highlighted word in a dedicated span', async () => {
+    await render();
+
+    const highlighted = testContainer!.querySelector('.text-primary-500');
+    expect(highlighted?.textContent).toBe('Wallet');
+  });
+});

--- a/src/app/pages/OpenSidePanel.test.tsx
+++ b/src/app/pages/OpenSidePanel.test.tsx
@@ -5,6 +5,9 @@ import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 
+import { closeOnboardingTab, openSidePanelToWallet } from 'lib/extension/side-panel-handoff';
+import { navigate } from 'lib/woozie';
+
 import OpenSidePanel from './OpenSidePanel';
 import en from '../../../public/_locales/en/en.json';
 
@@ -17,11 +20,15 @@ import en from '../../../public/_locales/en/en.json';
 //
 // The test deliberately uses the REAL react-i18next + Message components and
 // seeds a real i18n instance from the production en.json, so it exercises the
-// actual tag parsing rather than a stand-in.
+// actual tag parsing rather than a stand-in. It also covers the screen's
+// ready/not-ready branches and the "Open wallet" handoff outcomes.
+
+// `mock`-prefixed so jest's hoisted mock factory may reference it.
+let mockReady = true;
 
 jest.mock('app/atoms/Spinner/Spinner', () => ({
   __esModule: true,
-  default: () => null
+  default: () => <div data-testid="spinner" />
 }));
 
 jest.mock('app/icons/v2', () => ({
@@ -30,7 +37,11 @@ jest.mock('app/icons/v2', () => ({
 }));
 
 jest.mock('components/Button', () => ({
-  Button: () => null
+  Button: ({ title, onClick }: { title: string; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {title}
+    </button>
+  )
 }));
 
 jest.mock('lib/extension/side-panel-handoff', () => ({
@@ -39,14 +50,18 @@ jest.mock('lib/extension/side-panel-handoff', () => ({
 }));
 
 jest.mock('lib/miden/front', () => ({
-  useMidenContext: () => ({ ready: true })
+  useMidenContext: () => ({ ready: mockReady })
 }));
 
 jest.mock('lib/woozie', () => ({
   navigate: jest.fn()
 }));
 
-describe('OpenSidePanel - ready state', () => {
+const mockOpenSidePanel = openSidePanelToWallet as jest.Mock;
+const mockCloseTab = closeOnboardingTab as jest.Mock;
+const mockNavigate = navigate as jest.Mock;
+
+describe('OpenSidePanel', () => {
   let testRoot: ReturnType<typeof createRoot> | null = null;
   let testContainer: HTMLDivElement | null = null;
   let testI18n: typeof i18n;
@@ -60,6 +75,11 @@ describe('OpenSidePanel - ready state', () => {
   });
 
   beforeEach(async () => {
+    mockReady = true;
+    mockOpenSidePanel.mockReset();
+    mockCloseTab.mockReset();
+    mockNavigate.mockReset();
+
     testI18n = i18n.createInstance();
     await testI18n.use(initReactI18next).init({
       lng: 'en',
@@ -94,6 +114,17 @@ describe('OpenSidePanel - ready state', () => {
     });
   };
 
+  const clickOpenWallet = async () => {
+    const button = testContainer!.querySelector('button');
+    await act(async () => {
+      button!.click();
+      // Flush the handler's awaited promises (openSidePanelToWallet, then
+      // closeOnboardingTab) and any resulting state updates.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
   it('renders the ready title without leaking <highlight> markup', async () => {
     await render();
 
@@ -108,5 +139,49 @@ describe('OpenSidePanel - ready state', () => {
 
     const highlighted = testContainer!.querySelector('.text-primary-500');
     expect(highlighted?.textContent).toBe('Wallet');
+  });
+
+  it('shows a spinner while the wallet is still being created', async () => {
+    mockReady = false;
+    await render();
+
+    expect(testContainer!.querySelector('[data-testid="spinner"]')).not.toBeNull();
+    expect(testContainer!.querySelector('h1')).toBeNull();
+    expect(testContainer!.textContent).toContain('Creating your wallet');
+  });
+
+  it('opens the side panel and closes the onboarding tab on success', async () => {
+    mockOpenSidePanel.mockResolvedValue(true);
+    mockCloseTab.mockResolvedValue(true);
+    await render();
+
+    await clickOpenWallet();
+
+    expect(mockOpenSidePanel).toHaveBeenCalledTimes(1);
+    expect(mockCloseTab).toHaveBeenCalledTimes(1);
+    // Tab closed successfully — no fallback navigation.
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the wallet home when the side panel fails to open', async () => {
+    mockOpenSidePanel.mockResolvedValue(false);
+    await render();
+
+    await clickOpenWallet();
+
+    expect(mockOpenSidePanel).toHaveBeenCalledTimes(1);
+    expect(mockCloseTab).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('falls back to the wallet home when the onboarding tab cannot be closed', async () => {
+    mockOpenSidePanel.mockResolvedValue(true);
+    mockCloseTab.mockResolvedValue(false);
+    await render();
+
+    await clickOpenWallet();
+
+    expect(mockCloseTab).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 });

--- a/src/app/pages/OpenSidePanel.tsx
+++ b/src/app/pages/OpenSidePanel.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import Spinner from 'app/atoms/Spinner/Spinner';
 import { IconName } from 'app/icons/v2';
@@ -78,7 +78,12 @@ const OpenSidePanel: FC = () => {
                 icon={IconName.Success}
                 iconSize="3xl"
                 iconClassName="mb-8"
-                title={t('yourWalletIsReady')}
+                title={
+                  <Trans
+                    i18nKey="yourWalletIsReady"
+                    components={{ highlight: <span className="text-primary-500" /> }}
+                  />
+                }
                 description=""
               />
             </div>

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -4,9 +4,9 @@ import classNames from 'clsx';
 
 import { Icon, IconName, IconSize } from 'app/icons/v2';
 
-export interface MessageProps extends React.ButtonHTMLAttributes<HTMLDivElement> {
+export interface MessageProps extends Omit<React.ButtonHTMLAttributes<HTMLDivElement>, 'title'> {
   icon: IconName;
-  title: string;
+  title: React.ReactNode;
   description: string;
   secondDescription?: string;
   descriptionClasses?: string;


### PR DESCRIPTION
The Chrome onboarding → side-panel handoff completion screen showed the literal text **"Your `<highlight>`Wallet`</highlight>` is ready!"** — the i18n styling tags leaked into the UI.

## Root cause
`src/app/pages/OpenSidePanel.tsx` rendered its title via plain `title={t('yourWalletIsReady')}`. The `en.json` value is `"Your <highlight>Wallet</highlight> is ready!"` — the `<highlight>` markup is intentional (it colors the word "Wallet"), meant to be parsed by `<Trans>`, exactly as the sibling `Confirmation.tsx` screen already does. Plain `t()` returns the raw string, so the tags rendered as text.

## Fix
- **`OpenSidePanel.tsx`** — render the title through `<Trans i18nKey="yourWalletIsReady" components={{ highlight: <span className="text-primary-500" /> }} />`, matching `Confirmation.tsx`.
- **`Message.tsx`** — widen `title` from `string` to `React.ReactNode` (via `Omit<…, "title">` on the extended `ButtonHTMLAttributes`, since `title` is a custom heading, destructured out and never spread onto the DOM). Backward-compatible with the other string callers.
- **Regression test** (`OpenSidePanel.test.tsx`) — renders the real screen with a real i18n instance seeded from the actual `en.json`, asserts the heading reads "Your Wallet is ready!", that "Wallet" sits in a `.text-primary-500` span, and that no literal `<highlight>` leaks. Verified it fails on the pre-fix version.

## Release
Bumps the wallet version `1.15.6 → 1.15.7` (package.json, manifest.json, iOS `MARKETING_VERSION`, Android `versionCode`/`versionName`) and dates the `1.15.7` CHANGELOG section.

## Verification
`tsc --noEmit`, `eslint` (standard + i18n), and `jest src/app/pages src/components src/screens/onboarding` (138 tests) all pass.