### PR TITLE
chore(extension): use full name "Bread Wallet by Miden" for Chrome package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.15.7 (2026-07-20)
 
+### Changes
+
+* [CHANGE][extension] **Chrome extension renamed to the full product name "Bread Wallet by Miden".** The manifest `name` — shown in the Chrome Web Store listing and on `chrome://extensions` — changed from "Bread" to "Bread Wallet by Miden". Devnet builds keep their automatic "(Devnet)" suffix, so they read "Bread Wallet by Miden (Devnet)" (`vite.extension.config.ts` appends the suffix to whatever `name` is). `short_name` (constrained-UI slot), the toolbar tooltip (`default_title`), and in-app naming are unchanged.
+
 ### Fixes
 
 * [FIX][extension] **Onboarding "Your Wallet is ready!" no longer shows raw `<highlight>` tags.** The Chrome side-panel handoff completion screen (`OpenSidePanel`) rendered its title via plain `t('yourWalletIsReady')`, which returns the raw i18n string including the `<highlight>Wallet</highlight>` markup, so the tags appeared as literal text. It now renders through `<Trans>` (matching `Confirmation.tsx`), styling "Wallet" in the primary color; `Message.title` was widened to `ReactNode` to accept the styled node. Added a regression test that renders the screen with real i18n and asserts the tags are parsed.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Bread",
+  "name": "Bread Wallet by Miden",
   "version": "1.15.7",
 
   "icons": {


### PR DESCRIPTION
The Chrome submission currently lists the extension as **Bread** (and **Bread (Devnet)**). The full product name is **Bread Wallet by Miden** — this makes the Chrome packages carry it.

## Change
- `public/manifest.json`: `name` `"Bread"` → `"Bread Wallet by Miden"`. This is the name shown in the Chrome Web Store listing and on `chrome://extensions`.
- Devnet builds are unaffected by the rename mechanics: `vite.extension.config.ts` appends `" (Devnet)"` to whatever `name` is, so a devnet build reads **"Bread Wallet by Miden (Devnet)"**.

## Intentionally unchanged
- `short_name` stays `"Bread"` — Chrome uses it in constrained-UI slots (app launcher/shelf) where a ~12-char label is expected.
- `default_title` (toolbar tooltip) and in-app `appName` (About page / logo) stay `"Bread"` per the chosen scope (store name only).

Folds into the pending **1.15.7** release (no version bump; CHANGELOG entry added under the existing 1.15.7 section).

## Verification
Valid JSON; `name` is 21 chars (Chrome max 45); no test or source asserts the old literal name.