### PR TITLE
ci: skip devnet E2E on push until wallet reaches 0.16 (testnet gates main)

### DIFF
--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -1,11 +1,20 @@
 name: E2E Blockchain
 
 # Runs the blockchain-backed E2E suites (Chrome extension + iOS simulator)
-# against public networks on every push to main. The per-platform gate jobs
-# pass as long as AT LEAST ONE network (devnet OR testnet) succeeded for
-# that platform — this tolerates short windows where wallet@main and a
-# single network are protocol-mismatched (e.g. devnet ahead of the pinned
-# SDK version).
+# against public networks. Testnet runs on every push to main and gates the
+# result.
+#
+# Devnet is currently SKIPPED on push: devnet is on the 0.16 protocol line
+# while wallet@main is still on 0.15, so every devnet job fails on a protocol
+# mismatch and would (falsely) turn main red. The devnet jobs still run on
+# demand via `workflow_dispatch` (network = devnet | both). Re-enable them on
+# push by restoring each devnet job's `if:` to
+# `github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'`
+# once the wallet is on the same protocol line as devnet.
+#
+# The per-platform gate jobs pass as long as AT LEAST ONE network (devnet OR
+# testnet) succeeded for that platform, so a skipped devnet + green testnet
+# still passes the gate.
 
 on:
   push:
@@ -35,7 +44,7 @@ jobs:
 
   chrome-devnet:
     name: Chrome E2E (devnet)
-    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    if: github.event_name == 'workflow_dispatch' && (inputs.network == 'both' || inputs.network == 'devnet')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -216,7 +225,7 @@ jobs:
 
   chrome-guardian-devnet:
     name: Chrome Guardian E2E (devnet)
-    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    if: github.event_name == 'workflow_dispatch' && (inputs.network == 'both' || inputs.network == 'devnet')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -376,7 +385,7 @@ jobs:
 
   mobile-devnet:
     name: Mobile E2E (devnet)
-    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    if: github.event_name == 'workflow_dispatch' && (inputs.network == 'both' || inputs.network == 'devnet')
     # macos-26 matches build-mobile.yml — required for iOS 26 SDK symbols
     # used by dapp-browser's WKWebViewController. The -xlarge size is the
     # DEDICATED Apple-Silicon larger runner (2x vCPU/RAM, no noisy-neighbour
@@ -753,7 +762,7 @@ jobs:
   # gate) so a guardian outage never blocks the standard mobile gate.
   mobile-guardian-devnet:
     name: Mobile Guardian E2E (devnet)
-    if: github.event_name != 'workflow_dispatch' || inputs.network == 'both' || inputs.network == 'devnet'
+    if: github.event_name == 'workflow_dispatch' && (inputs.network == 'both' || inputs.network == 'devnet')
     # macos-26 matches build-mobile.yml — required for iOS 26 SDK symbols
     # used by dapp-browser's WKWebViewController. The -xlarge size is the
     # DEDICATED Apple-Silicon larger runner (2x vCPU/RAM, no noisy-neighbour


### PR DESCRIPTION
The **E2E Blockchain** workflow has been turning `main` red on every push since 07-20, even though nothing is actually broken in the wallet.

## Root cause (not a regression)
Every **devnet** job fails while every **testnet** job passes — devnet is on the **0.16** protocol line while `wallet@main` is still on **0.15**, so the devnet suites fail on a protocol mismatch (they time out at wallet-creation against the devnet RPC). The workflow already has per-platform **Gate** jobs that pass when *at least one* network succeeds, and those gates are green — but the raw devnet **jobs** are hard-fail, so the overall run conclusion is `failure` and `main` shows a red X.

Evidence (final 1.15.7 SHA `9728ef60`): all 4 devnet jobs `failure`, all 4 testnet jobs `success`, all 4 Gate jobs `success`. Streak began at `ba1bb2c6`/#339/#340 — commits that predate and cannot affect blockchain flows.

## Change
Skip the four **devnet** jobs on `push` (they now run only via manual `workflow_dispatch` with `network = devnet | both`). Testnet still runs on every push and gates `main`. A skipped devnet + green testnet still passes each Gate (`if: always()`, `devnet==success || testnet==success` → testnet wins), so `main` goes green — and we stop burning ~30–60 min of CI per push on jobs that are expected to fail.

Re-enable devnet on push (one line per job) once the wallet is on devnet's protocol line; the how-to is in the workflow header comment.

## Scope
Workflow-only change; no wallet code, no version bump. `E2E Blockchain` runs on push-to-main (not on PRs), so it validates on the merge commit — I'll confirm `main` goes green after merge.