### PR TITLE
ci: check out fork head repo in PR Tests so fork PRs run

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Fork PRs: the head branch lives in the contributor's fork, not the
+          # base repo. Without `repository`, checkout defaults to the base repo
+          # and the fetch of `head_ref` fails (Check Out Code errors, and every
+          # job that `needs: translations` skips). Push-back below stays gated
+          # to same-repo PRs, so forks check out + generate but skip the push.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
       - name: Use Node 22
@@ -87,6 +93,8 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v3
         with:
+          # Fork PRs: the head branch lives in the fork, not the base repo.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
       - name: Use Node 22
@@ -144,6 +152,8 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v3
         with:
+          # Fork PRs: the head branch lives in the fork, not the base repo.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
       - name: Use Node 22
@@ -172,6 +182,8 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v4
         with:
+          # Fork PRs: the head branch lives in the fork, not the base repo.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
       - name: Setup Node


### PR DESCRIPTION
## Problem

The **PR Tests** workflow (`.github/workflows/pr.yml`) fails at **Check Out Code** for any PR opened from a **fork**. Every job checks out with `ref: ${{ github.head_ref }}` and no `repository:`, so `actions/checkout` defaults to the base repo (`0xMiden/wallet`) and the `git fetch` of the head branch fails — that branch only exists in the contributor's fork. The first job (`translations`) dies at checkout, and everything that `needs: translations` (`Test`, `Coverage`, `Check for non-i18n'd strings`) shows `skipping`.

Observed on #337 (a fork PR): `Update Translation Files → Check Out Code → The process '/usr/bin/git' failed with exit code 1`, retried 3× then failed. Same-repo PRs (e.g. internal branches) are unaffected because `head_ref` exists in the base repo. The `changelog` and `local-e2e` workflows already run on forks because they use `actions/checkout` **without** a `ref:` override (checkout's default `pull_request` merge-ref, which exists for forks).

## Fix

Add `repository: ${{ github.event.pull_request.head.repo.full_name }}` to all four `Check Out Code` steps so they target the head repo:

- **Same-repo PRs:** `repository` resolves to `0xMiden/wallet` → identical behavior to today; the `translations` push-back still works.
- **Fork PRs:** checks out the fork's branch. Push-back is already gated to same-repo PRs (`head.repo.full_name == github.repository`), so forks check out + generate translations but skip the push. The `inject-linked-web-sdk-pr` step only *reads* the PR body (fine with a fork's read-only token) and its sticky-comment step is `continue-on-error`, so the job goes green on forks.

No trigger change: the workflow stays on `pull_request` (read-only token, no secrets for forks) — **not** `pull_request_target` — so no new exposure to untrusted code.

## Notes

- CI-infra only, no product/source changes → `no changelog` label.
- This can only take effect once merged to `main` and picked up by a fresh run on the target PR (see the PR discussion for how to re-trigger #337).