### PR TITLE
fix(ios): enable ProMotion 120Hz refresh rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.9 (TBD)
+
+### Fixes
+
+* [FIX][mobile] **iOS now renders at the display's native refresh rate (up to 120Hz ProMotion) instead of being capped at 60fps.** Added `CADisableMinimumFrameDurationOnPhone` to `Info.plist`. Since iOS 15, iPhones cap every app — including its WKWebView — to 60fps unless the app opts in to high frame rates, so on ProMotion devices animations and scrolling felt stuck at 60Hz (the same as Low Power Mode). CSS/compositor animations and native scrolling now run at the full display rate.
+
 ## 1.15.8 (2026-07-21)
 
 ### Changes

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>CAPACITOR_DEBUG</key>
 	<string>$(CAPACITOR_DEBUG)</string>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
## Problem

An iOS user on a 120Hz (ProMotion) iPhone reports the app feels capped at 60fps — *"the same as when I put it into low power mode."* That comparison is the tell: Low Power Mode's one relevant effect on a ProMotion iPhone is dropping the display to 60Hz.

## Root cause

Since **iOS 15**, iPhones cap every app to **60fps by default** — including the WKWebView our Capacitor app renders into — to conserve battery. Apps must explicitly opt in to higher frame rates via the `CADisableMinimumFrameDurationOnPhone` Info.plist key. That key was **absent from the entire `ios/` tree**, so the app (and its WebView compositor) was pinned at 60Hz on ProMotion devices.

## Fix

Add to `ios/App/App/Info.plist`:

```xml
<key>CADisableMinimumFrameDurationOnPhone</key>
<true/>
```

This lifts the cap and lets Core Animation and the WebView compositor run at the display's native rate.

## Impact

- ✅ CSS transitions/animations on `transform`/`opacity` (the compositor-driven ones the 1.15.8 polish pass standardized on) → up to 120fps.
- ✅ Native WebView scrolling / momentum → up to 120fps.
- ⚠️ `requestAnimationFrame`-driven JS animation uplift is iOS-version-dependent; most of our animation is CSS, so this is a minor asterisk.
- 🔋 Slightly higher GPU usage at 120Hz — negligible for a wallet, and the standard Ionic/Capacitor recommendation.

## Verification

Well-formed plist confirmed (`plutil -lint` OK; key reads back `true`). **True FPS can only be confirmed on a physical ProMotion device** — the simulator always reports 60Hz — so the real check is a TestFlight/device build in front of the reporting user.