### PR TITLE
fix(ios): biometric-only wallets can't lock out (App Store 2.1 rejection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+* [FIX][ios] **Biometric-only wallets can no longer get permanently locked out (App Store 2.1).** A hardware-only (passwordless) vault is now unlockable with the device passcode when biometrics can't be satisfied — the Secure Enclave key gains `.userPresence` and the unlock decrypt gates on `.deviceOwnerAuthentication` (biometric OR passcode). Onboarding no longer leaves an orphaned Secure Enclave key if setup is cancelled (it's deleted on failure), and iOS "Reset Wallet" now deletes the Secure Enclave key (previously desktop-only), so a stuck wallet can actually recover. Fixes the iPad review-lab lockout where the app "constantly displayed the Touch ID required message".
+
 * [FIX][devnet] **Restored the devnet developer (wrench) badge on the icon.** The v0 UI revamp (#248) rebranded the devnet icon to the plain Bread "B" and dropped the wrench badge, so devnet builds again looked identical to production. `public/misc/logo-devnet*.png` (234/128/48/40/32/16) now re-add the Advanced Settings / Developer wrench glyph in a white circle with a thin `#7286A0` ring, overlapping the B's bottom-right, so a devnet build is distinguishable at a glance. Wiring is unchanged — `vite.extension.config.ts` already swaps `logo-white-bg*` → `logo-devnet*` for `MIDEN_NETWORK=devnet` (manifest icons, action icon, and tab favicon).
 
 ## 1.15.6 (2026-07-09)

--- a/ios/App/App/LocalBiometricPlugin.swift
+++ b/ios/App/App/LocalBiometricPlugin.swift
@@ -255,15 +255,21 @@ public class LocalBiometricPlugin: CAPPlugin, CAPBridgedPlugin {
         ]
         SecItemDelete(deleteQuery as CFDictionary)
 
-        // Create access control - only require auth when USING the private key
-        // Using only .privateKeyUsage (not .userPresence) to avoid double FaceID prompt
-        // .privateKeyUsage triggers auth when key is used for signing/ECDH
-        // .userPresence would trigger auth when key is retrieved, causing double prompt
+        // Create access control - require user presence when USING the private key.
+        // `.userPresence` = biometric OR device passcode (same threat model the hot
+        // key uses, see HotKeyPlugin). This is the App Store fix: with only
+        // `.privateKeyUsage` the unlock prompt was biometric-ONLY, so a device with
+        // no enrolled Touch ID / Face ID (e.g. an iPad running the iPhone app in the
+        // review lab) could never satisfy it and got stuck on "Biometric Unlock
+        // Required". `.userPresence` falls back to the device passcode, and — unlike
+        // `.biometryCurrentSet` — survives biometric re-enrollment. The single prompt
+        // is issued explicitly via `.deviceOwnerAuthentication` in decryptWithHardwareKey
+        // and the same LAContext is reused on the key op, so there is no double prompt.
         var accessError: Unmanaged<CFError>?
         guard let accessControl = SecAccessControlCreateWithFlags(
             kCFAllocatorDefault,
             kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-            .privateKeyUsage,
+            [.privateKeyUsage, .userPresence],
             &accessError
         ) else {
             let errorMsg = accessError?.takeRetainedValue().localizedDescription ?? "Unknown error"
@@ -452,73 +458,87 @@ public class LocalBiometricPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        // Don't pass any LAContext - let iOS handle auth automatically
-        // With only .privateKeyUsage on the key, auth should only trigger
-        // when SecKeyCopyKeyExchangeResult uses the private key
-        os_log("[LocalBiometric] Accessing hardware key...", log: logger, type: .debug)
+        // Authenticate with biometric OR device passcode (`.deviceOwnerAuthentication`)
+        // BEFORE using the Secure Enclave key, then reuse this authenticated context on
+        // the key op so there is exactly one prompt. The device-passcode fallback is the
+        // App Store fix: a device with no enrolled Touch ID / Face ID (a normal review-lab
+        // state, e.g. an iPad running the iPhone app) can still unlock via its passcode
+        // instead of dead-ending on the "Biometric Unlock Required" retry loop.
+        let authContext = LAContext()
 
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassKey,
-            kSecAttrApplicationTag as String: kHardwareKeyTag.data(using: .utf8)!,
-            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-            kSecReturnRef as String: true
-        ]
-
-        var keyRef: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &keyRef)
-
-        guard status == errSecSuccess, let privateKey = keyRef else {
-            os_log("[LocalBiometric] Failed to get private key: %{public}d", log: logger, type: .error, status)
-            if status == errSecUserCanceled {
-                call.reject("Authentication cancelled", "USER_CANCELLED")
-            } else if status == errSecAuthFailed {
-                call.reject("Authentication failed", "AUTH_FAILED")
-            } else {
-                call.reject("Failed to access hardware key: \(status)")
+        authContext.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Unlock your wallet") { success, authError in
+            if !success {
+                let authCode = (authError as NSError?)?.code ?? 0
+                os_log("[LocalBiometric] decrypt auth failed: %{public}@", log: logger, type: .error, authError?.localizedDescription ?? "unknown")
+                if authCode == LAError.userCancel.rawValue || authCode == LAError.systemCancel.rawValue || authCode == LAError.appCancel.rawValue {
+                    call.reject("Authentication cancelled", "USER_CANCELLED")
+                } else {
+                    call.reject("Authentication failed", "AUTH_FAILED")
+                }
+                return
             }
-            return
-        }
 
-        // ECDH to derive shared secret - this is where FaceID will be triggered
-        // because the key has .privateKeyUsage access control
-        os_log("[LocalBiometric] Performing ECDH (biometric prompt expected here)...", log: logger, type: .debug)
-        var dhError: Unmanaged<CFError>?
-        guard let sharedSecret = SecKeyCopyKeyExchangeResult(
-            privateKey as! SecKey,
-            .ecdhKeyExchangeStandard,
-            ephemeralPublicKey,
-            [:] as CFDictionary,
-            &dhError
-        ) as Data? else {
-            let nsError = dhError?.takeRetainedValue() as? NSError
-            let errorMsg = nsError?.localizedDescription ?? "Unknown error"
-            os_log("[LocalBiometric] ECDH failed: %{public}@", log: logger, type: .error, errorMsg)
+            os_log("[LocalBiometric] Auth OK, accessing hardware key...", log: logger, type: .debug)
 
-            // Check if user cancelled
-            if nsError?.domain == LAError.errorDomain && nsError?.code == LAError.userCancel.rawValue {
-                call.reject("Authentication cancelled", "USER_CANCELLED")
-            } else if nsError?.domain == LAError.errorDomain && nsError?.code == LAError.authenticationFailed.rawValue {
-                call.reject("Authentication failed", "AUTH_FAILED")
-            } else {
-                call.reject("Failed to perform ECDH: \(errorMsg)")
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassKey,
+                kSecAttrApplicationTag as String: kHardwareKeyTag.data(using: .utf8)!,
+                kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+                kSecReturnRef as String: true,
+                kSecUseAuthenticationContext as String: authContext
+            ]
+
+            var keyRef: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &keyRef)
+
+            guard status == errSecSuccess, let privateKey = keyRef else {
+                os_log("[LocalBiometric] Failed to get private key: %{public}d", log: logger, type: .error, status)
+                if status == errSecUserCanceled {
+                    call.reject("Authentication cancelled", "USER_CANCELLED")
+                } else if status == errSecAuthFailed {
+                    call.reject("Authentication failed", "AUTH_FAILED")
+                } else {
+                    call.reject("Failed to access hardware key: \(status)")
+                }
+                return
             }
-            return
+
+            // ECDH to derive shared secret. No second prompt — `authContext` (already
+            // authenticated above) is reused via kSecUseAuthenticationContext.
+            var dhError: Unmanaged<CFError>?
+            guard let sharedSecret = SecKeyCopyKeyExchangeResult(
+                privateKey as! SecKey,
+                .ecdhKeyExchangeStandard,
+                ephemeralPublicKey,
+                [:] as CFDictionary,
+                &dhError
+            ) as Data? else {
+                let nsError = dhError?.takeRetainedValue() as? NSError
+                let errorMsg = nsError?.localizedDescription ?? "Unknown error"
+                os_log("[LocalBiometric] ECDH failed: %{public}@", log: logger, type: .error, errorMsg)
+                if nsError?.domain == LAError.errorDomain && nsError?.code == LAError.userCancel.rawValue {
+                    call.reject("Authentication cancelled", "USER_CANCELLED")
+                } else if nsError?.domain == LAError.errorDomain && nsError?.code == LAError.authenticationFailed.rawValue {
+                    call.reject("Authentication failed", "AUTH_FAILED")
+                } else {
+                    call.reject("Failed to perform ECDH: \(errorMsg)")
+                }
+                return
+            }
+
+            os_log("[LocalBiometric] ECDH successful, decrypting...", log: logger, type: .debug)
+
+            let aesKey = self.deriveAESKey(from: sharedSecret)
+
+            guard let decrypted = self.aesGCMDecrypt(data: Data(ciphertextAndTag), key: aesKey, iv: Data(iv)),
+                  let decryptedString = String(data: decrypted, encoding: .utf8) else {
+                call.reject("Failed to decrypt data")
+                return
+            }
+
+            os_log("[LocalBiometric] decryptWithHardwareKey success", log: logger, type: .debug)
+            call.resolve(["decrypted": decryptedString])
         }
-
-        os_log("[LocalBiometric] ECDH successful, decrypting...", log: logger, type: .debug)
-
-        // Derive AES key from shared secret
-        let aesKey = self.deriveAESKey(from: sharedSecret)
-
-        // Decrypt with AES-GCM
-        guard let decrypted = self.aesGCMDecrypt(data: Data(ciphertextAndTag), key: aesKey, iv: Data(iv)),
-              let decryptedString = String(data: decrypted, encoding: .utf8) else {
-            call.reject("Failed to decrypt data")
-            return
-        }
-
-        os_log("[LocalBiometric] decryptWithHardwareKey success", log: logger, type: .debug)
-        call.resolve(["decrypted": decryptedString])
     }
 
     /// Delete the hardware-backed key

--- a/src/app/pages/Unlock.tsx
+++ b/src/app/pages/Unlock.tsx
@@ -269,7 +269,7 @@ const Unlock: FC<UnlockProps> = ({ openForgotPasswordInFullPage = false }) => {
           </div>
           <Button
             id="retry-biometric"
-            title={t('tryAgain')}
+            title={t('unlock')}
             variant={ButtonVariant.Primary}
             onClick={onRetryHardwareUnlock}
             className="w-full justify-center mb-3"

--- a/src/lib/miden/back/vault.gaps.test.ts
+++ b/src/lib/miden/back/vault.gaps.test.ts
@@ -452,7 +452,8 @@ describe('Vault hardware-backed unlock + reveal', () => {
             return encrypted.slice(4, -1);
           }
           return storedHardwareB64 ?? '';
-        })
+        }),
+        deleteHardwareKey: jest.fn(async () => {})
       }),
       { virtual: true }
     );
@@ -509,5 +510,72 @@ describe('Vault hardware-backed unlock + reveal', () => {
         { publicKey: 'pk-1', name: 'A', isPublic: true, type: WalletType.OnChain, hdIndex: 0 }
       ])
     ).rejects.toThrow(PublicError);
+  });
+
+  it(
+    'deletes the orphaned hardware key when encryptWithHardwareKey throws AFTER a fresh key was generated ' +
+      'this call (hasHardwareKey() was false)',
+    async () => {
+      (isMobile as jest.Mock).mockReturnValue(true);
+      (isDesktop as jest.Mock).mockReturnValue(false);
+      // Default mock: hasHardwareKey() resolves false, so setupHardwareProtector's
+      // mobile branch calls generateHardwareKey() and sets generatedKeyThisCall = true
+      // before the encrypt step throws below.
+      const biometric = require('lib/biometric');
+      biometric.encryptWithHardwareKey.mockRejectedValueOnce(new Error('user cancelled auth prompt'));
+
+      await expect(
+        Vault.spawnFromMidenClient('', VALID_MNEMONIC, [
+          { publicKey: 'pk-1', name: 'A', isPublic: true, type: WalletType.OnChain, hdIndex: 0 }
+        ])
+      ).rejects.toThrow(PublicError);
+
+      expect(biometric.generateHardwareKey).toHaveBeenCalled();
+      // The key WE just generated is orphaned (no vault blob was saved) — it
+      // must be cleaned up so the next attempt doesn't dead-end on a stale key.
+      expect(biometric.deleteHardwareKey).toHaveBeenCalled();
+    }
+  );
+
+  it('does NOT delete the hardware key when it already existed before this call (hasHardwareKey() was true)', async () => {
+    (isMobile as jest.Mock).mockReturnValue(true);
+    (isDesktop as jest.Mock).mockReturnValue(false);
+    const biometric = require('lib/biometric');
+    // Simulate a pre-existing key: setupHardwareProtector must NOT call
+    // generateHardwareKey(), so generatedKeyThisCall stays false.
+    biometric.hasHardwareKey.mockResolvedValueOnce(true);
+    biometric.encryptWithHardwareKey.mockRejectedValueOnce(new Error('user cancelled auth prompt'));
+
+    await expect(
+      Vault.spawnFromMidenClient('', VALID_MNEMONIC, [
+        { publicKey: 'pk-1', name: 'A', isPublic: true, type: WalletType.OnChain, hdIndex: 0 }
+      ])
+    ).rejects.toThrow(PublicError);
+
+    expect(biometric.generateHardwareKey).not.toHaveBeenCalled();
+    // Must never delete a pre-existing valid key just because this call's
+    // encrypt step failed — only a key WE generated in this call is fair game.
+    expect(biometric.deleteHardwareKey).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failing best-effort deleteHardwareKey and still reports setup failure cleanly', async () => {
+    (isMobile as jest.Mock).mockReturnValue(true);
+    (isDesktop as jest.Mock).mockReturnValue(false);
+    const biometric = require('lib/biometric');
+    // Fresh key generated this call (hasHardwareKey() default false), then the
+    // encrypt step fails, AND the cleanup delete itself fails (e.g. Keychain
+    // busy). The cleanup try/catch must swallow that secondary failure —
+    // spawnFromMidenClient still surfaces the original setup failure as a
+    // PublicError, not an unhandled rejection from the cleanup attempt.
+    biometric.encryptWithHardwareKey.mockRejectedValueOnce(new Error('user cancelled auth prompt'));
+    biometric.deleteHardwareKey.mockRejectedValueOnce(new Error('keychain busy'));
+
+    await expect(
+      Vault.spawnFromMidenClient('', VALID_MNEMONIC, [
+        { publicKey: 'pk-1', name: 'A', isPublic: true, type: WalletType.OnChain, hdIndex: 0 }
+      ])
+    ).rejects.toThrow(PublicError);
+
+    expect(biometric.deleteHardwareKey).toHaveBeenCalled();
   });
 });

--- a/src/lib/miden/back/vault.ts
+++ b/src/lib/miden/back/vault.ts
@@ -1525,6 +1525,7 @@ async function setupHardwareProtector(vaultKeyBytes: Uint8Array): Promise<boolea
   }
 
   if (isMobile()) {
+    let generatedKeyThisCall = false;
     try {
       const hs = await import('lib/biometric');
       const available = await hs.isHardwareSecurityAvailable();
@@ -1532,6 +1533,7 @@ async function setupHardwareProtector(vaultKeyBytes: Uint8Array): Promise<boolea
         const hasKey = await hs.hasHardwareKey();
         if (!hasKey) {
           await hs.generateHardwareKey();
+          generatedKeyThisCall = true;
         }
         const vaultKeyBase64 = Buffer.from(vaultKeyBytes).toString('base64');
         const hardwareProtectedVaultKey = await hs.encryptWithHardwareKey(vaultKeyBase64);
@@ -1541,6 +1543,20 @@ async function setupHardwareProtector(vaultKeyBytes: Uint8Array): Promise<boolea
         return false;
       }
     } catch (error) {
+      // Setup failed AFTER we generated the SE key — most often the user cancelled
+      // the auth prompt during encryptWithHardwareKey. The key is now persisted in
+      // the Keychain but no vault blob was saved: an orphaned, un-unlockable key
+      // that would strand the next unlock on "Hardware protector is not configured".
+      // Delete it so onboarding can be retried cleanly. Only remove a key WE created
+      // in this call — never a pre-existing valid one.
+      if (generatedKeyThisCall) {
+        try {
+          const hs = await import('lib/biometric');
+          await hs.deleteHardwareKey();
+        } catch {
+          // best-effort cleanup
+        }
+      }
       return false;
     }
   }

--- a/src/lib/miden/reset.test.ts
+++ b/src/lib/miden/reset.test.ts
@@ -48,6 +48,15 @@ jest.mock(
   { virtual: true }
 );
 
+const mockDeleteHardwareKey = jest.fn(async () => {});
+jest.mock(
+  'lib/biometric',
+  () => ({
+    deleteHardwareKey: (...args: unknown[]) => mockDeleteHardwareKey(...args)
+  }),
+  { virtual: true }
+);
+
 import { isDesktop, isExtension, isMobile } from 'lib/platform';
 
 import { clearClientStorage, clearStorage, resetStorageDestructive } from './reset';
@@ -80,6 +89,28 @@ describe('clearStorage', () => {
     _g.__resetTest.prefStub.clear.mockResolvedValueOnce(undefined);
     await clearStorage();
     expect(_g.__resetTest.prefStub.clear).toHaveBeenCalled();
+  });
+
+  it('deletes the Secure Enclave hardware key after clearing Preferences on mobile', async () => {
+    (isMobile as jest.Mock).mockReturnValue(true);
+    _g.__resetTest.prefStub.clear.mockResolvedValueOnce(undefined);
+    await clearStorage();
+    expect(mockDeleteHardwareKey).toHaveBeenCalled();
+    // Preferences.clear() must complete before the hardware key is dropped — the
+    // key lives in the Keychain, not Preferences, so ordering doesn't affect
+    // correctness here, but asserting it documents the intended sequence from
+    // the clearPlatformKeyValueStorage implementation.
+    const prefClearOrder = _g.__resetTest.prefStub.clear.mock.invocationCallOrder[0];
+    const deleteKeyOrder = mockDeleteHardwareKey.mock.invocationCallOrder[0];
+    expect(prefClearOrder).toBeLessThan(deleteKeyOrder);
+  });
+
+  it('does not throw when deleteHardwareKey rejects (best-effort cleanup)', async () => {
+    (isMobile as jest.Mock).mockReturnValue(true);
+    _g.__resetTest.prefStub.clear.mockResolvedValueOnce(undefined);
+    mockDeleteHardwareKey.mockRejectedValueOnce(new Error('no hardware key on this platform'));
+    await expect(clearStorage()).resolves.toBeUndefined();
+    expect(mockDeleteHardwareKey).toHaveBeenCalled();
   });
 
   it('clears localStorage on desktop', async () => {

--- a/src/lib/miden/reset.ts
+++ b/src/lib/miden/reset.ts
@@ -7,6 +7,18 @@ async function clearPlatformKeyValueStorage(): Promise<void> {
     // On mobile, use native Capacitor Preferences.clear()
     const { Preferences } = await import('@capacitor/preferences');
     await Preferences.clear();
+    // Also delete the Secure Enclave hardware key. It lives in the iOS Keychain,
+    // NOT in Preferences, so Preferences.clear() leaves it behind. Without this a
+    // "Reset Wallet" can't recover from an orphaned/unusable hardware key: the next
+    // onboarding sees `hasHardwareKey() === true` and reuses the stale key, so the
+    // biometric-unlock dead-end survives the only escape button. Best-effort — the
+    // key may not exist, and non-iOS mobile platforms may not implement it.
+    try {
+      const { deleteHardwareKey } = await import('lib/biometric');
+      await deleteHardwareKey();
+    } catch {
+      // no hardware key / not supported on this platform — nothing to clean up
+    }
   } else if (isDesktop()) {
     // On desktop, use localStorage
     localStorage.clear();


### PR DESCRIPTION
## Problem — App Store rejection (Guideline 2.1(a), build 1.15.6)

On an iPad Air (M3) the reviewer reported the app *"constantly displayed the Touch ID required message."* Root cause (confirmed in code): a **biometric-only ("passwordless") wallet has no non-biometric way in, and the escape hatch is broken.**

- Choosing the primary "Use Face ID or Biometric" onboarding button creates a hardware-only vault with **no app passcode** (`Welcome.tsx:193`, `vault.ts` `setupHardwareProtector`).
- The most likely trigger is an **orphaned Secure Enclave key**: onboarding persists the SE key **before** encrypting the vault blob, so a cancelled setup leaves a key with no blob → unlock throws instantly → the "Biometric Unlock Required" screen, whose "Try Again" repeats and whose **"Reset Wallet" didn't even delete the SE key** (iOS reset only cleared Preferences) → truly stuck.

## Fix (defense-in-depth, preserves the passwordless design)

- **`LocalBiometricPlugin.swift`** — the vault Secure Enclave key gains `.userPresence` (matching the hot key), and the unlock decrypt now gates on `.deviceOwnerAuthentication` (**biometric OR device passcode**), reusing one authenticated context so there's a single prompt. A passwordless wallet on a device with no enrolled biometrics can now unlock with the **device passcode**.
- **`vault.ts`** — `setupHardwareProtector` deletes the just-generated SE key if setup fails (e.g. the user cancels the auth prompt), so no orphaned key is left behind.
- **`reset.ts`** — iOS reset now deletes the Secure Enclave key (was desktop-only), so a stuck wallet can actually recover.
- **`Unlock.tsx`** — relabel the recovery button to "Unlock" (the passcode path is now real).

## Verification

- **TypeScript fully verified**: `tsc` clean; existing `reset`/`vault` suites green; new tests added (orphaned-key cleanup, reset-deletes-SE-key, best-effort tolerance); **coverage clears the 95% gate** (95.80 / 95.06 / 95.44 / 95.80).
- **Swift reviewed but NOT device-tested** — the iOS *simulator force-disables hardware security*, so the biometric-only path cannot be exercised in the sim, and I had no real device. **Before merging/resubmitting, build in Xcode and device-test:** an iPhone/iPad with **biometrics NOT enrolled** + a **device passcode set** → fresh install → onboard with "Use Face ID or Biometric" → lock → confirm unlock via **device passcode**; also cancel setup mid-onboarding + relaunch and confirm no dead-end and that "Reset Wallet" recovers.

## Notes

- PR targets `wiktor/appstore-1.15.6` (the resubmission branch). The same fix should also be ported to `main` — the bug is in core code.
