### PR TITLE
feat(ios): disable in-app swap on iOS (App Store 3.1.5(iii))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.9 (TBD)
+
+### Changes
+
+* [CHANGE][mobile] **The in-app swap is disabled on iOS.** Apple App Review classifies the In-Protocol DEX swap as a cryptocurrency exchange service under Guideline 3.1.5(iii), which requires per-storefront licensing the app does not yet hold, so the iOS build ships as a pure non-custodial wallet with no exchange surface. Swap availability is now gated by a single `isSwapEnabled()` flag (`!isIOS()`) applied to the Swap action-bar segment, the home swipe pane, and the `/swap` route (which redirects home on iOS); Android, the browser extension, and desktop are unaffected.
+
 ## 1.15.8 (2026-07-21)
 
 ### Changes

--- a/src/app/PageRouter.test.tsx
+++ b/src/app/PageRouter.test.tsx
@@ -43,6 +43,7 @@ const mockLocation: { pathname: string; trigger: string | null } = {
 };
 const mockEnv = { popup: false, fullPage: false };
 const mockMiden = { ready: false, locked: false, hydrated: false };
+const mockSwapEnabled = { value: true };
 
 // `lib/woozie` bundles the full history/location stack; keep the real Router so
 // createMap/resolve/SKIP behave exactly as in production, and stub the four
@@ -146,6 +147,11 @@ jest.mock('screens/send-flow/SendManager', () => ({
 }));
 jest.mock('screens/swap-flow/SwapManager', () => ({ SwapFlow: () => <div data-testid="swap-flow" /> }));
 
+// Swap is disabled on iOS; toggle the flag to assert `/swap` renders vs redirects.
+jest.mock('lib/feature-flags', () => ({
+  isSwapEnabled: () => mockSwapEnabled.value
+}));
+
 jest.mock('./pages/AllHistory', () => ({
   __esModule: true,
   default: ({ programId }: { programId?: string | null }) => (
@@ -204,6 +210,7 @@ beforeEach(() => {
   resolveRootViewMock.mockReset();
   resolveRootViewMock.mockImplementation(realResolveRootView);
   window.scrollTo = scrollToMock as unknown as typeof window.scrollTo;
+  mockSwapEnabled.value = true;
 });
 
 describe('app/PageRouter — pre-ready / special routes', () => {
@@ -384,9 +391,17 @@ describe('app/PageRouter — ready tab & full-screen routes', () => {
     expect(el).toHaveAttribute('data-is-loading', 'false');
   });
 
-  it('/swap renders SwapFlow inside TabLayout', () => {
+  it('/swap renders SwapFlow inside TabLayout when swap is enabled', () => {
     renderAt('/swap', ready);
     expect(screen.getByTestId('tab-layout')).toContainElement(screen.getByTestId('swap-flow'));
+  });
+
+  it('/swap redirects home when swap is disabled (iOS, App Store 3.1.5(iii))', () => {
+    mockSwapEnabled.value = false;
+    renderAt('/swap', ready);
+    expect(screen.queryByTestId('swap-flow')).toBeNull();
+    const redirect = screen.getByTestId('redirect');
+    expect(redirect).toHaveAttribute('data-to', '/');
   });
 
   it('/earn/vaults/:vaultId/deposit/review passes the vault id into EarnDepositReview', () => {

--- a/src/app/PageRouter.tsx
+++ b/src/app/PageRouter.tsx
@@ -11,6 +11,7 @@ import { Receive } from 'app/pages/Receive';
 import Settings from 'app/pages/Settings';
 import Unlock from 'app/pages/Unlock';
 import Welcome from 'app/pages/Welcome';
+import { isSwapEnabled } from 'lib/feature-flags';
 import { useMidenContext } from 'lib/miden/front';
 import * as Woozie from 'lib/woozie';
 import EarnDepositAmount from 'screens/earn-flow/EarnDepositAmount';
@@ -197,12 +198,20 @@ const ROUTE_MAP = Woozie.Router.createMap<RouteContext>([
     ))
   ],
   [
+    // Swap is disabled on iOS (App Store Guideline 3.1.5(iii) — see
+    // isSwapEnabled). The tab and swipe pane are already hidden there; this
+    // redirects any deep link / stale navigation to `/swap` back home so the
+    // exchange surface is unreachable on iOS.
     '/swap',
-    onlyReady(() => (
-      <TabLayout>
-        <SwapFlow />
-      </TabLayout>
-    ))
+    onlyReady(() =>
+      isSwapEnabled() ? (
+        <TabLayout>
+          <SwapFlow />
+        </TabLayout>
+      ) : (
+        <Woozie.Redirect to="/" />
+      )
+    )
   ],
   [
     '/earn/vaults/:vaultId/deposit/review',

--- a/src/app/layouts/HomeSwipeContainer.test.tsx
+++ b/src/app/layouts/HomeSwipeContainer.test.tsx
@@ -12,6 +12,7 @@ import HomeSwipeContainer from './HomeSwipeContainer';
 // ---------------------------------------------------------------------------
 const mockNavigate = jest.fn();
 let mockPathname = '/';
+const mockSwapEnabled = { value: true };
 
 const mockAnimateStop = jest.fn();
 const mockAnimate = jest.fn((..._args: unknown[]) => ({ stop: mockAnimateStop }));
@@ -88,6 +89,12 @@ jest.mock('screens/swap-flow/SwapManager', () => ({
   SwapFlow: () => <div data-testid="page-swap" />
 }));
 
+// Swap availability is gated by isSwapEnabled (false on iOS); toggle it to
+// assert the pane is added/removed and the track stays in sync.
+jest.mock('lib/feature-flags', () => ({
+  isSwapEnabled: () => mockSwapEnabled.value
+}));
+
 // ---------------------------------------------------------------------------
 // ResizeObserver is not implemented in jsdom. Provide a mock that captures the
 // observer callback so tests can drive width measurements deterministically.
@@ -121,6 +128,7 @@ beforeEach(() => {
   mockLastDragEnd = null;
   mockLastDragConstraints = null;
   mockRoCallback = null;
+  mockSwapEnabled.value = true;
 });
 
 // Drive the captured ResizeObserver callback to set a positive width.
@@ -155,6 +163,16 @@ describe('HomeSwipeContainer', () => {
   it('passes isLoading={false} to the SendFlow', () => {
     const { getByTestId } = render(<HomeSwipeContainer />);
     expect(getByTestId('page-send')).toHaveAttribute('data-loading', 'false');
+  });
+
+  it('drops the Swap pane when swap is disabled (iOS), keeping the other four', () => {
+    mockSwapEnabled.value = false;
+    const { getByTestId, queryByTestId } = render(<HomeSwipeContainer />);
+    expect(queryByTestId('page-swap')).toBeNull();
+    expect(getByTestId('page-explore')).toBeInTheDocument();
+    expect(getByTestId('page-send')).toBeInTheDocument();
+    expect(getByTestId('page-receive')).toBeInTheDocument();
+    expect(getByTestId('page-earn')).toBeInTheDocument();
   });
 
   it('on mount at width 0 sets the motion value directly instead of animating', () => {

--- a/src/app/layouts/HomeSwipeContainer.test.tsx
+++ b/src/app/layouts/HomeSwipeContainer.test.tsx
@@ -173,6 +173,10 @@ describe('HomeSwipeContainer', () => {
     expect(getByTestId('page-send')).toBeInTheDocument();
     expect(getByTestId('page-receive')).toBeInTheDocument();
     expect(getByTestId('page-earn')).toBeInTheDocument();
+    // Track math must derive from the 4-page filtered array — not a hardcoded 5 —
+    // so the drag bounds shrink accordingly (a phantom 5th slot would fail here).
+    measure(300);
+    expect(mockLastDragConstraints).toEqual({ left: -900, right: 0 }); // -(4 - 1) * 300
   });
 
   it('on mount at width 0 sets the motion value directly instead of animating', () => {

--- a/src/app/layouts/HomeSwipeContainer.tsx
+++ b/src/app/layouts/HomeSwipeContainer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { FC, ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { animate, motion, PanInfo, useMotionValue } from 'framer-motion';
 
@@ -6,13 +6,14 @@ import Earn from 'app/pages/Earn';
 import Explore from 'app/pages/Explore';
 import { Receive } from 'app/pages/Receive';
 import { springs } from 'lib/animation';
+import { isSwapEnabled } from 'lib/feature-flags';
 import { navigate, useLocation } from 'lib/woozie';
 import { SendFlow } from 'screens/send-flow/SendManager';
 import { SwapFlow } from 'screens/swap-flow/SwapManager';
 
 /**
- * Carousel container that mounts all five home-group pages (Overview /
- * Send / Receive / Earn / Swap) in a horizontal track and lets the user drag
+ * Carousel container that mounts the home-group pages (Overview / Send /
+ * Receive / Earn / Swap) in a horizontal track and lets the user drag
  * between them with their finger. The page tracks the finger in real
  * time and snaps to the next/previous index on release if dragged or
  * flicked past a threshold; otherwise it snaps back.
@@ -20,20 +21,18 @@ import { SwapFlow } from 'screens/swap-flow/SwapManager';
  * Pathname is the source of truth for which page is centered — the
  * SegmentedActionBar in TabLayout reads the same path and stays in sync
  * via its framer-motion layoutId pill.
+ *
+ * Swap is omitted on iOS (App Store Guideline 3.1.5(iii) — see isSwapEnabled).
+ * Track length, page widths and the index math all derive from the same
+ * filtered `pages` array, so the carousel stays consistent no matter how many
+ * pages are present.
  */
 
 interface HomePage {
   id: string;
   path: string;
+  node: ReactNode;
 }
-
-const PAGES: HomePage[] = [
-  { id: 'overview', path: '/' },
-  { id: 'send', path: '/send' },
-  { id: 'receive', path: '/receive' },
-  { id: 'earn', path: '/earn' },
-  { id: 'swap', path: '/swap' }
-];
 
 // Commit threshold: how far (as a fraction of the page width) the user
 // has to drag — accounting for fling velocity — to snap to the adjacent
@@ -50,11 +49,21 @@ const HomeSwipeContainer: FC = () => {
   const x = useMotionValue(0);
   const [width, setWidth] = useState(0);
 
+  // The Swap pane is dropped on iOS; every downstream calculation reads
+  // `pages`, so removing it can't desync the track width / index math.
+  const pages: HomePage[] = [
+    { id: 'overview', path: '/', node: <Explore /> },
+    { id: 'send', path: '/send', node: <SendFlow isLoading={false} /> },
+    { id: 'receive', path: '/receive', node: <Receive /> },
+    { id: 'earn', path: '/earn', node: <Earn /> },
+    ...(isSwapEnabled() ? [{ id: 'swap', path: '/swap', node: <SwapFlow /> }] : [])
+  ];
+
   const activeIdx = (() => {
-    const exact = PAGES.findIndex(p => p.path === pathname);
+    const exact = pages.findIndex(p => p.path === pathname);
     if (exact !== -1) return exact;
     // Match by prefix for nested routes (e.g. /send/sub-step).
-    const prefix = PAGES.findIndex(p => p.path !== '/' && pathname.startsWith(`${p.path}/`));
+    const prefix = pages.findIndex(p => p.path !== '/' && pathname.startsWith(`${p.path}/`));
     return prefix === -1 ? 0 : prefix;
   })();
 
@@ -94,14 +103,14 @@ const HomeSwipeContainer: FC = () => {
     const projected = info.offset.x + info.velocity.x * (VELOCITY_PROJECTION_MS / 1000);
 
     let newIdx = activeIdx;
-    if (projected < -width * COMMIT_THRESHOLD && activeIdx < PAGES.length - 1) {
+    if (projected < -width * COMMIT_THRESHOLD && activeIdx < pages.length - 1) {
       newIdx = activeIdx + 1;
     } else if (projected > width * COMMIT_THRESHOLD && activeIdx > 0) {
       newIdx = activeIdx - 1;
     }
 
     if (newIdx !== activeIdx) {
-      const target = PAGES[newIdx];
+      const target = pages[newIdx];
       if (target) navigate(target.path);
       // The activeIdx-driven useEffect above will animate to the new
       // resting position once the route commit causes a re-render.
@@ -112,13 +121,13 @@ const HomeSwipeContainer: FC = () => {
 
   // Drag constraints clamp the track to its valid x-range, with a small
   // elastic overshoot for that rubber-band feel at the ends.
-  const dragMaxLeft = width ? -(PAGES.length - 1) * width : 0;
+  const dragMaxLeft = width ? -(pages.length - 1) * width : 0;
 
   return (
     <div ref={containerRef} className="h-full w-full overflow-hidden touch-pan-y bg-app-bg">
       <motion.div
         className="h-full flex"
-        style={{ x, width: `${PAGES.length * 100}%` }}
+        style={{ x, width: `${pages.length * 100}%` }}
         drag="x"
         dragDirectionLock
         dragConstraints={{ left: dragMaxLeft, right: 0 }}
@@ -126,21 +135,11 @@ const HomeSwipeContainer: FC = () => {
         dragMomentum={false}
         onDragEnd={handleDragEnd}
       >
-        <div className="h-full shrink-0" style={{ width: `${100 / PAGES.length}%` }}>
-          <Explore />
-        </div>
-        <div className="h-full shrink-0" style={{ width: `${100 / PAGES.length}%` }}>
-          <SendFlow isLoading={false} />
-        </div>
-        <div className="h-full shrink-0" style={{ width: `${100 / PAGES.length}%` }}>
-          <Receive />
-        </div>
-        <div className="h-full shrink-0" style={{ width: `${100 / PAGES.length}%` }}>
-          <Earn />
-        </div>
-        <div className="h-full shrink-0" style={{ width: `${100 / PAGES.length}%` }}>
-          <SwapFlow />
-        </div>
+        {pages.map(page => (
+          <div key={page.id} className="h-full shrink-0" style={{ width: `${100 / pages.length}%` }}>
+            {page.node}
+          </div>
+        ))}
       </motion.div>
     </div>
   );

--- a/src/app/layouts/TabLayout.test.tsx
+++ b/src/app/layouts/TabLayout.test.tsx
@@ -13,7 +13,7 @@ import TabLayout from './TabLayout';
 // (Prefixed `mock*` so the jest hoister lets the factories close over them.)
 // ---------------------------------------------------------------------------
 const mockLocation = { pathname: '/' };
-const mockPlatform = { isMobile: false, isDesktop: false, isExtension: false };
+const mockPlatform = { isMobile: false, isDesktop: false, isExtension: false, isIOS: false };
 const mockEnv = { fullPage: false, sidePanel: false };
 const mockReturning = { value: false };
 const mockHasUnclaimed = { value: false };
@@ -36,7 +36,8 @@ jest.mock('lib/mobile/haptics', () => ({
 jest.mock('lib/platform', () => ({
   isMobile: () => mockPlatform.isMobile,
   isDesktop: () => mockPlatform.isDesktop,
-  isExtension: () => mockPlatform.isExtension
+  isExtension: () => mockPlatform.isExtension,
+  isIOS: () => mockPlatform.isIOS
 }));
 
 jest.mock('lib/mobile/webview-state', () => ({
@@ -140,6 +141,7 @@ beforeEach(() => {
   mockPlatform.isMobile = false;
   mockPlatform.isDesktop = false;
   mockPlatform.isExtension = false;
+  mockPlatform.isIOS = false;
   mockEnv.fullPage = false;
   mockEnv.sidePanel = false;
   mockReturning.value = false;
@@ -263,6 +265,26 @@ describe('TabLayout — tabs list composition', () => {
     mockHasUnclaimed.value = false;
     renderLayout();
     expect(screen.getByTestId('nav-activity')).toHaveAttribute('data-dot', 'false');
+  });
+});
+
+describe('TabLayout — swap action availability (isSwapEnabled)', () => {
+  it('shows the Swap action segment off-iOS', () => {
+    mockPlatform.isIOS = false;
+    mockLocation.pathname = '/';
+    renderLayout();
+    expect(screen.getByTestId('action-swap')).toBeInTheDocument();
+  });
+
+  it('hides the Swap action segment on iOS (App Store 3.1.5(iii))', () => {
+    mockPlatform.isIOS = true;
+    mockLocation.pathname = '/';
+    renderLayout();
+    expect(screen.queryByTestId('action-swap')).toBeNull();
+    // The rest of the action bar is unaffected.
+    expect(screen.getByTestId('action-overview')).toBeInTheDocument();
+    expect(screen.getByTestId('action-send')).toBeInTheDocument();
+    expect(screen.getByTestId('action-receive')).toBeInTheDocument();
   });
 });
 

--- a/src/app/layouts/TabLayout.tsx
+++ b/src/app/layouts/TabLayout.tsx
@@ -9,6 +9,7 @@ import { Icon, IconName } from 'app/icons/v2';
 import HomeSwipeContainer from 'app/layouts/HomeSwipeContainer';
 import { BottomNav, SegmentedActionBar } from 'components/ui';
 import { springs } from 'lib/animation';
+import { isSwapEnabled } from 'lib/feature-flags';
 import { hapticSelection } from 'lib/mobile/haptics';
 import { isReturningFromWebview } from 'lib/mobile/webview-state';
 import { isDesktop, isExtension, isMobile } from 'lib/platform';
@@ -120,11 +121,16 @@ const TabLayout: FC<PropsWithChildren> = ({ children }) => {
     //   label: 'Earn',
     //   icon: <Icon name={IconName.Earn} className="w-5 h-5" />
     // },
-    {
-      id: 'swap',
-      label: 'Swap',
-      icon: <Icon name={IconName.Convert} className="w-5 h-5" fill="currentColor" />
-    }
+    // Swap is hidden on iOS (App Store Guideline 3.1.5(iii) — see isSwapEnabled).
+    ...(isSwapEnabled()
+      ? [
+          {
+            id: 'swap',
+            label: 'Swap',
+            icon: <Icon name={IconName.Convert} className="w-5 h-5" fill="currentColor" />
+          }
+        ]
+      : [])
   ];
 
   const activeTab = activeTabFromPath(pathname);

--- a/src/app/pages/Browser/DappLauncher/AppsGrid.tsx
+++ b/src/app/pages/Browser/DappLauncher/AppsGrid.tsx
@@ -18,7 +18,7 @@ import React, { type FC, useState } from 'react';
 import { motion } from 'framer-motion';
 
 import { useSprings } from 'lib/animation';
-import { EXPLORE_GRID_DAPPS, type FeaturedDapp } from 'lib/dapp-browser';
+import { getExploreGridDapps, type FeaturedDapp } from 'lib/dapp-browser';
 import { hapticLight } from 'lib/mobile/haptics';
 
 interface AppsGridProps {
@@ -91,7 +91,7 @@ const AppCard: FC<AppCardProps> = ({ dapp, onOpen }) => {
 
 export const AppsGrid: FC<AppsGridProps> = ({ onOpen }) => (
   <section className="grid grid-cols-2 gap-3 px-4">
-    {EXPLORE_GRID_DAPPS.map(dapp => (
+    {getExploreGridDapps().map(dapp => (
       <AppCard key={dapp.id} dapp={dapp} onOpen={onOpen} />
     ))}
   </section>

--- a/src/lib/dapp-browser/featured-dapps.test.ts
+++ b/src/lib/dapp-browser/featured-dapps.test.ts
@@ -2,10 +2,17 @@ import {
   FEATURED_DAPPS,
   CAROUSEL_DAPPS,
   EXPLORE_GRID_DAPPS,
+  getExploreGridDapps,
   type FeaturedDapp,
   type FeaturedDappBadge,
   type FeaturedDappCategory
 } from './featured-dapps';
+
+const mockSwapEnabled = { value: true };
+
+jest.mock('lib/feature-flags', () => ({
+  isSwapEnabled: () => mockSwapEnabled.value
+}));
 
 const VALID_CATEGORIES: FeaturedDappCategory[] = ['defi', 'nft', 'tools', 'social'];
 const VALID_BADGES: FeaturedDappBadge[] = ['featured', 'new', 'verified'];
@@ -95,6 +102,16 @@ describe('FEATURED_DAPPS', () => {
     expect(FEATURED_DAPPS.some(d => d.featured === true)).toBe(true);
     expect(FEATURED_DAPPS.some(d => d.featured === undefined)).toBe(true);
   });
+
+  it('flags isExchange only on DEX/exchange entries', () => {
+    // Both the exchange and non-exchange branches exist in the data.
+    expect(FEATURED_DAPPS.some(d => d.isExchange === true)).toBe(true);
+    expect(FEATURED_DAPPS.some(d => d.isExchange === undefined)).toBe(true);
+    // Every exchange-flagged entry is a DEX genre (the surface hidden on iOS).
+    for (const d of FEATURED_DAPPS.filter(d => d.isExchange)) {
+      expect(d.genre).toBe('DEX');
+    }
+  });
 });
 
 describe('CAROUSEL_DAPPS', () => {
@@ -143,5 +160,24 @@ describe('EXPLORE_GRID_DAPPS', () => {
     const gridIds = EXPLORE_GRID_DAPPS.map(d => d.id);
     expect(gridIds.indexOf('zoro')).toBeLessThan(gridIds.indexOf('faucet'));
     expect(gridIds.indexOf('qash')).toBeLessThan(gridIds.indexOf('faucet'));
+  });
+});
+
+describe('getExploreGridDapps', () => {
+  afterEach(() => {
+    mockSwapEnabled.value = true;
+  });
+
+  it('returns the full grid unchanged when swap is enabled (off-iOS)', () => {
+    mockSwapEnabled.value = true;
+    expect(getExploreGridDapps()).toEqual(EXPLORE_GRID_DAPPS);
+  });
+
+  it('drops swap/exchange (DEX) dApps when swap is disabled (iOS, App Store 3.1.5(iii))', () => {
+    mockSwapEnabled.value = false;
+    const grid = getExploreGridDapps();
+    // 'zoro' (a DEX) is filtered out; the remaining curated apps keep their order.
+    expect(grid.some(d => d.isExchange)).toBe(false);
+    expect(grid.map(d => d.id)).toEqual(['qash', 'faucet', 'miden-name']);
   });
 });

--- a/src/lib/dapp-browser/featured-dapps.ts
+++ b/src/lib/dapp-browser/featured-dapps.ts
@@ -19,6 +19,7 @@ import midenIcon from 'app/misc/dapp-icons/miden.png';
 import playgroundIcon from 'app/misc/dapp-icons/playground.png';
 import qashIcon from 'app/misc/dapp-icons/qash.png';
 import zoroIcon from 'app/misc/dapp-icons/zoro.png';
+import { isSwapEnabled } from 'lib/feature-flags';
 
 export type FeaturedDappCategory = 'defi' | 'nft' | 'tools' | 'social';
 export type FeaturedDappBadge = 'featured' | 'new' | 'verified';
@@ -42,6 +43,13 @@ export interface FeaturedDapp {
   badge?: FeaturedDappBadge;
   /** Marks dApps that should appear in the hero carousel (vs. just the grid). */
   featured?: boolean;
+  /**
+   * Marks a swap/exchange (DEX) surface. These are hidden from the curated
+   * launcher on iOS, where the app ships without an exchange surface (Apple
+   * treats in-app crypto exchange as requiring licensing under Guideline
+   * 3.1.5(iii)). See `getExploreGridDapps` / `isSwapEnabled`.
+   */
+  isExchange?: boolean;
 }
 
 export const FEATURED_DAPPS: FeaturedDapp[] = [
@@ -66,7 +74,8 @@ export const FEATURED_DAPPS: FeaturedDapp[] = [
     brandColor: '#1D4ED8',
     category: 'defi',
     badge: 'featured',
-    featured: true
+    featured: true,
+    isExchange: true
   },
   {
     id: 'faucet',
@@ -89,7 +98,8 @@ export const FEATURED_DAPPS: FeaturedDapp[] = [
     brandColor: '#FACC15',
     category: 'defi',
     badge: 'new',
-    featured: true
+    featured: true,
+    isExchange: true
   },
   {
     id: 'qash',
@@ -130,3 +140,15 @@ export const CAROUSEL_DAPPS = FEATURED_DAPPS.filter(d => d.featured);
 export const EXPLORE_GRID_DAPPS: FeaturedDapp[] = ['zoro', 'qash', 'faucet', 'miden-name'].flatMap(id =>
   FEATURED_DAPPS.filter(d => d.id === id)
 );
+
+/**
+ * The Explore grid for the current platform. On iOS, where the app ships
+ * without a swap surface (App Store Guideline 3.1.5(iii)), swap/exchange (DEX)
+ * dApps are filtered out so the launcher does not first-party-promote an
+ * exchange the build otherwise omits. Off-iOS it returns EXPLORE_GRID_DAPPS
+ * unchanged. Call at render time (not module scope) so the platform check runs
+ * after Capacitor is initialized.
+ */
+export function getExploreGridDapps(): FeaturedDapp[] {
+  return isSwapEnabled() ? EXPLORE_GRID_DAPPS : EXPLORE_GRID_DAPPS.filter(d => !d.isExchange);
+}

--- a/src/lib/dapp-browser/index.test.ts
+++ b/src/lib/dapp-browser/index.test.ts
@@ -105,6 +105,7 @@ describe('dapp-browser barrel — re-export identity', () => {
     ['FEATURED_DAPPS', featuredDapps, 'FEATURED_DAPPS'],
     ['CAROUSEL_DAPPS', featuredDapps, 'CAROUSEL_DAPPS'],
     ['EXPLORE_GRID_DAPPS', featuredDapps, 'EXPLORE_GRID_DAPPS'],
+    ['getExploreGridDapps', featuredDapps, 'getExploreGridDapps'],
     // category-data
     ['CATEGORIES', categoryData, 'CATEGORIES'],
     // recent-dapps
@@ -155,6 +156,7 @@ describe('dapp-browser barrel — live wiring smoke checks', () => {
       'rectFromDOMRect',
       'rectsEqual',
       'useDappConfirmation',
+      'getExploreGridDapps',
       'getRecentDapps',
       'recordRecentDapp',
       'forgetRecentDapp',

--- a/src/lib/dapp-browser/index.ts
+++ b/src/lib/dapp-browser/index.ts
@@ -16,6 +16,7 @@ export {
   FEATURED_DAPPS,
   CAROUSEL_DAPPS,
   EXPLORE_GRID_DAPPS,
+  getExploreGridDapps,
   type FeaturedDapp,
   type FeaturedDappBadge,
   type FeaturedDappCategory

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,0 +1,23 @@
+import { isSwapEnabled } from './feature-flags';
+
+const mockPlatform = { isIOS: false };
+
+jest.mock('lib/platform', () => ({
+  isIOS: () => mockPlatform.isIOS
+}));
+
+describe('feature-flags — isSwapEnabled', () => {
+  afterEach(() => {
+    mockPlatform.isIOS = false;
+  });
+
+  it('enables swap off-iOS (Android / extension / desktop)', () => {
+    mockPlatform.isIOS = false;
+    expect(isSwapEnabled()).toBe(true);
+  });
+
+  it('disables swap on iOS (App Store Guideline 3.1.5(iii))', () => {
+    mockPlatform.isIOS = true;
+    expect(isSwapEnabled()).toBe(false);
+  });
+});

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,20 @@
+import { isIOS } from 'lib/platform';
+
+/**
+ * In-app swap (the In-Protocol DEX / PSWAP flow) is disabled on iOS.
+ *
+ * Apple App Review treats an in-app crypto swap as a "cryptocurrency exchange
+ * service" under App Store Review Guideline 3.1.5(iii), which requires
+ * per-storefront licensing the app does not currently hold. Until that
+ * compliance work is done, the iOS build ships as a pure non-custodial wallet
+ * with no exchange surface. Every other platform (Android, browser extension,
+ * desktop) keeps swap.
+ *
+ * This is the single source of truth for swap availability — the swap tab, the
+ * home swipe pane, and the `/swap` route all read it. To re-enable swap on iOS
+ * (e.g. once it is cleared for distribution, or behind a region/remote flag),
+ * change only this function.
+ */
+export function isSwapEnabled(): boolean {
+  return !isIOS();
+}


### PR DESCRIPTION
## Why

Apple App Review classifies the in-app swap (In-Protocol DEX / PSWAP) as a **cryptocurrency exchange service** under Guideline 3.1.5(iii), which requires per-storefront licensing the app does not yet hold. This gates the swap surface off on **iOS only** so the app can be resubmitted as a pure non-custodial wallet. **Android, browser extension, and desktop keep swap unchanged.**

## What

Single source of truth — `isSwapEnabled()` (= `!isIOS()`) in `src/lib/feature-flags.ts` — applied at all three swap entry points:

- **Swap segment** in the home action bar (`TabLayout`)
- **Swap pane** in the home swipe carousel (`HomeSwipeContainer`) — refactored to a filtered `pages` array so track length / page width / index math derive from one source and can't desync
- **`/swap` route** (`PageRouter`) — redirects home on iOS so a deep link or stale navigation can't reach the exchange surface

History-display helpers (`getSwapTokenByFaucetId`) and E2E-only swap test hooks are untouched — neither exposes a swap surface. To re-enable swap on iOS later, flip the one function.

## Tests

- `feature-flags.test.ts` — both branches of `isSwapEnabled`
- iOS-off cases added to `TabLayout`, `HomeSwipeContainer`, and `PageRouter` tests proving the tab, pane, and route each disappear / redirect on iOS
- Full suite: 6161 passing, coverage ≥95% on all metrics; `tsc` and `eslint` clean