### PR TITLE
test: fix two flaky CI tests (vault.gaps timeout + RecallCalendarDrawer clock race)

### DIFF
--- a/src/lib/miden/back/vault.gaps.test.ts
+++ b/src/lib/miden/back/vault.gaps.test.ts
@@ -17,6 +17,14 @@ import { PublicError } from './defaults';
 import { encryptAndSaveMany, savePlain } from './safe-storage';
 import { Vault } from './vault';
 
+// Nearly every test here seeds a real vault, which runs the production PBKDF2
+// key derivation (~10.3M SHA-256 iterations). Each test passes comfortably in
+// isolation, but under full-suite CPU contention on CI the derivation can push
+// a single test past Jest's 5s default, intermittently failing the coverage
+// job. Raise the per-test ceiling for this crypto-heavy file so a slow-but-
+// healthy run doesn't flake; a genuine hang would still blow past this.
+jest.setTimeout(30_000);
+
 const memoryStore: Record<string, any> = {};
 jest.mock('lib/platform/storage-adapter', () => ({
   getStorageProvider: jest.fn(() => ({

--- a/src/screens/send-flow/RecallCalendarDrawer.test.tsx
+++ b/src/screens/send-flow/RecallCalendarDrawer.test.tsx
@@ -149,6 +149,21 @@ describe('SECONDS_PER_BLOCK', () => {
 });
 
 describe('dateTimeToRecallBlocks', () => {
+  // Freeze the clock. Each test builds its target from `Date.now()`, while
+  // dateTimeToRecallBlocks reads the current time via `new Date()` internally;
+  // if any time elapses between those two reads, a boundary-aligned target
+  // (e.g. exactly 30s = 10 blocks) slips just under the boundary and
+  // `Math.floor` drops the count by one (1009 instead of 1010). That's rare
+  // locally but reliably flakes under CI load. Fake timers pin BOTH `Date.now()`
+  // and `new Date()` to the same instant so the two reads always agree.
+  const FROZEN_NOW = new Date('2030-01-01T00:00:00Z').getTime();
+  beforeEach(() => {
+    jest.useFakeTimers({ now: FROZEN_NOW });
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('returns the current block for a past/now target (<= 0 seconds until target)', () => {
     const past = new Date(Date.now() - 60_000);
     expect(dateTimeToRecallBlocks(past, 500)).toBe(500);


### PR DESCRIPTION
## Problem

`src/lib/miden/back/vault.gaps.test.ts` intermittently fails the **Coverage Check** job with `Exceeded timeout of 5000 ms for a test` — on branches that don't touch vault code at all (most recently #355). It's a long-standing flake: the suite passes 18/18 in isolation but times out under full-suite CPU contention on CI.

## Root cause

Nearly every test seeds a real vault, which runs the **production PBKDF2 key derivation (~10.3M SHA-256 iterations)** — deliberately real, so the `revealPrivateKey` / hardware-unlock tests exercise the actual decrypt paths (mocking the crypto would defeat them). In isolation each test is well under 5s; under heavy CI contention a single derivation can cross Jest's 5s default.

## Fix

File-level `jest.setTimeout(30_000)` for this crypto-heavy suite. A slow-but-healthy run no longer flakes; a genuine hang still blows past 30s. **Test-only, coverage-neutral** (same tests run; no source change).

Marked `no changelog` (trivial test-infra change).