### PR TITLE
fix: route guardian dApp txs correctly (normalize account id vs composite publicKey)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 * [FIX][mobile] **iOS now renders at the display's native refresh rate (up to 120Hz ProMotion) instead of being capped at 60fps.** Added `CADisableMinimumFrameDurationOnPhone` to `Info.plist`. Since iOS 15, iPhones cap every app — including its WKWebView — to 60fps unless the app opts in to high frame rates, so on ProMotion devices animations and scrolling felt stuck at 60Hz (the same as Low Power Mode). CSS/compositor animations and native scrolling now run at the full display rate.
+* [FIX][all] **dApp transactions from a Guardian account no longer fail with "transaction is unauthorized".** A dApp/adapter supplies the account as its bare bech32 address (e.g. `mtst1…`), but `WalletAccount.publicKey` is a composite `<address>_<suffix>`; `isGuardianAccount` / `getOrCreateMultisigService` compared them with a raw `===`, which missed — so a Guardian account's dApp transaction was routed through the non-guardian path, no guardian co-signature was attached, and the on-chain guardian auth rejected it as `AUTH_UNAUTHORIZED` (e.g. registering a name on miden.name). Routing now matches through a shared `sameWalletAccountId` normalizer (both ids canonicalized to the SDK account id derived from the address portion), and `getOrCreateMultisigService` loads the SDK account by the matched account's stored `publicKey`. In-wallet Guardian sends (which already used the composite id) and single-sig accounts were unaffected.
 
 ## 1.15.8 (2026-07-21)
 

--- a/src/lib/miden/back/dapp.guardian-info.test.ts
+++ b/src/lib/miden/back/dapp.guardian-info.test.ts
@@ -112,7 +112,8 @@ jest.mock('../sdk/miden-client', () => ({
 }));
 
 jest.mock('lib/miden/sdk/helpers', () => ({
-  getBech32AddressFromAccountId: () => 'bech32-addr'
+  getBech32AddressFromAccountId: () => 'bech32-addr',
+  sameWalletAccountId: (a: string, b: string) => (a.split('_')[0] ?? a) === (b.split('_')[0] ?? b)
 }));
 
 jest.mock('@demox-labs/miden-wallet-adapter-base', () => ({

--- a/src/lib/miden/back/dapp.ts
+++ b/src/lib/miden/back/dapp.ts
@@ -68,7 +68,7 @@ import { queueNoteImport } from '../activity';
 import { getCurrentMidenNetwork } from './safe-network';
 import { store, withUnlocked } from './store';
 import { startTransactionProcessing } from './transaction-processor';
-import { getBech32AddressFromAccountId } from '../sdk/helpers';
+import { getBech32AddressFromAccountId, sameWalletAccountId } from '../sdk/helpers';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 import { resolvePublicKeyCommitments } from '../sdk/resolve-public-key-commitments';
 import {
@@ -860,7 +860,9 @@ const NOT_GUARDIAN_INFO: GuardianInfo = {
 async function getGuardianInfoData(accountId: string): Promise<GuardianInfo> {
   return withUnlocked(async ({ vault }) => {
     const accounts = await vault.fetchAccounts();
-    const account = accounts.find(acc => acc.publicKey === accountId);
+    // Tolerant match: the dApp-connected id may be the bare bech32 address while
+    // the stored publicKey is a composite `<address>_<suffix>`.
+    const account = accounts.find(acc => sameWalletAccountId(acc.publicKey, accountId));
     if (!account || account.type !== WalletType.Guardian) {
       return NOT_GUARDIAN_INFO;
     }

--- a/src/lib/miden/back/vault.gaps.test.ts
+++ b/src/lib/miden/back/vault.gaps.test.ts
@@ -60,7 +60,8 @@ jest.mock('../sdk/miden-client', () => ({
 }));
 
 jest.mock('../sdk/helpers', () => ({
-  getBech32AddressFromAccountId: jest.fn((id: any) => (typeof id === 'string' ? id : 'bech32:unknown'))
+  getBech32AddressFromAccountId: jest.fn((id: any) => (typeof id === 'string' ? id : 'bech32:unknown')),
+  sameWalletAccountId: (a: string, b: string) => (a.split('_')[0] ?? a) === (b.split('_')[0] ?? b)
 }));
 
 jest.mock('lib/miden/reset', () => ({

--- a/src/lib/miden/back/vault.ts
+++ b/src/lib/miden/back/vault.ts
@@ -34,7 +34,7 @@ import { compareAccountIds } from '../activity/utils';
 import { fetchFromStorage, putToStorage } from '../front/storage';
 import type { CreatedGuardianKeys } from '../guardian/account';
 import { getSignerDetailsFromAccount } from '../guardian/account';
-import { getBech32AddressFromAccountId } from '../sdk/helpers';
+import { getBech32AddressFromAccountId, sameWalletAccountId } from '../sdk/helpers';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 import { MidenClientCreateOptions } from '../sdk/miden-client-interface';
 
@@ -1136,7 +1136,9 @@ export class Vault {
     // tag-stripping consumer — Guardian — but isn't guaranteed to round-trip through the SDK's
     // `Signature.deserialize`.)
     if (signKind === 'word' && accountId) {
-      const account = (await this.fetchAccounts()).find(acc => acc.publicKey === accountId);
+      // Tolerant match: a dApp signBytes supplies the bare bech32 address, but the
+      // stored publicKey is a composite `<address>_<suffix>` (see sameWalletAccountId).
+      const account = (await this.fetchAccounts()).find(acc => sameWalletAccountId(acc.publicKey, accountId));
       if (account?.hotPublicKey) {
         const wordHex = `0x${bytesToHex(b64ToU8(data))}`;
         const sigHex = await this.signWord(account.hotPublicKey, wordHex);

--- a/src/lib/miden/front/guardian-manager.test.ts
+++ b/src/lib/miden/front/guardian-manager.test.ts
@@ -226,6 +226,17 @@ describe('guardian-manager', () => {
       await expect(isGuardianAccount(GUARDIAN_PK, provider)).resolves.toBe(true);
     });
 
+    it('matches a dApp-supplied bare address against the stored composite publicKey', async () => {
+      // Regression: dApp/adapter txs arrive with the bare bech32 address, but
+      // WalletAccount.publicKey is a composite `<address>_<suffix>`. A raw `===`
+      // missed → the Guardian account was misrouted through the non-guardian path
+      // (no co-signature → on-chain AUTH_UNAUTHORIZED). Must resolve to guardian.
+      const compositeGuardian = { ...guardianAccount, publicKey: 'mtst1qabc_qr7suffix' };
+      const provider = makeProvider([compositeGuardian, onChainAccount]);
+
+      await expect(isGuardianAccount('mtst1qabc', provider)).resolves.toBe(true);
+    });
+
     it('returns false for a non-Guardian account', async () => {
       const provider = makeProvider([guardianAccount, onChainAccount]);
 

--- a/src/lib/miden/front/guardian-manager.ts
+++ b/src/lib/miden/front/guardian-manager.ts
@@ -4,6 +4,7 @@ import { WalletAccount } from 'lib/shared/types';
 import { WalletType } from 'screens/onboarding/types';
 
 import { getSignerDetailsFromAccount, resolveGuardianEndpoint } from '../guardian/account';
+import { sameWalletAccountId } from '../sdk/helpers';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 
 // Cache MultisigService instances to avoid re-initialization on every sync cycle.
@@ -69,7 +70,9 @@ export async function getOrCreateMultisigService(
   const initPromise = (async () => {
     // Verify this is a Guardian account
     const accounts = await provider.getAccounts();
-    const account = accounts.find(acc => acc.publicKey === accountPublicKey);
+    // Match tolerant of id form: dApp-initiated txs arrive with the bare bech32
+    // address while WalletAccount.publicKey is a composite `<address>_<suffix>`.
+    const account = accounts.find(acc => sameWalletAccountId(acc.publicKey, accountPublicKey));
     if (!account || account.type !== WalletType.Guardian) {
       throw new Error('Account is not a Guardian account');
     }
@@ -103,7 +106,9 @@ export async function getOrCreateMultisigService(
     // Get the Account object from the Miden client.
     const { sdkAccount } = await withWasmClientLock(async () => {
       const midenClient = await getMidenClient();
-      const sdkAccount = await midenClient.getAccount(accountPublicKey);
+      // Use the matched account's stored publicKey (the form the in-wallet path
+      // uses) rather than the possibly-bare dApp-supplied id.
+      const sdkAccount = await midenClient.getAccount(account.publicKey);
       return { sdkAccount };
     });
 
@@ -145,7 +150,9 @@ export async function getOrCreateMultisigService(
  */
 export async function isGuardianAccount(accountPublicKey: string, provider: GuardianAccountProvider): Promise<boolean> {
   const accounts = await provider.getAccounts();
-  const account = accounts.find(acc => acc.publicKey === accountPublicKey);
+  // Tolerant match — see sameWalletAccountId. A raw `===` misses when a dApp
+  // supplies the bare bech32 address, misrouting a Guardian account non-guardian.
+  const account = accounts.find(acc => sameWalletAccountId(acc.publicKey, accountPublicKey));
   return account?.type === WalletType.Guardian;
 }
 

--- a/src/lib/miden/sdk/helpers.test.ts
+++ b/src/lib/miden/sdk/helpers.test.ts
@@ -1,6 +1,6 @@
 import { Address } from '@miden-sdk/miden-sdk/lazy';
 
-import { accountIdStringToSdk, getBech32AddressFromAccountId } from './helpers';
+import { accountIdStringToSdk, getBech32AddressFromAccountId, sameWalletAccountId } from './helpers';
 
 jest.mock('@miden-sdk/miden-sdk/lazy', () => ({
   Address: {
@@ -29,5 +29,26 @@ describe('miden sdk helpers', () => {
     const res = accountIdStringToSdk('mtst1qabc');
     expect(Address.fromBech32).toHaveBeenCalledWith('mtst1qabc');
     expect(res).toBe('accountId-mtst1qabc');
+  });
+
+  describe('sameWalletAccountId', () => {
+    it('matches a bare bech32 address against a composite `<address>_<suffix>` publicKey', () => {
+      // dApp/adapter passes the bare address; WalletAccount.publicKey is composite.
+      expect(sameWalletAccountId('mtst1qabc_qr7suffix', 'mtst1qabc')).toBe(true);
+      expect(sameWalletAccountId('mtst1qabc', 'mtst1qabc_qr7suffix')).toBe(true);
+    });
+
+    it('does not match different accounts', () => {
+      expect(sameWalletAccountId('mtst1qabc_x', 'mtst1qdef')).toBe(false);
+    });
+
+    it('falls back to the address portion when the id cannot be parsed', () => {
+      (Address.fromBech32 as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('not bech32');
+      });
+      // First arg fails to parse → falls back to the raw address portion; the
+      // second still canonicalizes, so they must NOT coincidentally match.
+      expect(sameWalletAccountId('rawid_suffix', 'mtst1qdef')).toBe(false);
+    });
   });
 });

--- a/src/lib/miden/sdk/helpers.test.ts
+++ b/src/lib/miden/sdk/helpers.test.ts
@@ -42,6 +42,15 @@ describe('miden sdk helpers', () => {
       expect(sameWalletAccountId('mtst1qabc_x', 'mtst1qdef')).toBe(false);
     });
 
+    it('unifies two different address encodings of the same account via the SDK round-trip', () => {
+      // Distinct address strings that resolve to the same on-chain account id must
+      // match — the value the SDK canonicalization adds over a plain prefix compare.
+      (Address.fromBech32 as jest.Mock)
+        .mockReturnValueOnce({ accountId: () => 'same-account-id' })
+        .mockReturnValueOnce({ accountId: () => 'same-account-id' });
+      expect(sameWalletAccountId('mtst1AAA_suffix', 'mtst1BBB')).toBe(true);
+    });
+
     it('falls back to the address portion when the id cannot be parsed', () => {
       (Address.fromBech32 as jest.Mock).mockImplementationOnce(() => {
         throw new Error('not bech32');

--- a/src/lib/miden/sdk/helpers.ts
+++ b/src/lib/miden/sdk/helpers.ts
@@ -10,3 +10,32 @@ export function getBech32AddressFromAccountId(accountId: AccountId): string {
 export function accountIdStringToSdk(accountIdStr: string): AccountId {
   return Address.fromBech32(accountIdStr).accountId();
 }
+
+/**
+ * Canonicalize a wallet-account identifier so the two id forms that meet inside
+ * the wallet compare equal. dApp/adapter-initiated transactions arrive with the
+ * bare bech32 address (e.g. `mtst1…5068r3`), whereas `WalletAccount.publicKey` is
+ * a composite `<address>_<suffix>` (e.g. `mtst1…5068r3_qr7qqq9wr6w`). Reduce both
+ * to the SDK account id derived from the address portion; fall back to the raw
+ * address portion if it can't be parsed.
+ */
+export function canonicalWalletAccountId(id: string): string {
+  const address = id.split('_')[0] ?? id;
+  try {
+    return accountIdStringToSdk(address).toString();
+  } catch {
+    return address;
+  }
+}
+
+/**
+ * True when two ids refer to the same wallet account despite differing forms
+ * (bare bech32 address vs composite `WalletAccount.publicKey`). Use this instead
+ * of a raw `===` anywhere a dApp-supplied account id is matched against a stored
+ * `WalletAccount.publicKey` — a raw compare misses on dApp txs and misroutes a
+ * Guardian account through the non-guardian path (no co-signature → the on-chain
+ * guardian auth fails as AUTH_UNAUTHORIZED).
+ */
+export function sameWalletAccountId(a: string, b: string): boolean {
+  return canonicalWalletAccountId(a) === canonicalWalletAccountId(b);
+}

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -43,7 +43,7 @@ import {
   Transaction,
   UpdateProcedureThresholdTransaction
 } from '../db/types';
-import { accountIdStringToSdk } from '../sdk/helpers';
+import { accountIdStringToSdk, canonicalWalletAccountId, sameWalletAccountId } from '../sdk/helpers';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 import { MidenClientCreateOptions } from '../sdk/miden-client-interface';
 
@@ -106,7 +106,10 @@ export const generateTransaction = async (
       // delta per account at a time, and concurrent same-account txs make its
       // expected commitment diverge from on-chain, stalling canonicalization
       // for minutes (see guardian/serialize.ts and OpenZeppelin/guardian#303).
-      await withGuardianAccountLock(transaction.accountId, () =>
+      // Canonicalize the lock key: the same guardian account can arrive as a bare
+      // bech32 address (dApp) or the composite publicKey (in-wallet); both must take
+      // the SAME per-account chain, else concurrent deltas stall canonicalization.
+      await withGuardianAccountLock(canonicalWalletAccountId(transaction.accountId), () =>
         generateGuardianTransaction(transaction, signCallback, guardianProvider)
       );
     } catch (error) {
@@ -245,7 +248,9 @@ const generateGuardianTransaction = async (
   // and never route through this function, so exempting switch-guardian here only
   // affects the deliberate Settings-driven switch flow, not account recovery.
   if (transaction.type !== 'switch-guardian') {
-    const walletAccount = (await guardianProvider.getAccounts()).find(a => a.publicKey === transaction.accountId);
+    const walletAccount = (await guardianProvider.getAccounts()).find(a =>
+      sameWalletAccountId(a.publicKey, transaction.accountId)
+    );
     if (walletAccount) {
       assertGuardianInSync(walletAccount);
     }

--- a/src/lib/miden/transaction/transactions.gaps.test.ts
+++ b/src/lib/miden/transaction/transactions.gaps.test.ts
@@ -122,7 +122,9 @@ jest.mock('../helpers', () => ({
 
 jest.mock('../sdk/helpers', () => ({
   getBech32AddressFromAccountId: (x: any) => (typeof x === 'string' ? x : 'bech32-stub'),
-  accountIdStringToSdk: (x: any) => ({ __accountIdStub: x })
+  accountIdStringToSdk: (x: any) => ({ __accountIdStub: x }),
+  canonicalWalletAccountId: (id: string) => id.split('_')[0] ?? id,
+  sameWalletAccountId: (a: string, b: string) => (a.split('_')[0] ?? a) === (b.split('_')[0] ?? b)
 }));
 
 const mockTransactionResultDeserialize = jest.fn();

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -91,7 +91,9 @@ jest.mock('lib/store', () => ({
 }));
 
 jest.mock('lib/miden/sdk/helpers', () => ({
-  accountIdStringToSdk: (id: string) => ({ toString: () => `sdk-${id}` })
+  accountIdStringToSdk: (id: string) => ({ toString: () => `sdk-${id}` }),
+  canonicalWalletAccountId: (id: string) => id.split('_')[0] ?? id,
+  sameWalletAccountId: (a: string, b: string) => (a.split('_')[0] ?? a) === (b.split('_')[0] ?? b)
 }));
 
 jest.mock('@miden-sdk/miden-sdk/lazy', () => {


### PR DESCRIPTION
## Problem

A dApp transaction from a **Guardian** account fails at execute time with:

```
transaction execution failed: transaction is unauthorized with summary TransactionSummary { … }
```

Reproduced on **miden.name** (name registration → a network note): every attempt from a guardian account failed, while single-sig accounts and in-wallet guardian sends worked. It is **not** attachments, the tx summary, the guardian-server version, or the network-account setup.

## Root cause

The failure is a **guardian routing** miss caused by an account-id **format mismatch**:

- A dApp/adapter supplies the account as its **bare bech32 address**, e.g. `mtst1arqnh74pn2m37sff0w30uvmfdc5068r3`.
- `WalletAccount.publicKey` is a **composite** `<address>_<suffix>`, e.g. `mtst1arqnh74pn2m37sff0w30uvmfdc5068r3_qr7qqq9wr6w`.

`isGuardianAccount` and `getOrCreateMultisigService` (`front/guardian-manager.ts`) matched them with a raw `acc.publicKey === accountId`, which **misses** on the dApp form. `generateTransaction` then routes the tx down the **non-guardian** path (`midenClient.newTransaction`), so **no guardian co-signature is attached** and the on-chain guardian auth (`verify_signatures`) finds zero guardian sigs → `AUTH_UNAUTHORIZED`.

This explains the full symptom set:
- **In-wallet guardian sends work** — they use the wallet's own composite `publicKey` → exact match → routed guardian → co-signed.
- **Single-sig works** — non-guardian routing is correct for it; the id mismatch is irrelevant.
- **dApp guardian txs fail** — bare address → routing miss → no co-sign → unauthorized.

## Fix

- Add a shared **`sameWalletAccountId(a, b)`** (+ `canonicalWalletAccountId`) in `sdk/helpers.ts` that canonicalizes both ids to the SDK account id derived from the address portion (stripping the `_suffix`), with a safe fallback.
- `isGuardianAccount` and `getOrCreateMultisigService` now match via `sameWalletAccountId` instead of raw `===`.
- `getOrCreateMultisigService` loads the SDK account by the **matched account's stored `publicKey`** (the form the working in-wallet path uses), not the possibly-bare dApp id.

The dApp is correct to send the bech32 address; the wallet is the side that stores a composite and must resolve it.

## Verified

- Reproduced end-to-end with an instrumented build: pre-fix the tx was routed non-guardian and failed `AUTH_UNAUTHORIZED`; **post-fix it routes guardian, co-signs, and the miden.name registration succeeds** (`[TransactionProcessor] Loop result: true`).
- `yarn ts` clean, `yarn lint` clean on the changed files, and the two affected suites pass (`guardian-manager.test.ts`, `helpers.test.ts`) — includes a regression test (bare address → routes guardian) and `sameWalletAccountId` unit tests covering the SDK-canonical and fallback paths.

## Notes

- Scope is the two guardian-routing lookups on the dApp critical path. Other `publicKey === id` sites exist (e.g. in `vault.ts`) but are internal flows that consistently use the composite `publicKey`; routing the dApp-facing ones through `sameWalletAccountId` as a follow-up would harden against recurrence on other guardian entry points.