### PR TITLE
chore(release): fold 1.15.9 (TBD) changelog into 1.15.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,10 @@
 # Changelog
 
-## 1.15.9 (TBD)
+## 1.15.8 (2026-07-21)
 
 ### Features
 
 * [FEATURE][all] **Guardian accounts now auto-detect and reconcile out-of-band guardian switches; dApps can read guardian info via `requestGuardianInfo()`.**
-### Changes
-
-* [CHANGE][mobile] **The in-app swap is disabled on iOS.** Apple App Review classifies the In-Protocol DEX swap as a cryptocurrency exchange service under Guideline 3.1.5(iii), which requires per-storefront licensing the app does not yet hold, so the iOS build ships as a pure non-custodial wallet with no exchange surface. Swap availability is now gated by a single `isSwapEnabled()` flag (`!isIOS()`) applied to the Swap action-bar segment, the home swipe pane, and the `/swap` route (which redirects home on iOS); Android, the browser extension, and desktop are unaffected.
-
-### Fixes
-
-* [FIX][mobile] **iOS now renders at the display's native refresh rate (up to 120Hz ProMotion) instead of being capped at 60fps.** Added `CADisableMinimumFrameDurationOnPhone` to `Info.plist`. Since iOS 15, iPhones cap every app — including its WKWebView — to 60fps unless the app opts in to high frame rates, so on ProMotion devices animations and scrolling felt stuck at 60Hz (the same as Low Power Mode). CSS/compositor animations and native scrolling now run at the full display rate.
-* [FIX][all] **dApp transactions from a Guardian account no longer fail with "transaction is unauthorized".** A dApp/adapter supplies the account as its bare bech32 address (e.g. `mtst1…`), but `WalletAccount.publicKey` is a composite `<address>_<suffix>`; `isGuardianAccount` / `getOrCreateMultisigService` compared them with a raw `===`, which missed — so a Guardian account's dApp transaction was routed through the non-guardian path, no guardian co-signature was attached, and the on-chain guardian auth rejected it as `AUTH_UNAUTHORIZED` (e.g. registering a name on miden.name). Routing now matches through a shared `sameWalletAccountId` normalizer (both ids canonicalized to the SDK account id derived from the address portion), and `getOrCreateMultisigService` loads the SDK account by the matched account's stored `publicKey`. In-wallet Guardian sends (which already used the composite id) and single-sig accounts were unaffected.
-
-## 1.15.8 (2026-07-21)
 
 ### Changes
 
@@ -30,11 +20,18 @@
 
 * [CHANGE][extension] **Refreshed the network icons.** The default/testnet build's orange bread "B" is regenerated from a new transparent-background master (dropping the old opaque white card and padding so the B fills the frame), and the devnet icon is redesigned from the orange "B" with a blue corner wrench to a sage-green "B" with a centered developer wrench, so devnet is easy to tell apart from the default build at a glance. All sizes (16/32/40/48/128/234) were regenerated for both `logo-white-bg*` (default) and `logo-devnet*` (devnet) from 1536px masters with gamma-correct (linear-light) downscaling. Affects the Chrome extension (manifest icons + toolbar `action.default_icon`, notifications, and the full-page view) and the Tauri desktop window favicon; mobile is unaffected — it uses separate native app icons (`AppIcon`/`ic_launcher`) and `misc/brand/*` splash assets. Icon-swap wiring in `vite.extension.config.ts` is unchanged.
 
+* [CHANGE][mobile] **The in-app swap is disabled on iOS.** Apple App Review classifies the In-Protocol DEX swap as a cryptocurrency exchange service under Guideline 3.1.5(iii), which requires per-storefront licensing the app does not yet hold, so the iOS build ships as a pure non-custodial wallet with no exchange surface. Swap availability is now gated by a single `isSwapEnabled()` flag (`!isIOS()`) applied to the Swap action-bar segment, the home swipe pane, and the `/swap` route (which redirects home on iOS); Android, the browser extension, and desktop are unaffected.
+
 ### Fixes
 
 * [FIX][all] The transaction progress view no longer shows a spinning loader while the title already reads "Transaction completed" — a successful transaction now settles onto a green check hero for the beat before the success receipt appears, instead of reusing the in-progress spinner.
 
 * [FIX][mobile] **iOS no longer prompts Face ID every few seconds while a Guardian account syncs.** Reverts the `.userPresence` gate (#299) on the Secure Enclave hot key: guardian sync signs with the hot key on the ~3s AutoSync tick, so the per-use presence flag turned into a continuous Face ID prompt loop. New hot keys are created with `.privateKeyUsage` only again (silent signing, key still SE-bound). Since hot signing is silent everywhere now, the `background` consume flag and its Guardian cold-key auto-consume detour (which existed only to dodge that prompt) are also removed — every consume takes the standard hot-bound path. Android gets the equivalent fix: the Keystore hot-key wrapper is no longer auth-bound (`setUserAuthenticationRequired`), so hot signing no longer pops a fingerprint `BiometricPrompt` per signature; legacy auth-bound keys keep working through a prompt fallback until the hot key is rotated.
+
+* [FIX][mobile] **iOS now renders at the display's native refresh rate (up to 120Hz ProMotion) instead of being capped at 60fps.** Added `CADisableMinimumFrameDurationOnPhone` to `Info.plist`. Since iOS 15, iPhones cap every app — including its WKWebView — to 60fps unless the app opts in to high frame rates, so on ProMotion devices animations and scrolling felt stuck at 60Hz (the same as Low Power Mode). CSS/compositor animations and native scrolling now run at the full display rate.
+
+* [FIX][all] **dApp transactions from a Guardian account no longer fail with "transaction is unauthorized".** A dApp/adapter supplies the account as its bare bech32 address (e.g. `mtst1…`), but `WalletAccount.publicKey` is a composite `<address>_<suffix>`; `isGuardianAccount` / `getOrCreateMultisigService` compared them with a raw `===`, which missed — so a Guardian account's dApp transaction was routed through the non-guardian path, no guardian co-signature was attached, and the on-chain guardian auth rejected it as `AUTH_UNAUTHORIZED` (e.g. registering a name on miden.name). Routing now matches through a shared `sameWalletAccountId` normalizer (both ids canonicalized to the SDK account id derived from the address portion), and `getOrCreateMultisigService` loads the SDK account by the matched account's stored `publicKey`. In-wallet Guardian sends (which already used the composite id) and single-sig accounts were unaffected.
+
 ## 1.15.7 (2026-07-20)
 
 ### Changes


### PR DESCRIPTION
Prereq for cutting the **v1.15.8** release from `origin/main` HEAD.

Five PRs merged after the 1.15.8 release-prep (#348) and were filed under a new `## 1.15.9 (TBD)` heading:
- #350 iOS ProMotion 120Hz
- #355 disable in-app swap on iOS
- #349 guardian-info-to-dApps + out-of-band reconcile
- #357 flaky-test fix (no changelog entry)
- #358 guardian dApp routing fix

Their code ships in a build from HEAD regardless of the heading, so they belong to 1.15.8. This folds the **Features / Changes / Fixes** bullets into the dated `## 1.15.8 (2026-07-21)` section (byte-for-byte, only regrouped) and drops the now-empty 1.15.9 heading, so `release-notes.yml` extracts the complete set for the v1.15.8 release body.

- No code change; `package.json` is already 1.15.8.
- Verified: the removed and re-added `* ` bullet sets are identical (only reordered/regrouped).