### PR TITLE
chore(ci): add total test-count badge to README

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,10 +1,11 @@
-name: Coverage Badge
+name: Badges
 
-# Publishes the Jest line-coverage % to coverage.json on the orphan `badges`
-# branch so shields.io renders a live badge in README.md. Runs only after a
-# push to main. No external service login required — shields.io reads the JSON
-# directly from raw.githubusercontent.com. The `badges` branch is an orphan
-# holding only the endpoint JSON; nothing merges back into main.
+# Publishes the Jest line-coverage % (coverage.json) and total test count
+# (tests.json) to the orphan `badges` branch so shields.io renders live badges
+# in README.md. Both are derived from a single `yarn test:coverage` run. Runs
+# only after a push to main. No external service login required — shields.io
+# reads the JSON directly from raw.githubusercontent.com. The `badges` branch
+# is an orphan holding only the endpoint JSON; nothing merges back into main.
 on:
   push:
     branches: [main]
@@ -28,7 +29,11 @@ jobs:
         # coverage job, tolerating any latent lockfile drift on a first run.
         run: yarn install --network-timeout 600000
       - name: Run coverage
-        run: yarn test:coverage
+        # `--json --outputFile` writes the run summary (incl. numTotalTests) to
+        # jest-results.json for the test-count badge; with --json Jest keeps its
+        # normal console output on stderr, so the CI log is unchanged. Coverage
+        # is still emitted to coverage/ by the json-summary reporter as before.
+        run: yarn test:coverage --json --outputFile=jest-results.json
       - name: Compose shields.io endpoint JSON
         id: badge
         run: |
@@ -42,6 +47,11 @@ jobs:
           printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}\n' "$pct" "$color" > /tmp/coverage.json
           echo "Line coverage: ${pct}%"
           echo "pct=${pct}" >> "$GITHUB_OUTPUT"
+
+          count=$(node -e 'process.stdout.write(String(require("./jest-results.json").numTotalTests))')
+          printf '{"schemaVersion":1,"label":"tests","message":"%s","color":"blue"}\n' "$count" > /tmp/tests.json
+          echo "Total tests: ${count}"
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
       - name: Publish to `badges` branch
         run: |
           set -euo pipefail
@@ -55,10 +65,11 @@ jobs:
             git rm -rf . > /dev/null 2>&1 || true
           fi
           cp /tmp/coverage.json coverage.json
-          git add coverage.json
+          cp /tmp/tests.json tests.json
+          git add coverage.json tests.json
           if git diff --cached --quiet; then
             echo "Badge JSON unchanged"
           else
-            git commit -m "chore: coverage badge -> ${{ steps.badge.outputs.pct }}%"
+            git commit -m "chore: badges -> coverage ${{ steps.badge.outputs.pct }}%, tests ${{ steps.badge.outputs.count }}"
             git push origin badges
           fi

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![build](https://github.com/0xMiden/miden-wallet/actions/workflows/build-desktop.yml/badge.svg)](https://github.com/0xMiden/miden-wallet/actions/workflows/build-desktop.yml)
 [![build](https://github.com/0xMiden/miden-wallet/actions/workflows/build-mobile.yml/badge.svg)](https://github.com/0xMiden/miden-wallet/actions/workflows/build-mobile.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/0xMiden/wallet/badges/coverage.json)](https://github.com/0xMiden/wallet/actions/workflows/coverage-badge.yml)
+[![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/0xMiden/wallet/badges/tests.json)](https://github.com/0xMiden/wallet/actions/workflows/coverage-badge.yml)
 
 A secure, cross-platform wallet for the [Miden](https://miden.xyz) blockchain. Available as a browser extension, desktop application, and mobile app.
 


### PR DESCRIPTION
## What

Adds a **Tests** badge to the README next to the existing Coverage badge, showing the total number of Jest test cases (currently ~6,200).

## How

Reuses the existing self-hosted shields.io endpoint-badge mechanism (no Codecov/external service). The `Coverage Badge` workflow already runs the Jest suite on every push to `main` and publishes `coverage.json` to the orphan `badges` branch. This:

- Passes `--json --outputFile=jest-results.json` to the *same* `yarn test:coverage` run (no extra CI time). With `--json`, Jest keeps its normal console output on stderr, so the CI log is unchanged.
- Reads `numTotalTests` from that results file and publishes a second `tests.json` endpoint alongside `coverage.json`.
- Adds one README line: a shields.io endpoint badge pointing at `badges/tests.json`.

Renamed the workflow *Coverage Badge* → *Badges* since it now publishes both. Workflow filename is unchanged, so existing badge links keep resolving.

## Note

Like when the Coverage badge was first added, the Tests badge renders as "invalid" until this merges and the workflow runs once on `main` to create `tests.json`, then it shows the live count and self-updates on every push to main.