### PR TITLE
fix: let side panel shrink below 360px so Brave sidebar does not clip wallet (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.9 (TBD)
+
+### Fixes
+
+* [FIX][extension] **The side panel no longer clips its right edge in Brave's narrow sidebar.** The side-panel document hard-clamped its root to `min-width: 360px` with hidden overflow, so any host giving less than 360px (Brave's sidebar, whose icon rail eats width) clipped the balance, Faucet button, and token amounts with no scrollbar. The floor is removed so the layout shrinks to the host viewport.
+
 ## 1.15.8 (2026-07-21)
 
 ### Features

--- a/public/sidepanel.html
+++ b/public/sidepanel.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="" class="no-scrollbar" style="width: 100%; height: 100%; min-width: 360px; background-color: #FFFFFF;">
+<html lang="" class="no-scrollbar" style="width: 100%; height: 100%; min-width: 0; background-color: #FFFFFF;">
   <head>
     <meta charset="utf-8" />
     <meta

--- a/src/sidepanel.html.test.ts
+++ b/src/sidepanel.html.test.ts
@@ -19,7 +19,7 @@ describe('public/sidepanel.html', () => {
 
   const rootStyle = (() => {
     const match = html.match(/<html\b[^>]*\bstyle="([^"]*)"/i);
-    return match ? match[1] : '';
+    return match?.[1] ?? '';
   })();
 
   it('does not clamp the root <html> width to 360px', () => {

--- a/src/sidepanel.html.test.ts
+++ b/src/sidepanel.html.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression guard for issue #336.
+ *
+ * The side-panel document (`public/sidepanel.html`) must tolerate host
+ * viewports narrower than 360px. Brave's side panel renders below ~360px
+ * (its icon rail eats width), so a hard `min-width: 360px` on the root
+ * `<html>` forces the document wider than the viewport and clips the right
+ * edge (balance glyphs, the Faucet button, token fiat values) with no
+ * horizontal scrollbar — the content becomes unreachable.
+ *
+ * This asserts the root element no longer clamps its width, so the document
+ * can shrink to match the host viewport.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('public/sidepanel.html', () => {
+  const html = readFileSync(join(__dirname, '..', 'public', 'sidepanel.html'), 'utf8');
+
+  const rootStyle = (() => {
+    const match = html.match(/<html\b[^>]*\bstyle="([^"]*)"/i);
+    return match ? match[1] : '';
+  })();
+
+  it('does not clamp the root <html> width to 360px', () => {
+    expect(rootStyle).not.toMatch(/min-width:\s*360px/i);
+  });
+
+  it('allows the root <html> to shrink below 360px (no width floor)', () => {
+    // Absent entirely, or explicitly a non-clamping value ('0'); default to
+    // '0' when unset so the assertion covers both cases without branching.
+    const minWidth = rootStyle.match(/min-width:\s*([^;]+)/i)?.[1]?.trim() ?? '0';
+    expect(minWidth).toMatch(/^0(px|%|rem|em)?$/i);
+  });
+});


### PR DESCRIPTION
## Summary

The side panel could not shrink below 360px wide. In Brave, the browser's side panel renders narrower than ~360px (its icon rail eats into the available width), so the hard `min-width: 360px` on the root `<html>` forced the document wider than the host viewport. Because the side panel is styled with `no-scrollbar`, the overflow produced no horizontal scrollbar — the clipped right edge (balance glyphs, the Faucet button, token fiat values) simply became unreachable.

## Root cause

`public/sidepanel.html` set an inline `min-width: 360px` on the root `<html>` element. When the host viewport is narrower than 360px, that floor forces horizontal overflow, and the `no-scrollbar` styling hides the scrollbar that would otherwise let the user reach the clipped content.

## Fix

Change the root `<html>` inline style from `min-width: 360px` to `min-width: 0`, letting the document shrink to match the host viewport. The existing responsive layout inside the panel already reflows down to narrow widths, so removing the artificial floor lets the content fit within Brave's sub-360px side panel with no clipping.

Added `src/sidepanel.html.test.ts` as a regression guard asserting the root `<html>` no longer clamps its width to 360px.

## Testing

- `npx jest src/sidepanel.html.test.ts --no-cache --runInBand` — 2 passing tests.
- `npx eslint src/sidepanel.html.test.ts --max-warnings 0` — clean.

Note: this is a UI/CSS change that was NOT visually verified in this environment. Manual visual verification (Brave sidebar at sub-360px width for #336) is recommended before and after merge to confirm the wallet content fits without clipping.

Closes #336