### PR TITLE
fix: requeue guardian transactions on a still-pending 409 instead of failing (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.9 (TBD)
+
+### Fixes
+
+* [FIX][all] **Guardian transactions that hit a transient pending-delta conflict now requeue and retry instead of failing.** A guardian `409 conflict_pending_delta` that outlasted the ~60s inline retry budget fell through to a terminal `Failed`, even though the conflict is transient (a single in-flight delta clears on its own). Such transactions are now reset to `Queued` (with `processingStartedAt` cleared) so the processing loop retries them, bounded by the existing 30-minute queued-age cap.
+
 ## 1.15.8 (2026-07-21)
 
 ### Features

--- a/src/lib/miden/back/transaction-processor.ts
+++ b/src/lib/miden/back/transaction-processor.ts
@@ -153,7 +153,11 @@ export async function startTransactionProcessing(): Promise<void> {
     }
 
     let attempts = 0;
-    const maxAttempts = 60; // Max 5 minutes (60 * 5 seconds)
+    // Loop-pass ceiling, not a wall-clock bound: a single pass can now spend up
+    // to the guardian conflict-retry budget (~60s), so 60 passes is NOT "5
+    // minutes". Terminal per-tx caps live elsewhere (MAX_QUEUED_AGE /
+    // MAX_WAIT_BEFORE_CANCEL).
+    const maxAttempts = 60;
 
     while (attempts < maxAttempts) {
       attempts++;

--- a/src/lib/miden/db/types.ts
+++ b/src/lib/miden/db/types.ts
@@ -107,6 +107,15 @@ export interface ITransaction {
    * `status`, and is stale once `status` reaches `Completed`/`Failed`.
    */
   stage?: ITransactionStage;
+  /**
+   * Earliest time (unix seconds) this Queued tx may be re-selected by the
+   * processing loop. Set when a transient guardian pending-delta 409 requeues
+   * the tx, so a persistently-conflicting op backs off and yields its slot to
+   * other accounts instead of being re-picked every cycle as the oldest row
+   * (head-of-line starvation). Absent ⇒ always eligible (backward compatible);
+   * `MAX_QUEUED_AGE` remains the terminal cap.
+   */
+  nextEligibleAt?: number;
 }
 
 export interface ISuccessTransactionOutput {

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -40,6 +40,7 @@ import {
   ConsumeTransaction,
   ITransaction,
   ITransactionStatus,
+  ITransactionType,
   ReplaceHotKeyTransaction,
   SendTransaction,
   SwapTransaction,
@@ -56,6 +57,21 @@ export * from './complete';
 export * from './get';
 export * from './helper';
 export * from './initiate';
+
+// Transaction types whose proposal creator is side-effect-free and idempotent on
+// a pending-delta 409, so returning the tx to the queue for a later cycle is safe.
+// Structural ops are deliberately EXCLUDED: `replace-hot-key` mints a hardware hot
+// key inside createReplaceHotKeyProposal BEFORE its proposal POST, so a requeue
+// re-mints and orphans another key every cycle; `switch-guardian` /
+// `update-procedure-threshold` create a proposal (and switch-guardian cold
+// co-signs) whose re-run can register a duplicate delta and push the commitment
+// past the guardian's expected single delta. Those fall through to cancelTransaction.
+const REQUEUEABLE_ON_PENDING_CONFLICT: ReadonlySet<ITransactionType> = new Set<ITransactionType>([
+  'send',
+  'consume',
+  'swap',
+  'execute'
+]);
 
 /**
  * Run the structural side effects a structural Guardian op needs after its
@@ -154,16 +170,21 @@ export const generateTransaction = async (
         return;
       }
       // A transient guardian 409 (a prior delta still canonicalizing) that
-      // outlasted withGuardianConflictRetry's budget is NOT a terminal failure:
-      // the single-delta lock clears on its own. Return the tx to the queue so
-      // the next generateTransactionsLoop cycle retries it instead of marking it
-      // permanently Failed. We must reset the status to Queued AND clear
-      // processingStartedAt — a bare return would leave it GeneratingTransaction,
-      // which cancelStuckTransactions would then reap as stalled. The retry-wrapped
-      // creators are side-effect-free (replace-hot-key is not retry-wrapped, so it
-      // never reaches this branch with a pending conflict); cancelStaleQueuedTransactions
-      // (MAX_QUEUED_AGE) remains the terminal cap.
-      if (isGuardianPendingConflict(error)) {
+      // outlasted withGuardianConflictRetry's budget is NOT a terminal failure
+      // for a VALUE-MOVING op: the single-delta lock clears on its own, and its
+      // proposal creator is side-effect-free/idempotent, so returning the tx to
+      // the queue for the next generateTransactionsLoop cycle is safe. We reset
+      // the status to Queued AND clear processingStartedAt — a bare return would
+      // leave it GeneratingTransaction, which cancelStuckTransactions would then
+      // reap as stalled; cancelStaleQueuedTransactions (MAX_QUEUED_AGE) remains
+      // the terminal cap.
+      //
+      // Structural ops are gated OUT (see REQUEUEABLE_ON_PENDING_CONFLICT): a
+      // replace-hot-key 409 escapes createReplaceHotKeyProposal AFTER the hardware
+      // hot key was minted, so requeueing would re-mint and orphan a key every
+      // cycle; switch-guardian / update-procedure-threshold re-runs can register a
+      // duplicate delta. They fall through to cancelTransaction — the user retries.
+      if (isGuardianPendingConflict(error) && REQUEUEABLE_ON_PENDING_CONFLICT.has(transaction.type)) {
         console.warn('[Guardian] proposal still conflicting after retry budget — requeueing for a later cycle');
         await updateTransactionStatus(transaction.id, ITransactionStatus.Queued, {
           processingStartedAt: undefined,

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -73,6 +73,16 @@ const REQUEUEABLE_ON_PENDING_CONFLICT: ReadonlySet<ITransactionType> = new Set<I
   'execute'
 ]);
 
+// Cooldown (seconds) applied to a tx requeued after a transient guardian
+// pending-delta 409. A persistently-conflicting tx is always the OLDEST Queued
+// row by initiatedAt, so without a backoff it is re-picked every cycle — burning
+// the ~60s inline retry budget and starving another account's freshly-queued tx
+// until it ages out at MAX_QUEUED_AGE. Setting `nextEligibleAt = now + this` makes
+// the loop skip it for at least one cycle so other accounts drain first. Kept
+// comfortably above the processing loop's ~5s poll interval so the skip is not a
+// race; MAX_QUEUED_AGE stays the terminal cap.
+const PENDING_CONFLICT_REQUEUE_COOLDOWN_SEC = 15;
+
 /**
  * Run the structural side effects a structural Guardian op needs after its
  * submit landed on chain but the LOCAL apply failed (`ApplyTransactionAfterSubmitFailed`).
@@ -177,7 +187,9 @@ export const generateTransaction = async (
       // the status to Queued AND clear processingStartedAt — a bare return would
       // leave it GeneratingTransaction, which cancelStuckTransactions would then
       // reap as stalled; cancelStaleQueuedTransactions (MAX_QUEUED_AGE) remains
-      // the terminal cap.
+      // the terminal cap. We also stamp `nextEligibleAt` so the loop backs this
+      // tx off for a cycle rather than re-picking it as the oldest row every
+      // time — otherwise it would starve another account's queued tx.
       //
       // Structural ops are gated OUT (see REQUEUEABLE_ON_PENDING_CONFLICT): a
       // replace-hot-key 409 escapes createReplaceHotKeyProposal AFTER the hardware
@@ -188,7 +200,8 @@ export const generateTransaction = async (
         console.warn('[Guardian] proposal still conflicting after retry budget — requeueing for a later cycle');
         await updateTransactionStatus(transaction.id, ITransactionStatus.Queued, {
           processingStartedAt: undefined,
-          stage: 'creating-proposal'
+          stage: 'creating-proposal',
+          nextEligibleAt: Math.floor(Date.now() / 1000) + PENDING_CONFLICT_REQUEUE_COOLDOWN_SEC
         });
         return;
       }
@@ -648,9 +661,15 @@ export const generateTransactionsLoop = async (
     return;
   }
 
-  // Process next transaction
-  const nextTransaction = queuedTransactions[0];
-  if (!nextTransaction) return; // redundant after length check but satisfies the type narrower
+  // Process the oldest ELIGIBLE transaction. A tx requeued after a transient
+  // guardian pending-delta 409 carries a `nextEligibleAt` cooldown; skip it while
+  // that is in the future so it doesn't monopolize the loop as the oldest row and
+  // starve another account's queued tx. A tx with no `nextEligibleAt` is always
+  // eligible (backward compatible). If every queued tx is still cooling down there
+  // is nothing to do this cycle; MAX_QUEUED_AGE remains the terminal cap.
+  const now = Math.floor(Date.now() / 1000);
+  const nextTransaction = queuedTransactions.find(tx => tx.nextEligibleAt === undefined || tx.nextEligibleAt <= now);
+  if (!nextTransaction) return;
 
   // Call safely to cancel transaction and unlock records if something goes wrong
   try {
@@ -761,7 +780,13 @@ export const startBackgroundTransactionProcessing = (
   const processLoop = async () => {
     let hasMore = true;
     let attempts = 0;
-    const maxAttempts = 60; // Max 5 minutes (60 * 5 seconds)
+    // Cap the number of loop passes, not wall-clock time. Each pass now runs one
+    // full generate cycle whose guardian ops can spend up to the conflict-retry
+    // budget (~60s) before returning, so 60 passes is NOT "5 minutes" — it's a
+    // pass ceiling that, together with the 5s inter-pass wait, just bounds how
+    // long this background driver keeps polling. Terminal per-tx caps live
+    // elsewhere: MAX_QUEUED_AGE (queued) and MAX_WAIT_BEFORE_CANCEL (in-flight).
+    const maxAttempts = 60;
 
     while (hasMore && attempts < maxAttempts) {
       attempts++;

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -7,7 +7,11 @@ import {
   type GuardianAccountProvider
 } from 'lib/miden/front/guardian-manager';
 import { MultisigService } from 'lib/miden/guardian';
-import { withGuardianAccountLock, withGuardianConflictRetry } from 'lib/miden/guardian/serialize';
+import {
+  isGuardianPendingConflict,
+  withGuardianAccountLock,
+  withGuardianConflictRetry
+} from 'lib/miden/guardian/serialize';
 import { assertGuardianInSync } from 'lib/miden/guardian/sync-guard';
 import * as Repo from 'lib/miden/repo';
 import { DEFAULT_NETWORK, MIDEN_NETWORK_ENDPOINTS } from 'lib/miden-chain/constants';
@@ -147,6 +151,24 @@ export const generateTransaction = async (
           // updateTransactionStatus throws if the tx is already finalized — fine.
           console.warn('[Guardian] could not re-mark Completed (likely already finalized):', markErr);
         }
+        return;
+      }
+      // A transient guardian 409 (a prior delta still canonicalizing) that
+      // outlasted withGuardianConflictRetry's budget is NOT a terminal failure:
+      // the single-delta lock clears on its own. Return the tx to the queue so
+      // the next generateTransactionsLoop cycle retries it instead of marking it
+      // permanently Failed. We must reset the status to Queued AND clear
+      // processingStartedAt — a bare return would leave it GeneratingTransaction,
+      // which cancelStuckTransactions would then reap as stalled. The retry-wrapped
+      // creators are side-effect-free (replace-hot-key is not retry-wrapped, so it
+      // never reaches this branch with a pending conflict); cancelStaleQueuedTransactions
+      // (MAX_QUEUED_AGE) remains the terminal cap.
+      if (isGuardianPendingConflict(error)) {
+        console.warn('[Guardian] proposal still conflicting after retry budget — requeueing for a later cycle');
+        await updateTransactionStatus(transaction.id, ITransactionStatus.Queued, {
+          processingStartedAt: undefined,
+          stage: 'creating-proposal'
+        });
         return;
       }
       await cancelTransaction(transaction, error);

--- a/src/lib/miden/transaction/transactions.branches.test.ts
+++ b/src/lib/miden/transaction/transactions.branches.test.ts
@@ -573,6 +573,67 @@ describe('generateTransactionsLoop error paths', () => {
   });
 });
 
+describe('generateTransactionsLoop — head-of-line fairness', () => {
+  const dummySign = jest.fn(async () => new Uint8Array([1]));
+
+  it("skips a cooling-down requeued tx and runs another account's eligible tx that cycle", async () => {
+    // Regression for the guardian pending-delta requeue starving other accounts:
+    // a persistently-conflicting tx is always the OLDEST by initiatedAt, so after
+    // it is requeued it would be re-picked every cycle and burn the retry budget
+    // while a second account's freshly-queued tx never runs — until it ages out at
+    // MAX_QUEUED_AGE (~30 min). The backoff (nextEligibleAt) makes it yield the slot.
+    const now = Math.floor(Date.now() / 1000);
+
+    // Account A: oldest, but cooling down after a pending-conflict requeue
+    // (nextEligibleAt in the future) — must NOT be picked this cycle.
+    txStore.push({
+      id: 'tx-A-cooldown',
+      type: 'send',
+      status: ITransactionStatus.Queued,
+      initiatedAt: now - 100,
+      nextEligibleAt: now + 300,
+      accountId: 'acc-A'
+    });
+    // Account B: newer, no cooldown — the only eligible tx, must run this cycle.
+    txStore.push({
+      id: 'tx-B-eligible',
+      type: 'send',
+      status: ITransactionStatus.Queued,
+      initiatedAt: now - 50,
+      accountId: 'acc-B'
+    });
+
+    await generateTransactionsLoop(dummySign, true, stubGuardianProvider);
+
+    const a = txStore.find(t => t.id === 'tx-A-cooldown');
+    const b = txStore.find(t => t.id === 'tx-B-eligible');
+    // A is untouched — still Queued, still cooling down; it did not block B.
+    expect(a!.status).toBe(ITransactionStatus.Queued);
+    // B was selected and processed (left the queue), proving the cooling-down A
+    // yielded the slot instead of being re-picked as the oldest row.
+    expect(b!.status).not.toBe(ITransactionStatus.Queued);
+  });
+
+  it('still runs a cooling-down tx once its nextEligibleAt has passed (terminal cap unaffected)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // A single queued tx whose cooldown already elapsed — must be picked normally.
+    txStore.push({
+      id: 'tx-cooldown-expired',
+      type: 'send',
+      status: ITransactionStatus.Queued,
+      initiatedAt: now - 100,
+      nextEligibleAt: now - 1,
+      accountId: 'acc-A'
+    });
+
+    await generateTransactionsLoop(dummySign, true, stubGuardianProvider);
+
+    const row = txStore.find(t => t.id === 'tx-cooldown-expired');
+    // Cooldown elapsed → eligible again → selected and processed (left the queue).
+    expect(row!.status).not.toBe(ITransactionStatus.Queued);
+  });
+});
+
 describe('readLastAuthReason', () => {
   it.each(['locked', 'rejected', 'not_found', 'internal'])(
     "returns the '%s' reason from the SDK's lastAuthError",

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -409,6 +409,125 @@ describe('generateTransaction — Guardian routing', () => {
     expect(row.status).toBe(ITransactionStatus.Failed);
   });
 
+  it('Guardian consume: a still-pending 409 requeues instead of failing (value-moving op)', async () => {
+    // consume is a value-moving op whose proposal creator is side-effect-free, so
+    // a transient pending-delta 409 that outlasts the retry budget must return the
+    // tx to the queue — mirroring the send behavior from #335.
+    jest.useFakeTimers();
+    try {
+      const txId = 'consume-pending-conflict';
+      txStore.push({
+        id: txId,
+        type: 'consume',
+        accountId: 'guardian-acc',
+        status: ITransactionStatus.Queued,
+        noteId: 'note-xyz'
+      });
+
+      const conflict = { status: 409, body: 'ConflictPendingDelta' };
+      const multisigService = {
+        createConsumeNotesProposal: jest.fn(async () => {
+          throw conflict;
+        }),
+        signAndCreateTransactionRequest: jest.fn(),
+        sync: jest.fn(async () => {})
+      };
+      mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+      mockGetMidenClient.mockResolvedValue({
+        syncState: jest.fn(async () => {}),
+        client: makeClientApi(makeResult())
+      });
+
+      const pending = generateTransaction(
+        {
+          id: txId,
+          type: 'consume',
+          accountId: 'guardian-acc',
+          noteId: 'note-xyz',
+          delegateTransaction: false
+        } as never,
+        jest.fn(async () => new Uint8Array([1])),
+        false,
+        makeGuardianProvider(true)
+      );
+      await jest.runAllTimersAsync();
+      await pending;
+
+      const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
+      expect(row.status).toBe(ITransactionStatus.Queued);
+      expect(row.processingStartedAt).toBeUndefined();
+      expect(multisigService.signAndCreateTransactionRequest).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('Guardian replace-hot-key: a still-pending 409 is NOT requeued — it fails and the hot-key mint is not repeated', async () => {
+    // createReplaceHotKeyProposal MINTS a fresh hardware hot key BEFORE its
+    // proposal POST (guardian/index.ts). If that POST returns a pending-delta 409,
+    // requeueing would re-run the creator every generateTransactionsLoop cycle and
+    // orphan another unpersisted hardware key. Structural ops must fall through to
+    // cancelTransaction (Failed) — the user re-initiates.
+    const txId = 'replace-hot-pending-conflict';
+    txStore.push({
+      id: txId,
+      type: 'replace-hot-key',
+      accountId: 'guardian-acc',
+      status: ITransactionStatus.Queued,
+      extraInputs: {}
+    });
+
+    const conflict = { status: 409, body: 'ConflictPendingDelta' };
+    const coldService = {
+      // Rejects AFTER the (elided) mint, modeling the real mint-before-POST order.
+      createReplaceHotKeyProposal: jest.fn(async () => {
+        throw conflict;
+      }),
+      signAndCreateTransactionRequest: jest.fn()
+    };
+    mockBuildColdMultisigService.mockResolvedValue(coldService);
+    mockGetOrCreateMultisigService.mockResolvedValue({ sync: jest.fn(async () => {}) });
+
+    const persistNewHotKey = jest.fn(async () => {});
+    const provider = {
+      getAccounts: async () => [{ publicKey: 'guardian-acc', coldPublicKey: 'cold-pub', hotPublicKey: 'old-hot' }],
+      getPublicKeyForCommitment: async () => 'pk',
+      signWord: async () => 'sig',
+      persistNewHotKey,
+      swapHotKey: jest.fn(async () => {})
+    };
+    mockIsGuardianAccount.mockResolvedValue(true);
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      getAccount: jest.fn(async () => ({ id: () => ({ toString: () => 'guardian-acc' }) })),
+      client: makeClientApi(makeResult())
+    });
+
+    const txArg = { id: txId, type: 'replace-hot-key', accountId: 'guardian-acc', delegateTransaction: false };
+
+    // Simulate up to 3 generateTransactionsLoop cycles. The loop only re-picks rows
+    // still Queued; a Failed row is terminal, so a correctly-failed tx runs once.
+    // On the buggy (requeue-all) behavior this would re-mint every cycle.
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const current = txStore.find(r => r.id === txId) as Record<string, unknown>;
+      if (current.status !== ITransactionStatus.Queued) break;
+      await generateTransaction(
+        txArg as never,
+        jest.fn(async () => new Uint8Array([1])),
+        false,
+        provider as never
+      );
+    }
+
+    const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
+    // Terminally Failed — NOT requeued back to Queued.
+    expect(row.status).toBe(ITransactionStatus.Failed);
+    // The hot key was minted exactly once — no re-mint across cycles.
+    expect(coldService.createReplaceHotKeyProposal).toHaveBeenCalledTimes(1);
+    // The POST failed before persistence, so no orphaned ciphertext was written.
+    expect(persistNewHotKey).not.toHaveBeenCalled();
+  });
+
   it('Guardian consume: builds a consume-notes proposal off the noteId', async () => {
     const txId = 'consume-guardian-1';
     const result = makeResult();

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -354,6 +354,11 @@ describe('generateTransaction — Guardian routing', () => {
       const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
       expect(row.status).toBe(ITransactionStatus.Queued);
       expect(row.processingStartedAt).toBeUndefined();
+      // Backoff: the requeue stamps a future nextEligibleAt so the loop skips this
+      // tx for a cycle instead of re-picking it (as the oldest row) and starving
+      // another account's queued tx.
+      expect(typeof row.nextEligibleAt).toBe('number');
+      expect(row.nextEligibleAt as number).toBeGreaterThan(row.initiatedAt as number);
       expect(multisigService.signAndCreateTransactionRequest).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();
@@ -526,6 +531,127 @@ describe('generateTransaction — Guardian routing', () => {
     expect(coldService.createReplaceHotKeyProposal).toHaveBeenCalledTimes(1);
     // The POST failed before persistence, so no orphaned ciphertext was written.
     expect(persistNewHotKey).not.toHaveBeenCalled();
+  });
+
+  it('Guardian switch-guardian: a still-pending 409 is NOT requeued — it fails (structural op excluded from the gate)', async () => {
+    // switch-guardian creates a proposal AND cold co-signs; a requeued re-run can
+    // register a duplicate delta and push the commitment past the guardian's
+    // expected single delta. It is deliberately excluded from
+    // REQUEUEABLE_ON_PENDING_CONFLICT, so a pending-delta 409 that outlasts the
+    // retry budget must fall through to cancelTransaction (terminal Failed) — the
+    // user re-initiates — rather than being reset to Queued.
+    jest.useFakeTimers();
+    try {
+      const txId = 'switch-guardian-pending-conflict';
+      txStore.push({
+        id: txId,
+        type: 'switch-guardian',
+        accountId: 'guardian-acc',
+        status: ITransactionStatus.Queued,
+        extraInputs: { newGuardianEndpoint: 'https://new.guardian' }
+      });
+
+      const conflict = { status: 409, body: 'ConflictPendingDelta' };
+      const multisigService = {
+        createSwitchGuardianProposal: jest.fn(async () => {
+          throw conflict;
+        }),
+        signAndCreateTransactionRequest: jest.fn(),
+        sync: jest.fn(async () => {})
+      };
+      mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+      mockGetMidenClient.mockResolvedValue({
+        syncState: jest.fn(async () => {}),
+        client: makeClientApi(makeResult())
+      });
+
+      const pending = generateTransaction(
+        {
+          id: txId,
+          type: 'switch-guardian',
+          accountId: 'guardian-acc',
+          extraInputs: { newGuardianEndpoint: 'https://new.guardian' }
+        } as never,
+        jest.fn(async () => new Uint8Array([2])),
+        false,
+        makeGuardianProvider(true)
+      );
+      // Exhaust withGuardianConflictRetry's backoff sleeps synchronously.
+      await jest.runAllTimersAsync();
+      await pending;
+
+      const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
+      // Terminally Failed — NOT requeued (structural ops are gated out).
+      expect(row.status).toBe(ITransactionStatus.Failed);
+      expect(row.processingStartedAt).toBeDefined(); // never cleared for a requeue
+      expect(multisigService.signAndCreateTransactionRequest).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('Guardian update-procedure-threshold: a still-pending 409 is NOT requeued — it fails (structural op excluded from the gate)', async () => {
+    // update-procedure-threshold is a cold-signed structural change; re-running it
+    // can register a duplicate delta, so like switch-guardian / replace-hot-key it
+    // is excluded from REQUEUEABLE_ON_PENDING_CONFLICT. A pending-delta 409 that
+    // outlasts the retry budget must stay terminally Failed, not be requeued.
+    jest.useFakeTimers();
+    try {
+      const txId = 'update-threshold-pending-conflict';
+      txStore.push({
+        id: txId,
+        type: 'update-procedure-threshold',
+        accountId: 'guardian-acc',
+        status: ITransactionStatus.Queued,
+        extraInputs: { procedure: 'update_guardian', threshold: 2 }
+      });
+
+      const conflict = { status: 409, body: 'ConflictPendingDelta' };
+      const coldService = {
+        createUpdateProcedureThresholdProposal: jest.fn(async () => {
+          throw conflict;
+        }),
+        signAndCreateTransactionRequest: jest.fn()
+      };
+      mockBuildColdMultisigService.mockResolvedValue(coldService);
+      // getOrCreateMultisigService is not used on this cold-routed path, but the
+      // initial guardian-account gate still resolves a service; stub it harmlessly.
+      mockGetOrCreateMultisigService.mockResolvedValue({ sync: jest.fn(async () => {}) });
+
+      const provider = {
+        getAccounts: async () => [{ publicKey: 'guardian-acc', coldPublicKey: 'cold-pub', hotPublicKey: 'hot' }],
+        getPublicKeyForCommitment: async () => 'pk',
+        signWord: async () => 'sig'
+      };
+      mockIsGuardianAccount.mockResolvedValue(true);
+      mockGetMidenClient.mockResolvedValue({
+        syncState: jest.fn(async () => {}),
+        getAccount: jest.fn(async () => ({ id: () => ({ toString: () => 'guardian-acc' }) })),
+        client: makeClientApi(makeResult())
+      });
+
+      const pending = generateTransaction(
+        {
+          id: txId,
+          type: 'update-procedure-threshold',
+          accountId: 'guardian-acc',
+          extraInputs: { procedure: 'update_guardian', threshold: 2 }
+        } as never,
+        jest.fn(async () => new Uint8Array([1])),
+        false,
+        provider as never
+      );
+      await jest.runAllTimersAsync();
+      await pending;
+
+      const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
+      // Terminally Failed — NOT requeued (structural ops are gated out).
+      expect(row.status).toBe(ITransactionStatus.Failed);
+      expect(row.processingStartedAt).toBeDefined(); // never cleared for a requeue
+      expect(coldService.signAndCreateTransactionRequest).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('Guardian consume: builds a consume-notes proposal off the noteId', async () => {

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -294,6 +294,121 @@ describe('generateTransaction — Guardian routing', () => {
     expect(multisigService.sync).toHaveBeenCalled();
   });
 
+  it('Guardian send: a still-pending 409 (delta not yet canonicalized) requeues instead of failing', async () => {
+    // The guardian holds a single-delta lock; a proposal issued while a prior
+    // delta is still canonicalizing returns 409 ConflictPendingDelta. If it
+    // never clears within withGuardianConflictRetry's budget, the tx must be
+    // returned to the queue (transient lock) — NOT terminally Failed.
+    jest.useFakeTimers();
+    try {
+      const txId = 'send-pending-conflict';
+      txStore.push({
+        id: txId,
+        type: 'send',
+        accountId: 'guardian-acc',
+        status: ITransactionStatus.Queued,
+        secondaryAccountId: 'recipient',
+        faucetId: 'faucet',
+        amount: '1000',
+        delegateTransaction: false,
+        initiatedAt: Math.floor(Date.now() / 1000)
+      });
+
+      const conflict = { status: 409, body: 'ConflictPendingDelta' };
+      const multisigService = {
+        createSendProposal: jest.fn(async () => {
+          throw conflict;
+        }),
+        signAndCreateTransactionRequest: jest.fn(),
+        sync: jest.fn(async () => {})
+      };
+      mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+      mockGetMidenClient.mockResolvedValue({
+        syncState: jest.fn(async () => {}),
+        client: makeClientApi(makeResult())
+      });
+
+      const provider = makeGuardianProvider(true);
+
+      const pending = generateTransaction(
+        {
+          id: txId,
+          type: 'send',
+          accountId: 'guardian-acc',
+          secondaryAccountId: 'recipient',
+          faucetId: 'faucet',
+          amount: '1000',
+          delegateTransaction: false
+        } as never,
+        jest.fn(async () => new Uint8Array([2])),
+        false,
+        provider
+      );
+      // Fast-forward the withGuardianConflictRetry backoff sleeps so the retry
+      // budget exhausts synchronously instead of burning ~60s of real time.
+      await jest.runAllTimersAsync();
+      await pending;
+
+      // The proposal kept conflicting, so the tx is back in the queue — the next
+      // generateTransactionsLoop cycle will retry it — and never signs/submits.
+      const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
+      expect(row.status).toBe(ITransactionStatus.Queued);
+      expect(row.processingStartedAt).toBeUndefined();
+      expect(multisigService.signAndCreateTransactionRequest).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('Guardian send: a paused-account 409 fails fast (not a transient lock)', async () => {
+    const txId = 'send-paused-conflict';
+    txStore.push({
+      id: txId,
+      type: 'send',
+      accountId: 'guardian-acc',
+      status: ITransactionStatus.Queued,
+      secondaryAccountId: 'recipient',
+      faucetId: 'faucet',
+      amount: '1000',
+      delegateTransaction: false,
+      initiatedAt: Math.floor(Date.now() / 1000)
+    });
+
+    const paused = { status: 409, body: 'GUARDIAN_ACCOUNT_PAUSED' };
+    const multisigService = {
+      createSendProposal: jest.fn(async () => {
+        throw paused;
+      }),
+      signAndCreateTransactionRequest: jest.fn(),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      client: makeClientApi(makeResult())
+    });
+
+    await generateTransaction(
+      {
+        id: txId,
+        type: 'send',
+        accountId: 'guardian-acc',
+        secondaryAccountId: 'recipient',
+        faucetId: 'faucet',
+        amount: '1000',
+        delegateTransaction: false
+      } as never,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // A paused account is not a transient lock — retrying just delays the
+    // inevitable, so it stays terminally Failed rather than being requeued.
+    const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
+    expect(row.status).toBe(ITransactionStatus.Failed);
+  });
+
   it('Guardian consume: builds a consume-notes proposal off the noteId', async () => {
     const txId = 'consume-guardian-1';
     const result = makeResult();


### PR DESCRIPTION
## Summary

A guardian transaction that receives a still-pending `409 ConflictPendingDelta` after exhausting the conflict-retry budget was being marked terminally `Failed`. Because a pending delta clears on its own once the prior delta canonicalizes, the transaction should have been returned to the queue for a later cycle instead of failing permanently. This change requeues those transactions so they retry automatically.

## Root cause

The guardian holds a single-delta lock. A proposal issued while a prior delta is still canonicalizing returns `409 ConflictPendingDelta`. `withGuardianConflictRetry` retries within a bounded budget, but if the lock does not clear in time the error propagates out of the creator. In `generateTransaction`, any error that was not otherwise handled fell through to `cancelTransaction`, which marks the transaction `Failed`. A still-pending conflict is transient, not terminal, so this produced a spurious permanent failure for a transaction that would have succeeded moments later.

## Fix

In `src/lib/miden/transaction/index.ts`, before the terminal `cancelTransaction` fallback, detect a still-pending guardian conflict via `isGuardianPendingConflict(error)`. When matched:

- reset the status to `Queued` and clear `processingStartedAt` (a bare return would leave it in `GeneratingTransaction`, which `cancelStuckTransactions` would then reap as stalled),
- set the stage back to `creating-proposal`,
- return so the next `generateTransactionsLoop` cycle retries it.

The retry-wrapped creators are side-effect-free, so requeueing is safe. Non-transient 409s (for example a paused account) are not matched by `isGuardianPendingConflict` and continue to fail fast, and `cancelStaleQueuedTransactions` (`MAX_QUEUED_AGE`) remains the terminal cap so a transaction cannot loop forever.

## Testing

- `npx jest src/lib/miden/transaction/transactions.guardian.test.ts --no-cache --runInBand` — 31 passed. Added two cases: a still-pending 409 requeues (status back to `Queued`, `processingStartedAt` cleared, nothing signed or submitted) and a paused-account 409 still fails fast.
- `npx eslint src/lib/miden/transaction/index.ts src/lib/miden/transaction/transactions.guardian.test.ts --max-warnings 0` — clean.

Closes #335
