### PR TITLE
fix: recover Dexie and surface stuck-tx heal failures (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.9 (TBD)
+
+### Fixes
+
+* [FIX][extension] **The stuck-transaction heal alarm now recovers a closed database and surfaces failures instead of silently swallowing them.** After an MV3 service-worker respawn left a stale Dexie handle, the heal alarm hit `DatabaseClosedError` on every tick and only `console.warn`'d it, so it never recovered and there was no diagnostic surface. It now re-opens Dexie and retries on `DatabaseClosedError`, and escalates persistent failures through analytics instead of swallowing them.
+
 ## 1.15.8 (2026-07-21)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* [FIX][extension] **The stuck-transaction heal alarm now recovers a closed database and surfaces failures instead of silently swallowing them.** After an MV3 service-worker respawn left a stale Dexie handle, the heal alarm hit `DatabaseClosedError` on every tick and only `console.warn`'d it, so it never recovered and there was no diagnostic surface. It now re-opens Dexie and retries on `DatabaseClosedError`, and escalates persistent failures through analytics instead of swallowing them.
+* [FIX][extension] **The stuck-transaction heal alarm now recovers a closed database and surfaces failures instead of silently swallowing them.** After an MV3 service-worker respawn left a stale Dexie handle, the heal alarm hit `DatabaseClosedError` on every tick and only `console.warn`'d it, so it never recovered and there was no diagnostic surface. It now re-opens Dexie and retries on `DatabaseClosedError`, and persists a diagnostic record (`stuckTxHealDiagnostic`) to `chrome.storage.local` on persistent failure — a sink that works in the MV3 service worker and survives a broken IndexedDB — instead of swallowing them.
 
 ## 1.15.8 (2026-07-21)
 

--- a/src/lib/miden/back/transaction-processor.test.ts
+++ b/src/lib/miden/back/transaction-processor.test.ts
@@ -16,6 +16,8 @@
 const mockAlarmsCreate = jest.fn();
 const mockAlarmsClear = jest.fn();
 const mockAlarmsOnAlarm = { addListener: jest.fn() };
+const mockStorageGet = jest.fn();
+const mockStorageSet = jest.fn();
 
 // The real webextension-polyfill module shape. Tests override the
 // import behavior in specific cases to force rejection.
@@ -24,6 +26,12 @@ const mockPolyfill = {
     create: (...args: unknown[]) => mockAlarmsCreate(...args),
     clear: (...args: unknown[]) => mockAlarmsClear(...args),
     onAlarm: mockAlarmsOnAlarm
+  },
+  storage: {
+    local: {
+      get: (...args: unknown[]) => mockStorageGet(...args),
+      set: (...args: unknown[]) => mockStorageSet(...args)
+    }
   }
 };
 
@@ -48,11 +56,6 @@ jest.mock('lib/miden/repo', () => ({
   db: { open: (...args: unknown[]) => mockDbOpen(...args) }
 }));
 
-const mockTrackEvent = jest.fn();
-jest.mock('./analytics', () => ({
-  trackEvent: (...args: unknown[]) => mockTrackEvent(...args)
-}));
-
 const mockWithUnlocked = jest.fn();
 jest.mock('./store', () => ({
   withUnlocked: (fn: (ctx: unknown) => unknown) => mockWithUnlocked(fn)
@@ -70,7 +73,8 @@ beforeEach(() => {
   mockSafeGenerateTransactionsLoop.mockResolvedValue({ success: true });
   mockCancelStuckTransactions.mockResolvedValue(undefined);
   mockDbOpen.mockResolvedValue(undefined);
-  mockTrackEvent.mockResolvedValue(undefined);
+  mockStorageGet.mockResolvedValue({});
+  mockStorageSet.mockResolvedValue(undefined);
 });
 
 /** Flush a few microtask / macrotask ticks so in-flight awaits can progress. */
@@ -248,16 +252,21 @@ describe('setupTransactionProcessor', () => {
 
     expect(mockDbOpen).toHaveBeenCalledTimes(1);
     expect(mockCancelStuckTransactions).toHaveBeenCalledTimes(2);
-    // A recovered heal must not escalate.
-    expect(mockTrackEvent).not.toHaveBeenCalled();
+    // A recovered heal must not escalate — no diagnostic gets persisted.
+    expect(mockStorageSet).not.toHaveBeenCalled();
   });
 
-  it('escalates via trackEvent when the heal keeps failing after re-open (issue #254)', async () => {
+  it('persists a diagnostic to chrome.storage.local when the heal keeps failing after re-open (issue #254)', async () => {
+    // The Segment escalation the PR originally used is dead in the shipped SW
+    // build (`back/analytics.ts` throws without ALEO_WALLET_SEGMENT_WRITE_KEY,
+    // which the background Vite build never defines), so a persistently-wedged
+    // heal must be recorded to `chrome.storage.local` — a sink that actually
+    // works in the MV3 SW and survives a broken IndexedDB.
     const mod = await import('./transaction-processor');
     mod.setupTransactionProcessor();
     await flushAsync();
     mockCancelStuckTransactions.mockClear();
-    mockTrackEvent.mockClear();
+    mockStorageSet.mockClear();
 
     const dbClosed = new Error('database is closed');
     dbClosed.name = 'DatabaseClosedError';
@@ -268,8 +277,39 @@ describe('setupTransactionProcessor', () => {
     listener({ name: 'miden-tx-stuck-heal' });
     await flushAsync();
 
-    // A silently-failing heal must be surfaced, not swallowed.
-    expect(mockTrackEvent).toHaveBeenCalledWith(expect.objectContaining({ event: expect.stringContaining('Heal') }));
+    expect(mockStorageSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stuckTxHealDiagnostic: expect.objectContaining({
+          message: expect.stringContaining('DatabaseClosedError'),
+          consecutiveFailures: 1,
+          lastFailureAt: expect.any(Number)
+        })
+      })
+    );
+  });
+
+  it('increments the consecutiveFailures counter across repeated persistent heal failures (issue #254)', async () => {
+    const mod = await import('./transaction-processor');
+    mod.setupTransactionProcessor();
+    await flushAsync();
+    mockCancelStuckTransactions.mockClear();
+    mockStorageSet.mockClear();
+
+    // A prior diagnostic already exists from earlier failed ticks.
+    mockStorageGet.mockResolvedValue({
+      stuckTxHealDiagnostic: { lastFailureAt: 1, message: 'old failure', consecutiveFailures: 4 }
+    });
+    mockCancelStuckTransactions.mockRejectedValueOnce(new Error('still broken'));
+
+    const listener = mockAlarmsOnAlarm.addListener.mock.calls[0][0];
+    listener({ name: 'miden-tx-stuck-heal' });
+    await flushAsync();
+
+    expect(mockStorageSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stuckTxHealDiagnostic: expect.objectContaining({ consecutiveFailures: 5 })
+      })
+    );
   });
 
   it('escalates a non-DatabaseClosedError without attempting a Dexie re-open (issue #254)', async () => {
@@ -278,7 +318,7 @@ describe('setupTransactionProcessor', () => {
     await flushAsync();
     mockCancelStuckTransactions.mockClear();
     mockDbOpen.mockClear();
-    mockTrackEvent.mockClear();
+    mockStorageSet.mockClear();
 
     mockCancelStuckTransactions.mockRejectedValueOnce(new Error('some other failure'));
 
@@ -287,7 +327,7 @@ describe('setupTransactionProcessor', () => {
     await flushAsync();
 
     expect(mockDbOpen).not.toHaveBeenCalled();
-    expect(mockTrackEvent).toHaveBeenCalled();
+    expect(mockStorageSet).toHaveBeenCalledWith(expect.objectContaining({ stuckTxHealDiagnostic: expect.any(Object) }));
   });
 
   it('keepalive alarm tick does not invoke cancelStuckTransactions', async () => {

--- a/src/lib/miden/back/transaction-processor.test.ts
+++ b/src/lib/miden/back/transaction-processor.test.ts
@@ -18,6 +18,7 @@ const mockAlarmsClear = jest.fn();
 const mockAlarmsOnAlarm = { addListener: jest.fn() };
 const mockStorageGet = jest.fn();
 const mockStorageSet = jest.fn();
+const mockStorageRemove = jest.fn();
 
 // The real webextension-polyfill module shape. Tests override the
 // import behavior in specific cases to force rejection.
@@ -30,7 +31,8 @@ const mockPolyfill = {
   storage: {
     local: {
       get: (...args: unknown[]) => mockStorageGet(...args),
-      set: (...args: unknown[]) => mockStorageSet(...args)
+      set: (...args: unknown[]) => mockStorageSet(...args),
+      remove: (...args: unknown[]) => mockStorageRemove(...args)
     }
   }
 };
@@ -75,6 +77,7 @@ beforeEach(() => {
   mockDbOpen.mockResolvedValue(undefined);
   mockStorageGet.mockResolvedValue({});
   mockStorageSet.mockResolvedValue(undefined);
+  mockStorageRemove.mockResolvedValue(undefined);
 });
 
 /** Flush a few microtask / macrotask ticks so in-flight awaits can progress. */
@@ -310,6 +313,52 @@ describe('setupTransactionProcessor', () => {
         stuckTxHealDiagnostic: expect.objectContaining({ consecutiveFailures: 5 })
       })
     );
+  });
+
+  it('clears the persisted diagnostic on a successful heal so consecutiveFailures is truly consecutive (issue #254)', async () => {
+    // Without a clear-on-success, `consecutiveFailures` is really a monotonic
+    // total: a recovered DB would leave a stale record lingering forever,
+    // implying a wedged heal that has actually healed. A successful heal must
+    // remove the diagnostic key so the counter is truly consecutive.
+    const mod = await import('./transaction-processor');
+    mod.setupTransactionProcessor();
+    await flushAsync();
+    const listener = mockAlarmsOnAlarm.addListener.mock.calls[0][0];
+
+    // A tick fails and persists the diagnostic...
+    mockCancelStuckTransactions.mockRejectedValueOnce(new Error('still broken'));
+    mockStorageSet.mockClear();
+    listener({ name: 'miden-tx-stuck-heal' });
+    await flushAsync();
+    expect(mockStorageSet).toHaveBeenCalled();
+
+    // ...then a later tick succeeds and must clear the lingering diagnostic.
+    mockStorageRemove.mockClear();
+    mockCancelStuckTransactions.mockResolvedValueOnce(undefined);
+    listener({ name: 'miden-tx-stuck-heal' });
+    await flushAsync();
+
+    expect(mockStorageRemove).toHaveBeenCalledWith('stuckTxHealDiagnostic');
+  });
+
+  it('clears the persisted diagnostic when the heal succeeds after a Dexie re-open (issue #254)', async () => {
+    const mod = await import('./transaction-processor');
+    mod.setupTransactionProcessor();
+    await flushAsync();
+    mockCancelStuckTransactions.mockClear();
+    mockStorageRemove.mockClear();
+
+    // First read rejects with DatabaseClosedError; the retry after re-open
+    // succeeds — the post-reopen success path must also clear the diagnostic.
+    const dbClosed = new Error('database is closed');
+    dbClosed.name = 'DatabaseClosedError';
+    mockCancelStuckTransactions.mockRejectedValueOnce(dbClosed).mockResolvedValueOnce(undefined);
+
+    const listener = mockAlarmsOnAlarm.addListener.mock.calls[0][0];
+    listener({ name: 'miden-tx-stuck-heal' });
+    await flushAsync();
+
+    expect(mockStorageRemove).toHaveBeenCalledWith('stuckTxHealDiagnostic');
   });
 
   it('escalates a non-DatabaseClosedError without attempting a Dexie re-open (issue #254)', async () => {

--- a/src/lib/miden/back/transaction-processor.test.ts
+++ b/src/lib/miden/back/transaction-processor.test.ts
@@ -43,6 +43,16 @@ jest.mock('lib/miden/transaction', () => ({
   cancelStuckTransactions: (...args: unknown[]) => mockCancelStuckTransactions(...args)
 }));
 
+const mockDbOpen = jest.fn();
+jest.mock('lib/miden/repo', () => ({
+  db: { open: (...args: unknown[]) => mockDbOpen(...args) }
+}));
+
+const mockTrackEvent = jest.fn();
+jest.mock('./analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args)
+}));
+
 const mockWithUnlocked = jest.fn();
 jest.mock('./store', () => ({
   withUnlocked: (fn: (ctx: unknown) => unknown) => mockWithUnlocked(fn)
@@ -59,6 +69,8 @@ beforeEach(() => {
   mockGetAllUncompletedTransactions.mockResolvedValue([]);
   mockSafeGenerateTransactionsLoop.mockResolvedValue({ success: true });
   mockCancelStuckTransactions.mockResolvedValue(undefined);
+  mockDbOpen.mockResolvedValue(undefined);
+  mockTrackEvent.mockResolvedValue(undefined);
 });
 
 /** Flush a few microtask / macrotask ticks so in-flight awaits can progress. */
@@ -215,6 +227,67 @@ describe('setupTransactionProcessor', () => {
     const listener = mockAlarmsOnAlarm.addListener.mock.calls[0][0];
     listener({ name: 'miden-tx-stuck-heal' });
     expect(mockCancelStuckTransactions).toHaveBeenCalled();
+  });
+
+  it('re-opens Dexie and retries the heal once when it hits DatabaseClosedError (issue #254)', async () => {
+    const mod = await import('./transaction-processor');
+    mod.setupTransactionProcessor();
+    await flushAsync();
+    mockCancelStuckTransactions.mockClear();
+    mockDbOpen.mockClear();
+
+    // An MV3 SW respawn can leave a stale/closed Dexie handle; the first read
+    // rejects with DatabaseClosedError, the retry after re-open succeeds.
+    const dbClosed = new Error('database is closed');
+    dbClosed.name = 'DatabaseClosedError';
+    mockCancelStuckTransactions.mockRejectedValueOnce(dbClosed).mockResolvedValueOnce(undefined);
+
+    const listener = mockAlarmsOnAlarm.addListener.mock.calls[0][0];
+    listener({ name: 'miden-tx-stuck-heal' });
+    await flushAsync();
+
+    expect(mockDbOpen).toHaveBeenCalledTimes(1);
+    expect(mockCancelStuckTransactions).toHaveBeenCalledTimes(2);
+    // A recovered heal must not escalate.
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('escalates via trackEvent when the heal keeps failing after re-open (issue #254)', async () => {
+    const mod = await import('./transaction-processor');
+    mod.setupTransactionProcessor();
+    await flushAsync();
+    mockCancelStuckTransactions.mockClear();
+    mockTrackEvent.mockClear();
+
+    const dbClosed = new Error('database is closed');
+    dbClosed.name = 'DatabaseClosedError';
+    // Rejects persistently — the re-open + retry still fails.
+    mockCancelStuckTransactions.mockRejectedValue(dbClosed);
+
+    const listener = mockAlarmsOnAlarm.addListener.mock.calls[0][0];
+    listener({ name: 'miden-tx-stuck-heal' });
+    await flushAsync();
+
+    // A silently-failing heal must be surfaced, not swallowed.
+    expect(mockTrackEvent).toHaveBeenCalledWith(expect.objectContaining({ event: expect.stringContaining('Heal') }));
+  });
+
+  it('escalates a non-DatabaseClosedError without attempting a Dexie re-open (issue #254)', async () => {
+    const mod = await import('./transaction-processor');
+    mod.setupTransactionProcessor();
+    await flushAsync();
+    mockCancelStuckTransactions.mockClear();
+    mockDbOpen.mockClear();
+    mockTrackEvent.mockClear();
+
+    mockCancelStuckTransactions.mockRejectedValueOnce(new Error('some other failure'));
+
+    const listener = mockAlarmsOnAlarm.addListener.mock.calls[0][0];
+    listener({ name: 'miden-tx-stuck-heal' });
+    await flushAsync();
+
+    expect(mockDbOpen).not.toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalled();
   });
 
   it('keepalive alarm tick does not invoke cancelStuckTransactions', async () => {

--- a/src/lib/miden/back/transaction-processor.ts
+++ b/src/lib/miden/back/transaction-processor.ts
@@ -232,6 +232,28 @@ async function reportHealFailure(err: unknown): Promise<void> {
 }
 
 /**
+ * Clear the persisted heal-failure diagnostic after a successful heal.
+ *
+ * `reportHealFailure` bumps `consecutiveFailures` but never resets it, so
+ * without this a record persisted while the DB was down would linger forever
+ * once the DB recovers — implying a wedged heal that has actually healed, and
+ * turning `consecutiveFailures` into a monotonic total. Removing the key on a
+ * successful heal keeps the counter truly *consecutive*. The `remove` is
+ * idempotent (a no-op when nothing is stored) and fully swallowed on error so
+ * clearing can never break the heal (and so non-extension bundles never touch
+ * `browser.storage`).
+ */
+async function clearHealDiagnostic(): Promise<void> {
+  try {
+    const browser = await getBrowser();
+    await browser.storage.local.remove(STUCK_TX_HEAL_DIAGNOSTIC_KEY);
+  } catch {
+    // No `browser.storage` (non-extension bundle) or a remove failure — a stale
+    // record, if any, is harmless and the next failed heal re-persists a fresh one.
+  }
+}
+
+/**
  * Run the stuck-transaction self-heal, recovering from a stale Dexie handle.
  *
  * An MV3 SW respawn can leave the Dexie connection closed, so the first read
@@ -243,11 +265,15 @@ async function reportHealFailure(err: unknown): Promise<void> {
 async function healStuckTransactions(): Promise<void> {
   try {
     await cancelStuckTransactions();
+    // First-call success: clear any diagnostic left by earlier failed ticks.
+    await clearHealDiagnostic();
   } catch (err) {
     if ((err as { name?: unknown })?.name === 'DatabaseClosedError') {
       try {
         await Repo.db.open();
         await cancelStuckTransactions();
+        // Post-reopen retry success: clear any lingering diagnostic too.
+        await clearHealDiagnostic();
         return;
       } catch (retryErr) {
         await reportHealFailure(retryErr);

--- a/src/lib/miden/back/transaction-processor.ts
+++ b/src/lib/miden/back/transaction-processor.ts
@@ -3,7 +3,6 @@
 // init_store → init_fetchBalances → init_prices → init_store (via __esmMin async factories).
 // Direct import avoids this because transaction-processor doesn't need the
 // activity module's full init chain.
-import { AnalyticsEventCategory } from 'lib/miden/analytics-types';
 import { type GuardianAccountProvider } from 'lib/miden/front/guardian-manager';
 import * as Repo from 'lib/miden/repo';
 import {
@@ -187,33 +186,47 @@ export async function startTransactionProcessing(): Promise<void> {
   }
 }
 
+// Diagnostic record persisted to `chrome.storage.local` when the self-heal
+// keeps failing. Read it from the SW DevTools console with
+// `chrome.storage.local.get('stuckTxHealDiagnostic')`.
+const STUCK_TX_HEAL_DIAGNOSTIC_KEY = 'stuckTxHealDiagnostic';
+interface StuckTxHealDiagnostic {
+  lastFailureAt: number;
+  message: string;
+  consecutiveFailures: number;
+}
+
 /**
  * Escalate a self-heal failure that survived the Dexie re-open + retry.
  *
- * A bare `console.warn` is invisible without an open DevTools session, so a
- * silently-wedged heal is undiagnosable in the field. Surface it on the
- * shipped telemetry sink (Segment) instead. The analytics module is loaded
- * lazily and guarded exactly like `getBrowser()`: `back/analytics.ts` throws
- * at module load when the Segment write key is absent and pulls in a Node
- * SDK, so it must never be evaluated on the mobile / desktop bundle's load
- * path — only inside this SW-only error branch, and even then failures to
- * report are swallowed so telemetry can never break the heal itself.
+ * A bare `console.error` is invisible without an open DevTools session, so a
+ * silently-wedged heal is undiagnosable in the field. The obvious escalation
+ * sink — Segment via `back/analytics.ts` — is DEAD in the shipped SW build:
+ * that module throws at load unless `ALEO_WALLET_SEGMENT_WRITE_KEY` is set, and
+ * the background Vite build (`vite.background.config.ts`) never defines it, so a
+ * dynamic `import('./analytics')` here would only ever reject and emit nothing.
+ * Escalating to a Dexie table is just as self-defeating: the heal usually fails
+ * BECAUSE IndexedDB is down. Persist a small diagnostic to `chrome.storage.local`
+ * instead — it works in the MV3 service worker and survives a broken IndexedDB —
+ * bumping a consecutive-failure counter so a persistently-wedged heal is visible.
+ * Loaded lazily via `getBrowser()` and fully swallowed on error so escalation
+ * can never break the heal itself (and so non-extension bundles never touch it).
  */
 async function reportHealFailure(err: unknown): Promise<void> {
   console.error('[TransactionProcessor] Stuck-tx self-heal failed:', err);
   try {
-    const { trackEvent } = await import('./analytics');
-    await trackEvent({
-      userId: 'service-worker',
-      rpc: undefined,
-      event: 'StuckTxHealFailed',
-      category: AnalyticsEventCategory.General,
-      properties: {
-        error: err instanceof Error ? `${err.name}: ${err.message}` : String(err)
-      }
-    });
+    const browser = await getBrowser();
+    const previous = (await browser.storage.local.get(STUCK_TX_HEAL_DIAGNOSTIC_KEY))[STUCK_TX_HEAL_DIAGNOSTIC_KEY] as
+      | StuckTxHealDiagnostic
+      | undefined;
+    const diagnostic: StuckTxHealDiagnostic = {
+      lastFailureAt: Date.now(),
+      message: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      consecutiveFailures: (previous?.consecutiveFailures ?? 0) + 1
+    };
+    await browser.storage.local.set({ [STUCK_TX_HEAL_DIAGNOSTIC_KEY]: diagnostic });
   } catch {
-    // Telemetry sink unavailable (no write key / non-extension bundle) —
+    // No `browser.storage` (non-extension bundle) or a storage write failure —
     // the console.error above remains as the fallback diagnostic surface.
   }
 }

--- a/src/lib/miden/back/transaction-processor.ts
+++ b/src/lib/miden/back/transaction-processor.ts
@@ -3,7 +3,9 @@
 // init_store → init_fetchBalances → init_prices → init_store (via __esmMin async factories).
 // Direct import avoids this because transaction-processor doesn't need the
 // activity module's full init chain.
+import { AnalyticsEventCategory } from 'lib/miden/analytics-types';
 import { type GuardianAccountProvider } from 'lib/miden/front/guardian-manager';
+import * as Repo from 'lib/miden/repo';
 import {
   cancelStuckTransactions,
   getAllUncompletedTransactions,
@@ -186,6 +188,64 @@ export async function startTransactionProcessing(): Promise<void> {
 }
 
 /**
+ * Escalate a self-heal failure that survived the Dexie re-open + retry.
+ *
+ * A bare `console.warn` is invisible without an open DevTools session, so a
+ * silently-wedged heal is undiagnosable in the field. Surface it on the
+ * shipped telemetry sink (Segment) instead. The analytics module is loaded
+ * lazily and guarded exactly like `getBrowser()`: `back/analytics.ts` throws
+ * at module load when the Segment write key is absent and pulls in a Node
+ * SDK, so it must never be evaluated on the mobile / desktop bundle's load
+ * path — only inside this SW-only error branch, and even then failures to
+ * report are swallowed so telemetry can never break the heal itself.
+ */
+async function reportHealFailure(err: unknown): Promise<void> {
+  console.error('[TransactionProcessor] Stuck-tx self-heal failed:', err);
+  try {
+    const { trackEvent } = await import('./analytics');
+    await trackEvent({
+      userId: 'service-worker',
+      rpc: undefined,
+      event: 'StuckTxHealFailed',
+      category: AnalyticsEventCategory.General,
+      properties: {
+        error: err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+      }
+    });
+  } catch {
+    // Telemetry sink unavailable (no write key / non-extension bundle) —
+    // the console.error above remains as the fallback diagnostic surface.
+  }
+}
+
+/**
+ * Run the stuck-transaction self-heal, recovering from a stale Dexie handle.
+ *
+ * An MV3 SW respawn can leave the Dexie connection closed, so the first read
+ * inside `cancelStuckTransactions` rejects with `DatabaseClosedError` and,
+ * without recovery, every subsequent alarm tick fails identically and the
+ * heal never progresses (issue #254). Re-open the connection once and retry;
+ * if that (or any other error) still fails, escalate rather than swallow.
+ */
+async function healStuckTransactions(): Promise<void> {
+  try {
+    await cancelStuckTransactions();
+  } catch (err) {
+    if ((err as { name?: unknown })?.name === 'DatabaseClosedError') {
+      try {
+        await Repo.db.open();
+        await cancelStuckTransactions();
+        return;
+      } catch (retryErr) {
+        await reportHealFailure(retryErr);
+        return;
+      }
+    }
+    await reportHealFailure(err);
+  }
+}
+
+/**
  * Set up on SW startup: check for orphaned transactions and resume processing.
  */
 export function setupTransactionProcessor(): void {
@@ -203,9 +263,7 @@ export function setupTransactionProcessor(): void {
           // processingStartedAt is past MAX_WAIT_BEFORE_CANCEL. This is
           // independent of `startTransactionProcessing` so we don't depend
           // on the SW being mid-loop when an orphan ages out.
-          cancelStuckTransactions().catch(err =>
-            console.warn('[TransactionProcessor] Stuck-tx heal alarm error:', err)
-          );
+          void healStuckTransactions();
         }
       });
       // Long-period self-heal alarm. Chrome MV3 clamps periodInMinutes to
@@ -246,5 +304,5 @@ export function setupTransactionProcessor(): void {
   // orphan is reaped even when nothing else is queued. (The alarm above
   // catches the steady state; this catches the very-first SW respawn
   // after long idle, before the first alarm tick.)
-  cancelStuckTransactions().catch(err => console.warn('[TransactionProcessor] Startup heal error:', err));
+  void healStuckTransactions();
 }


### PR DESCRIPTION
## Summary

The stuck-transaction self-heal (`cancelStuckTransactions`) runs both on service-worker startup and on the `miden-tx-stuck-heal` alarm. Both call sites attached a bare `.catch(err => console.warn(...))`. That handler swallowed every failure with no recovery and no field-visible diagnostic, so a wedged heal could recur silently on every alarm tick forever.

The most common wedge is a stale Dexie handle: an MV3 service-worker respawn can leave the `TridentMain` connection closed, so the first read inside `cancelStuckTransactions` rejects with `DatabaseClosedError`. With the old handler, every subsequent alarm tick failed identically and the heal never made progress.

## Root cause

- `console.warn` output is invisible without an attached DevTools session, so a persistently-failing heal was undiagnosable in the field.
- Neither call site attempted to recover the Dexie connection, so a closed handle turned a transient condition into a permanent one — the heal never re-opened the DB.

## Fix

Introduce a single `healStuckTransactions()` wrapper used by both the alarm listener and the startup path:

- On `DatabaseClosedError`, re-open the Dexie connection once (`Repo.db.open()`) and retry the heal. This recovers the common MV3 respawn case without escalation.
- If the retry still fails, or the original error is not a `DatabaseClosedError`, escalate via `reportHealFailure()` instead of swallowing it.
- `reportHealFailure()` logs `console.error` and additionally surfaces a `StuckTxHealFailed` event on the shipped telemetry sink (Segment). The analytics module is imported lazily and guarded exactly like `getBrowser()` — it throws at module load when the Segment write key is absent and pulls in a Node SDK, so it is only ever evaluated inside this service-worker-only error branch, and reporting failures are themselves swallowed so telemetry can never break the heal.

## Testing

- `npx jest src/lib/miden/back/transaction-processor.test.ts --no-cache --runInBand` — 19 passed. New cases cover: re-open + retry succeeds on `DatabaseClosedError` (no escalation), persistent failure after re-open escalates via `trackEvent`, and a non-`DatabaseClosedError` escalates without attempting a re-open.
- `npx eslint src/lib/miden/back/transaction-processor.ts src/lib/miden/back/transaction-processor.test.ts --max-warnings 0` — clean.

Closes #254