### PR TITLE
fix: stop double-adding chain height to note reclaim height (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.9 (TBD)
+
+### Fixes
+
+* [FIX][all] **Scheduled recall/reclaim height is no longer double-counted.** The send UI produced an absolute reclaim block height while the SDK interface layer added the current chain height again, so a note's on-chain reclaim height landed at roughly twice the chain height and the recall stayed un-executable for days. The UI now emits a relative offset and the interface layer resolves it against the current height exactly once.
+
 ## 1.15.8 (2026-07-21)
 
 ### Features

--- a/src/lib/miden/back/dapp.branches.test.ts
+++ b/src/lib/miden/back/dapp.branches.test.ts
@@ -383,6 +383,25 @@ describe('requestSendTransaction — mobile error branches', () => {
       transaction: { ...validTx, recallBlocks: 100 }
     } as never);
     expect(res.type).toBe(MidenDAppMessageType.SendTransactionResponse);
+    expect(mockRequestConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({ transactionMessages: expect.arrayContaining(['Recall Blocks, 100']) })
+    );
+  });
+
+  // Regression guard for #308: a 0 recall offset means "reclaimable at the
+  // current height" and IS honored on execution, so the preview must surface
+  // the row (value 0) rather than hide it behind a truthiness check.
+  it('surfaces the recallBlocks row in preview when the offset is 0', async () => {
+    mockInitiateSendTransaction.mockResolvedValue('tx-recall-zero');
+    const res = await dapp.requestSendTransaction('https://miden.xyz', {
+      type: MidenDAppMessageType.SendTransactionRequest,
+      sourcePublicKey: 'miden-account-1',
+      transaction: { ...validTx, recallBlocks: 0 }
+    } as never);
+    expect(res.type).toBe(MidenDAppMessageType.SendTransactionResponse);
+    expect(mockRequestConfirmation).toHaveBeenCalledWith(
+      expect.objectContaining({ transactionMessages: expect.arrayContaining(['Recall Blocks, 0']) })
+    );
   });
 });
 

--- a/src/lib/miden/back/dapp.ts
+++ b/src/lib/miden/back/dapp.ts
@@ -1619,7 +1619,7 @@ function formatSendTransactionPreview(transaction: SendTransaction): string[] {
     `Note Type, ${capitalizeFirstLetter(transaction.noteType)}`
   ];
 
-  if (transaction.recallBlocks) {
+  if (transaction.recallBlocks != null) {
     tsTexts.push(`Recall Blocks, ${transaction.recallBlocks}`);
   }
 

--- a/src/lib/miden/db/types.ts
+++ b/src/lib/miden/db/types.ts
@@ -175,6 +175,10 @@ export class SendTransaction implements ITransaction {
   displayMessage?: string;
   displayIcon: ITransactionIcon;
   delegateTransaction?: boolean;
+  // `recallBlocks` is a RELATIVE block offset (blocks from send time until the
+  // note becomes reclaimable). The absolute P2IDE reclaim height is derived once,
+  // in MidenClientInterface.sendTransaction, as `sync.blockNum() + recallBlocks`.
+  // Do NOT pre-add the current height here or it gets counted twice (see #308).
   extraInputs: { recallBlocks?: number } = {
     recallBlocks: undefined
   };

--- a/src/lib/miden/sdk/miden-client-interface.test.ts
+++ b/src/lib/miden/sdk/miden-client-interface.test.ts
@@ -395,6 +395,51 @@ describe('MidenClientInterface', () => {
 
     expect(result).toBe(fakeTransactionResult);
     expect(fakeMidenClient.transactions.send).toHaveBeenCalled();
+    // No recall requested → the note must be broadcast without a reclaim height.
+    expect(fakeMidenClient.transactions.send).toHaveBeenCalledWith(
+      expect.objectContaining({ reclaimAfter: undefined })
+    );
+    expect(fakeMidenClient.sync).not.toHaveBeenCalled();
+  });
+
+  // Regression guard for #308 (edge case): a RELATIVE offset of 0 means "reclaimable
+  // right now" (the user kept "today" and picked a time that is now/past, so
+  // `dateTimeToRecallBlocks` returned 0). It must resolve to `reclaimAfter = current
+  // height + 0`, NOT be dropped — otherwise a NON-reclaimable note is broadcast and
+  // the sender can never reclaim it.
+  it('treats a zero recallBlocks offset as immediately reclaimable, not non-reclaimable (#308)', async () => {
+    const fakeMidenClient = buildFakeMidenClient({
+      sync: jest.fn(async () => ({ blockNum: () => 1000 }))
+    });
+
+    jest.doMock('./helpers', () => ({
+      getBech32AddressFromAccountId: (id: any) => String(id)
+    }));
+    jest.doMock('@miden-sdk/miden-sdk/lazy', () => ({
+      TransactionProver: {
+        newLocalProver: jest.fn(() => 'local')
+      }
+    }));
+    jest.doMock('lib/miden/activity/connectivity-state', () => ({
+      markConnectivityIssue: jest.fn(),
+      clearConnectivityIssue: jest.fn()
+    }));
+
+    const { MidenClientInterface } = await import('./miden-client-interface');
+    const client = MidenClientInterface.fromClient(fakeMidenClient as any, 'testnet');
+
+    await client.sendTransaction({
+      accountId: 'sender',
+      secondaryAccountId: 'recipient',
+      faucetId: 'faucet',
+      noteType: 'public' as any,
+      amount: BigInt(100),
+      extraInputs: { recallBlocks: 0 }
+    } as any);
+
+    // reclaimAfter must be H + 0 = 1000 (reclaimable now), NOT undefined (never).
+    expect(fakeMidenClient.transactions.send).toHaveBeenCalledWith(expect.objectContaining({ reclaimAfter: 1000 }));
+    expect(fakeMidenClient.sync).toHaveBeenCalledTimes(1);
   });
 
   // Regression guard for #308: `extraInputs.recallBlocks` is a RELATIVE offset.

--- a/src/lib/miden/sdk/miden-client-interface.test.ts
+++ b/src/lib/miden/sdk/miden-client-interface.test.ts
@@ -397,6 +397,48 @@ describe('MidenClientInterface', () => {
     expect(fakeMidenClient.transactions.send).toHaveBeenCalled();
   });
 
+  // Regression guard for #308: `extraInputs.recallBlocks` is a RELATIVE offset.
+  // The interface must add the current chain height exactly ONCE to derive the
+  // note's absolute reclaim height. A double-add (height baked in by the UI AND
+  // added again here) put the on-chain reclaim height at ~2x the chain height,
+  // so every sender-side reclaim before that (days out) failed the kernel's
+  // ERR_P2IDE_RECLAIM_HEIGHT_NOT_REACHED assertion.
+  it('adds the current chain height exactly once to a relative recallBlocks offset (#308)', async () => {
+    // Fixed sync height H = 1000; a 30-min offset is 1800s / 3s = 600 blocks.
+    const fakeMidenClient = buildFakeMidenClient({
+      sync: jest.fn(async () => ({ blockNum: () => 1000 }))
+    });
+
+    jest.doMock('./helpers', () => ({
+      getBech32AddressFromAccountId: (id: any) => String(id)
+    }));
+    jest.doMock('@miden-sdk/miden-sdk/lazy', () => ({
+      TransactionProver: {
+        newLocalProver: jest.fn(() => 'local')
+      }
+    }));
+    jest.doMock('lib/miden/activity/connectivity-state', () => ({
+      markConnectivityIssue: jest.fn(),
+      clearConnectivityIssue: jest.fn()
+    }));
+
+    const { MidenClientInterface } = await import('./miden-client-interface');
+    const client = MidenClientInterface.fromClient(fakeMidenClient as any, 'testnet');
+
+    await client.sendTransaction({
+      accountId: 'sender',
+      secondaryAccountId: 'recipient',
+      faucetId: 'faucet',
+      noteType: 'public' as any,
+      amount: BigInt(100),
+      extraInputs: { recallBlocks: 600 }
+    } as any);
+
+    // reclaimAfter must be H + offset = 1600, NOT H + (H + offset) = 2600.
+    expect(fakeMidenClient.transactions.send).toHaveBeenCalledWith(expect.objectContaining({ reclaimAfter: 1600 }));
+    expect(fakeMidenClient.sync).toHaveBeenCalledTimes(1);
+  });
+
   it('consumeNoteId returns TransactionResult', async () => {
     const fakeMidenClient = buildFakeMidenClient();
 

--- a/src/lib/miden/sdk/miden-client-interface.ts
+++ b/src/lib/miden/sdk/miden-client-interface.ts
@@ -478,10 +478,13 @@ export class MidenClientInterface {
     const { accountId, secondaryAccountId, faucetId, noteType, amount, extraInputs } = dbTransaction;
 
     let reclaimAfter: number | undefined;
-    if (extraInputs?.recallBlocks) {
+    if (extraInputs?.recallBlocks != null) {
       // `recallBlocks` is a RELATIVE offset (blocks from now); the current chain
       // height is added here, in exactly ONE place, to derive the note's absolute
       // P2IDE reclaim height. Callers (send UI + dApp) MUST pass a relative offset.
+      // A 0 offset means "reclaimable right now" (current height + 0), so we guard
+      // on `!= null` — treating 0 as falsy would drop it and broadcast a note the
+      // sender can NEVER reclaim (see #308).
       const syncResult = await this.client.sync();
       reclaimAfter = syncResult.blockNum() + extraInputs.recallBlocks;
     }

--- a/src/lib/miden/sdk/miden-client-interface.ts
+++ b/src/lib/miden/sdk/miden-client-interface.ts
@@ -479,6 +479,9 @@ export class MidenClientInterface {
 
     let reclaimAfter: number | undefined;
     if (extraInputs?.recallBlocks) {
+      // `recallBlocks` is a RELATIVE offset (blocks from now); the current chain
+      // height is added here, in exactly ONE place, to derive the note's absolute
+      // P2IDE reclaim height. Callers (send UI + dApp) MUST pass a relative offset.
       const syncResult = await this.client.sync();
       reclaimAfter = syncResult.blockNum() + extraInputs.recallBlocks;
     }

--- a/src/screens/send-flow/RecallCalendarDrawer.test.tsx
+++ b/src/screens/send-flow/RecallCalendarDrawer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { dateTimeToRecallBlocks, RecallCalendarDrawer, SECONDS_PER_BLOCK } from './RecallCalendarDrawer';
 
@@ -70,26 +70,6 @@ jest.mock('lib/ui/calendar', () => ({
   )
 }));
 
-// `lib/miden-chain/constants` touches WASM-backed `Endpoint`/`MidenClient`; stub
-// the two functions the component actually calls.
-const ensureSdkWasmReady = jest.fn<Promise<void>, []>();
-const getRpcEndpoint = jest.fn(() => 'rpc-endpoint');
-jest.mock('lib/miden-chain/constants', () => ({
-  ensureSdkWasmReady: () => ensureSdkWasmReady(),
-  getRpcEndpoint: () => getRpcEndpoint()
-}));
-
-// RpcClient from the lazy SDK subpath. The default moduleNameMapper points this
-// at `wasmMock.js` (which has no RpcClient), so provide our own factory.
-const getBlockHeaderByNumber = jest.fn<Promise<{ blockNum: () => number }>, []>();
-const RpcClientCtor = jest.fn();
-jest.mock('@miden-sdk/miden-sdk/lazy', () => ({
-  RpcClient: function RpcClient(endpoint: unknown) {
-    RpcClientCtor(endpoint);
-    return { getBlockHeaderByNumber: () => getBlockHeaderByNumber() };
-  }
-}));
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -107,35 +87,18 @@ const makeProps = (overrides: Partial<Props> = {}): Props => ({
   ...overrides
 });
 
-/** A never-resolving deferred so we can control effect timing. */
-const deferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-};
-
-/** Flush the mount effect's promise chain (ensureSdkWasmReady → rpc → setSyncHeight). */
-const flushEffects = () => act(async () => void (await new Promise(r => setTimeout(r, 0))));
-
-/** Render and settle the mount effect so no `setSyncHeight` fires outside `act`. */
-const renderDrawer = async (props: Props = makeProps()) => {
-  const utils = render(<RecallCalendarDrawer {...props} />);
-  await flushEffects();
-  return utils;
-};
+/**
+ * Render the drawer. The component is fully synchronous (no mount fetch), but
+ * this returns a resolved Promise so the existing `await renderDrawer(...)` call
+ * sites stay valid.
+ */
+const renderDrawer = (props: Props = makeProps()) => Promise.resolve(render(<RecallCalendarDrawer {...props} />));
 
 /** First-of-current-month, matching the component's initial `calendarMonth`. */
 const firstOfThisMonth = () => new Date(new Date().getFullYear(), new Date().getMonth(), 1);
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Default: WASM ready, block header resolves to a fixed height.
-  ensureSdkWasmReady.mockResolvedValue(undefined);
-  getBlockHeaderByNumber.mockResolvedValue({ blockNum: () => 12345 });
 });
 
 // ---------------------------------------------------------------------------
@@ -164,21 +127,21 @@ describe('dateTimeToRecallBlocks', () => {
     jest.useRealTimers();
   });
 
-  it('returns the current block for a past/now target (<= 0 seconds until target)', () => {
+  it('returns a zero offset for a past/now target (<= 0 seconds until target)', () => {
     const past = new Date(Date.now() - 60_000);
-    expect(dateTimeToRecallBlocks(past, 500)).toBe(500);
+    expect(dateTimeToRecallBlocks(past)).toBe(0);
   });
 
-  it('adds one block per SECONDS_PER_BLOCK seconds for a future target', () => {
-    // 30s in the future → floor(1000 + 30/3) = 1010.
+  it('returns one block of offset per SECONDS_PER_BLOCK seconds for a future target', () => {
+    // 30s in the future → floor(30/3) = 10 (a RELATIVE offset, not an absolute height).
     const future = new Date(Date.now() + 30_000);
-    expect(dateTimeToRecallBlocks(future, 1000)).toBe(1010);
+    expect(dateTimeToRecallBlocks(future)).toBe(10);
   });
 
   it('floors the fractional block count', () => {
-    // 8s in the future → floor(0 + 8/3) = floor(2.66..) = 2.
+    // 8s in the future → floor(8/3) = floor(2.66..) = 2.
     const future = new Date(Date.now() + 8_000);
-    expect(dateTimeToRecallBlocks(future, 0)).toBe(2);
+    expect(dateTimeToRecallBlocks(future)).toBe(2);
   });
 });
 
@@ -205,15 +168,6 @@ describe('RecallCalendarDrawer', () => {
     ['30mins', '1hour', '5hours', 'tomorrow', 'inAWeek', 'in2Weeks'].forEach(label => {
       expect(screen.getByText(label)).toBeInTheDocument();
     });
-  });
-
-  it('fetches the block height on mount and constructs an RpcClient with the endpoint', async () => {
-    render(<RecallCalendarDrawer {...makeProps()} />);
-
-    await waitFor(() => expect(getBlockHeaderByNumber).toHaveBeenCalledTimes(1));
-    expect(ensureSdkWasmReady).toHaveBeenCalledTimes(1);
-    expect(getRpcEndpoint).toHaveBeenCalledTimes(1);
-    expect(RpcClientCtor).toHaveBeenCalledWith('rpc-endpoint');
   });
 
   it('reflects a passed recallTime and forwards edits to onRecallTimeChange', async () => {
@@ -267,30 +221,26 @@ describe('RecallCalendarDrawer', () => {
     expect(screen.queryByText('confirm')).not.toBeInTheDocument();
   });
 
-  it('confirm applies the selection, computes blocks, and closes the drawer', async () => {
+  it('confirm applies the selection, computes a relative block offset, and closes the drawer', async () => {
     const recallDate = new Date('2035-06-15T00:00:00');
     const props = makeProps({ recallDate, recallTime: '14:30' });
-    render(<RecallCalendarDrawer {...props} />);
-
-    // Wait for the mount effect to install the fetched sync height (12345).
-    await waitFor(() => expect(getBlockHeaderByNumber).toHaveBeenCalled());
+    await renderDrawer(props);
 
     fireEvent.click(screen.getByText('confirm'));
 
     expect(props.onRecallDateChange).toHaveBeenCalledWith(recallDate);
     expect(props.onRecallTimeChange).toHaveBeenCalledWith('14:30');
-    // A far-future date → blocks strictly above the fetched sync height.
+    // A far-future date → a large positive RELATIVE offset (blocks from now).
     const blocksArg = (props.onRecallBlocksChange as jest.Mock).mock.calls[0][0];
     expect(typeof blocksArg).toBe('string');
-    expect(Number(blocksArg)).toBeGreaterThan(12345);
+    expect(Number(blocksArg)).toBeGreaterThan(0);
     expect(props.onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it('confirm handles a time with no minutes segment (minutes ?? 0 fallback)', async () => {
     const recallDate = new Date('2035-06-15T00:00:00');
     const props = makeProps({ recallDate, recallTime: '5' });
-    render(<RecallCalendarDrawer {...props} />);
-    await waitFor(() => expect(getBlockHeaderByNumber).toHaveBeenCalled());
+    await renderDrawer(props);
 
     fireEvent.click(screen.getByText('confirm'));
 
@@ -301,8 +251,7 @@ describe('RecallCalendarDrawer', () => {
   it('confirm handles an empty time string without throwing', async () => {
     const recallDate = new Date('2035-06-15T00:00:00');
     const props = makeProps({ recallDate, recallTime: '' });
-    render(<RecallCalendarDrawer {...props} />);
-    await waitFor(() => expect(getBlockHeaderByNumber).toHaveBeenCalled());
+    await renderDrawer(props);
 
     fireEvent.click(screen.getByText('confirm'));
     expect(props.onOpenChange).toHaveBeenCalledWith(false);
@@ -312,8 +261,7 @@ describe('RecallCalendarDrawer', () => {
     'preset "%s" applies a computed date/time and closes the drawer',
     async label => {
       const props = makeProps();
-      render(<RecallCalendarDrawer {...props} />);
-      await waitFor(() => expect(getBlockHeaderByNumber).toHaveBeenCalled());
+      await renderDrawer(props);
 
       fireEvent.click(screen.getByText(label));
 
@@ -335,54 +283,5 @@ describe('RecallCalendarDrawer', () => {
     fireEvent.click(screen.getByTestId('drawer-onOpenChange-false'));
 
     expect(props.onOpenChange).toHaveBeenCalledWith(false);
-  });
-
-  // -- Effect cancellation / error branches ---------------------------------
-
-  it('does not set state when unmounted before ensureSdkWasmReady resolves', async () => {
-    const d = deferred<void>();
-    ensureSdkWasmReady.mockReturnValue(d.promise);
-
-    const { unmount } = render(<RecallCalendarDrawer {...makeProps()} />);
-    unmount();
-
-    // Resolving after unmount hits the `if (cancelled) return;` early exit.
-    await act(async () => {
-      d.resolve();
-      await Promise.resolve();
-    });
-
-    expect(getBlockHeaderByNumber).not.toHaveBeenCalled();
-  });
-
-  it('does not set state when unmounted before the block header resolves', async () => {
-    ensureSdkWasmReady.mockResolvedValue(undefined);
-    const d = deferred<{ blockNum: () => number }>();
-    getBlockHeaderByNumber.mockReturnValue(d.promise);
-
-    const { unmount } = render(<RecallCalendarDrawer {...makeProps()} />);
-
-    // Let the WASM-ready promise settle so getBlockHeaderByNumber is in flight.
-    await waitFor(() => expect(getBlockHeaderByNumber).toHaveBeenCalledTimes(1));
-
-    unmount();
-
-    // Resolving after unmount hits the `if (!cancelled)` guard around setSyncHeight.
-    await act(async () => {
-      d.resolve({ blockNum: () => 999 });
-      await Promise.resolve();
-    });
-    // No throw / no act warning is the assertion here.
-    expect(true).toBe(true);
-  });
-
-  it('swallows a rejected block-height fetch (catch branch)', async () => {
-    ensureSdkWasmReady.mockRejectedValue(new Error('wasm boom'));
-
-    render(<RecallCalendarDrawer {...makeProps()} />);
-
-    // The rejection is caught; confirm still uses the initial syncHeight of 0.
-    await waitFor(() => expect(ensureSdkWasmReady).toHaveBeenCalled());
-    expect(getBlockHeaderByNumber).not.toHaveBeenCalled();
   });
 });

--- a/src/screens/send-flow/RecallCalendarDrawer.tsx
+++ b/src/screens/send-flow/RecallCalendarDrawer.tsx
@@ -1,21 +1,26 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
-import { RpcClient } from '@miden-sdk/miden-sdk/lazy';
 import { addDays, addHours, addMinutes, differenceInSeconds, format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
 import { Icon, IconName } from 'app/icons/v2';
-import { ensureSdkWasmReady, getRpcEndpoint } from 'lib/miden-chain/constants';
 import { Calendar } from 'lib/ui/calendar';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from 'lib/ui/drawer';
 
 export const SECONDS_PER_BLOCK = 3;
 
-/** Block height that the given target date maps to, relative to `currentBlockNum`. */
-export function dateTimeToRecallBlocks(targetDate: Date, currentBlockNum: number): number {
+/**
+ * Number of blocks from *now* until the given target date — a RELATIVE offset,
+ * not an absolute height. The SDK interface (`sendTransaction`) turns this into
+ * the note's absolute P2IDE reclaim height by adding the current sync height:
+ * `reclaimAfter = sync.blockNum() + offset`. Keeping this relative means the
+ * current height is added in exactly one place (see the note on
+ * `SendTransaction.extraInputs.recallBlocks`). Returns 0 for a past/now target.
+ */
+export function dateTimeToRecallBlocks(targetDate: Date): number {
   const secondsUntilTarget = differenceInSeconds(targetDate, new Date());
-  if (secondsUntilTarget <= 0) return currentBlockNum;
-  return Math.floor(currentBlockNum + secondsUntilTarget / SECONDS_PER_BLOCK);
+  if (secondsUntilTarget <= 0) return 0;
+  return Math.floor(secondsUntilTarget / SECONDS_PER_BLOCK);
 }
 
 const RECALL_PRESETS = (t: (key: string) => string) => [
@@ -39,9 +44,10 @@ export interface RecallCalendarDrawerProps {
 
 /**
  * Calendar + preset picker for the send "Expiration Date" (reclaim height).
- * Self-contained: fetches the current block height and converts the chosen
- * date/time into `recallBlocks` via `onRecallBlocksChange`. Extracted from
- * the old SendDetails screen so the Review page can reuse it.
+ * Self-contained: converts the chosen date/time into a RELATIVE `recallBlocks`
+ * offset via `onRecallBlocksChange`. The current chain height is added later,
+ * once, by the SDK interface. Extracted from the old SendDetails screen so the
+ * Review page can reuse it.
  */
 export const RecallCalendarDrawer: React.FC<RecallCalendarDrawerProps> = ({
   open,
@@ -53,27 +59,9 @@ export const RecallCalendarDrawer: React.FC<RecallCalendarDrawerProps> = ({
   onRecallTimeChange
 }) => {
   const { t } = useTranslation();
-  const [syncHeight, setSyncHeight] = useState(0);
   const [calendarMonth, setCalendarMonth] = useState<Date>(
     new Date(new Date().getFullYear(), new Date().getMonth(), 1)
   );
-
-  useEffect(() => {
-    let cancelled = false;
-    // Page-side SDK calls need WASM loaded — see ensureSdkWasmReady comment.
-    ensureSdkWasmReady()
-      .then(() => {
-        if (cancelled) return;
-        const rpc = new RpcClient(getRpcEndpoint());
-        return rpc.getBlockHeaderByNumber().then(header => {
-          if (!cancelled) setSyncHeight(header.blockNum());
-        });
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const applyDateTimeSelection = useCallback(
     (date: Date, time: string) => {
@@ -82,10 +70,10 @@ export const RecallCalendarDrawer: React.FC<RecallCalendarDrawerProps> = ({
       dateWithTime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
       onRecallDateChange(date);
       onRecallTimeChange(time);
-      onRecallBlocksChange(String(dateTimeToRecallBlocks(dateWithTime, syncHeight)));
+      onRecallBlocksChange(String(dateTimeToRecallBlocks(dateWithTime)));
       onOpenChange(false);
     },
-    [onRecallBlocksChange, onOpenChange, onRecallDateChange, onRecallTimeChange, syncHeight]
+    [onRecallBlocksChange, onOpenChange, onRecallDateChange, onRecallTimeChange]
   );
 
   return (

--- a/src/screens/send-flow/ReviewTransaction.test.tsx
+++ b/src/screens/send-flow/ReviewTransaction.test.tsx
@@ -9,7 +9,6 @@ import {
   requestSpeculateInvalidate,
   requestSWTransactionProcessing
 } from 'lib/miden/activity';
-import { ensureSdkWasmReady } from 'lib/miden-chain/constants';
 import { isExtension } from 'lib/platform';
 import { isDelegateProofEnabled } from 'lib/settings/helpers';
 import { goBack, navigate } from 'lib/woozie';
@@ -36,22 +35,6 @@ const mockWalletStoreState = {
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
-
-// RpcClient lives on the lazy SDK subpath (mapped to wasmMock, which has no
-// RpcClient). Provide a controllable class + expose its header fn.
-jest.mock('@miden-sdk/miden-sdk/lazy', () => {
-  const getBlockHeaderByNumber = jest.fn();
-  class RpcClient {
-    endpoint: string;
-    constructor(endpoint: string) {
-      this.endpoint = endpoint;
-    }
-    getBlockHeaderByNumber() {
-      return getBlockHeaderByNumber();
-    }
-  }
-  return { RpcClient, __getBlockHeaderByNumber: getBlockHeaderByNumber };
-});
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
@@ -126,11 +109,6 @@ jest.mock('lib/miden/types', () => ({
   NoteTypeEnum: { Public: 'public', Private: 'private' }
 }));
 
-jest.mock('lib/miden-chain/constants', () => ({
-  ensureSdkWasmReady: jest.fn(),
-  getRpcEndpoint: jest.fn(() => 'https://rpc.example')
-}));
-
 jest.mock('lib/platform', () => ({
   isExtension: jest.fn(() => false)
 }));
@@ -178,7 +156,6 @@ const stringToBigIntMock = stringToBigInt as jest.Mock;
 const initiateMock = initiateSendTransaction as jest.Mock;
 const requestSpeculateInvalidateMock = requestSpeculateInvalidate as jest.Mock;
 const requestSWMock = requestSWTransactionProcessing as jest.Mock;
-const ensureSdkWasmReadyMock = ensureSdkWasmReady as jest.Mock;
 const isExtensionMock = isExtension as jest.Mock;
 const isDelegateProofEnabledMock = isDelegateProofEnabled as jest.Mock;
 const isValidMidenAddressMock = isValidMidenAddress as jest.Mock;
@@ -186,7 +163,6 @@ const goBackMock = goBack as jest.Mock;
 const navigateMock = navigate as jest.Mock;
 const clearSendDraftMock = clearSendDraft as jest.Mock;
 const dateTimeToRecallBlocksMock = dateTimeToRecallBlocks as jest.Mock;
-const getBlockHeaderMock = (jest.requireMock('@miden-sdk/miden-sdk/lazy') as any).__getBlockHeaderByNumber as jest.Mock;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -230,8 +206,6 @@ beforeEach(() => {
   confirmMock.mockResolvedValue(true);
   stringToBigIntMock.mockReturnValue(12345n);
   initiateMock.mockResolvedValue('tx-abc');
-  ensureSdkWasmReadyMock.mockResolvedValue(undefined);
-  getBlockHeaderMock.mockResolvedValue({ blockNum: () => 1000 });
   dateTimeToRecallBlocksMock.mockReturnValue(999);
   isExtensionMock.mockReturnValue(false);
   isDelegateProofEnabledMock.mockReturnValue(false);
@@ -311,23 +285,12 @@ describe('ReviewTransaction — rendering', () => {
     // Recipient row value.
     expect(screen.getByText('0xrecipient')).toBeInTheDocument();
 
-    // Block-height effect resolved -> recallDate seeded -> capitalized relative
-    // label + reclaim note both present.
+    // Mount effect synchronously seeds recallDate with a RELATIVE offset ->
+    // capitalized relative label + reclaim note both present.
     await waitFor(() => expect(screen.getByTestId('row-note')).toBeInTheDocument());
     expect(screen.getByTestId('row-note').textContent).toBe('recallReturnsNote');
     expect(screen.getByText(/^In .+/)).toBeInTheDocument();
-    expect(dateTimeToRecallBlocksMock).toHaveBeenCalledWith(expect.any(Date), 1000);
-  });
-
-  it('shows the "none" expiration label when the block-height fetch fails', async () => {
-    setValidRoute();
-    ensureSdkWasmReadyMock.mockRejectedValue(new Error('wasm down'));
-    render(<ReviewTransaction />);
-    await flush();
-
-    expect(screen.getByText('none')).toBeInTheDocument();
-    expect(screen.queryByTestId('row-note')).not.toBeInTheDocument();
-    expect(dateTimeToRecallBlocksMock).not.toHaveBeenCalled();
+    expect(dateTimeToRecallBlocksMock).toHaveBeenCalledWith(expect.any(Date));
   });
 
   it('renders with an undefined token when balances have not loaded (hero symbol empty)', async () => {
@@ -365,67 +328,6 @@ describe('ReviewTransaction — rendering', () => {
     fireEvent.click(screen.getByTestId('row-edit'));
     await flush();
     expect(screen.getByTestId('recall-drawer').getAttribute('data-open')).toBe('true');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Block-height seeding effect — cancellation / catch branches
-// ---------------------------------------------------------------------------
-describe('ReviewTransaction — block-height effect lifecycle', () => {
-  it('bails out (before constructing RpcClient) when unmounted before wasm is ready', async () => {
-    setValidRoute();
-    const d = deferred();
-    ensureSdkWasmReadyMock.mockReturnValue(d.promise);
-
-    const { unmount } = render(<ReviewTransaction />);
-    unmount(); // cleanup sets cancelled = true
-
-    await act(async () => {
-      d.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(getBlockHeaderMock).not.toHaveBeenCalled();
-    expect(dateTimeToRecallBlocksMock).not.toHaveBeenCalled();
-  });
-
-  it('bails out (after fetching the header) when unmounted mid-flight', async () => {
-    setValidRoute();
-    const wasmD = deferred();
-    const headerD = deferred<{ blockNum: () => number }>();
-    ensureSdkWasmReadyMock.mockReturnValue(wasmD.promise);
-    getBlockHeaderMock.mockReturnValue(headerD.promise);
-
-    const { unmount } = render(<ReviewTransaction />);
-
-    // Let the wasm-ready then-callback run: constructs RpcClient + calls header.
-    await act(async () => {
-      wasmD.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    expect(getBlockHeaderMock).toHaveBeenCalledTimes(1);
-
-    unmount(); // cancelled = true before the header resolves
-
-    await act(async () => {
-      headerD.resolve({ blockNum: () => 42 });
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(dateTimeToRecallBlocksMock).not.toHaveBeenCalled();
-  });
-
-  it('swallows a header-fetch rejection without seeding the date', async () => {
-    setValidRoute();
-    getBlockHeaderMock.mockRejectedValue(new Error('rpc down'));
-    render(<ReviewTransaction />);
-    await flush();
-
-    expect(screen.getByText('none')).toBeInTheDocument();
-    expect(dateTimeToRecallBlocksMock).not.toHaveBeenCalled();
   });
 });
 
@@ -469,17 +371,6 @@ describe('ReviewTransaction — onSubmit', () => {
 
     expect(requestSWMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledWith('/generating-transaction-full/tx-abc', 'replacestate');
-  });
-
-  it('passes undefined recall blocks when the height was never seeded', async () => {
-    setValidRoute();
-    ensureSdkWasmReadyMock.mockRejectedValue(new Error('wasm down'));
-    render(<ReviewTransaction />);
-    await flush();
-
-    await clickSubmit();
-
-    expect(initiateMock).toHaveBeenCalledWith('pubkey-1', '0xrecipient', 'tok1', 'private', 12345n, undefined, false);
   });
 
   it('forwards the delegate-proof flag from settings', async () => {

--- a/src/screens/send-flow/ReviewTransaction.tsx
+++ b/src/screens/send-flow/ReviewTransaction.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { RpcClient } from '@miden-sdk/miden-sdk/lazy';
 import { addDays, format, formatDistanceToNow } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
@@ -16,7 +15,6 @@ import {
 } from 'lib/miden/activity';
 import { useAccount, useAllBalances, useAllTokensBaseMetadata } from 'lib/miden/front';
 import { NoteTypeEnum } from 'lib/miden/types';
-import { ensureSdkWasmReady, getRpcEndpoint } from 'lib/miden-chain/constants';
 import { isExtension } from 'lib/platform';
 import { isDelegateProofEnabled } from 'lib/settings/helpers';
 import { useWalletStore } from 'lib/store';
@@ -88,27 +86,15 @@ export const ReviewTransaction: React.FC = () => {
   const [recallBlocks, setRecallBlocks] = useState<string | undefined>(undefined);
   const [showCalendar, setShowCalendar] = useState(false);
 
-  // Default every send to a 7-day reclaim (expiration) height. Fetch the
-  // current block height once on mount and seed recallDate/recallBlocks. The
-  // user can override via the "Edit" link, which opens RecallCalendarDrawer.
+  // Default every send to a 7-day reclaim (expiration) offset. recallBlocks is a
+  // RELATIVE block offset — the current chain height is added later, once, by the
+  // SDK interface — so no block-height fetch is needed here. The user can override
+  // via the "Edit" link, which opens RecallCalendarDrawer.
   useEffect(() => {
-    let cancelled = false;
-    ensureSdkWasmReady()
-      .then(() => {
-        if (cancelled) return;
-        const rpc = new RpcClient(getRpcEndpoint());
-        return rpc.getBlockHeaderByNumber().then(header => {
-          if (cancelled) return;
-          const date = addDays(new Date(), 7);
-          setRecallDate(date);
-          setRecallTime(format(date, 'HH:mm'));
-          setRecallBlocks(String(dateTimeToRecallBlocks(date, header.blockNum())));
-        });
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
+    const date = addDays(new Date(), 7);
+    setRecallDate(date);
+    setRecallTime(format(date, 'HH:mm'));
+    setRecallBlocks(String(dateTimeToRecallBlocks(date)));
   }, []);
 
   // Leaving review = leaving the send flow: drop any cached speculative prove


### PR DESCRIPTION
## Summary

Recall (P2IDE reclaim) height was being stored on-chain at roughly twice the current chain height, so every sender-side reclaim attempt before that far-future height failed the kernel's `ERR_P2IDE_RECLAIM_HEIGHT_NOT_REACHED` assertion. This makes the "expiration date" the user picks in the send flow unusable — the note only becomes reclaimable at ~2x chain height instead of the chosen offset.

## Root cause

The current chain height was added twice:

- The send UI's `dateTimeToRecallBlocks` returned an **absolute** block height (`currentBlockNum + secondsUntilTarget / SECONDS_PER_BLOCK`), fetching the current height itself.
- `MidenClientInterface.sendTransaction` treats `extraInputs.recallBlocks` as a **relative** offset and adds the current sync height again (`reclaimAfter = sync.blockNum() + recallBlocks`).

The SDK bakes `reclaimAfter` verbatim as the note's absolute P2IDE reclaim height, so the on-chain value landed at `height + (height + offset)` ≈ 2x the chain height. The dApp path already passed `recallBlocks` as a relative offset, so it was unaffected.

## Fix

Single-source the unit so the current height is added in exactly one place:

- `dateTimeToRecallBlocks` now returns a **relative** block offset (0 for a past/now target) and no longer takes/needs a `currentBlockNum`.
- `MidenClientInterface.sendTransaction` remains the one place that adds the current sync height. `SendTransaction.extraInputs.recallBlocks` is documented as a relative offset.
- The now-unnecessary on-mount block-height fetches (RpcClient / `ensureSdkWasmReady`) are removed from `RecallCalendarDrawer` and `ReviewTransaction`, along with their associated effect-lifecycle plumbing.

Net result: the on-chain reclaim height is `syncHeight + offset` instead of `~2 * syncHeight`.

## Testing

- Added a regression guard in `miden-client-interface.test.ts` asserting the interface adds the current chain height exactly once (`reclaimAfter === 1600` for `H = 1000`, `offset = 600`, not `2600`) and syncs once.
- Updated `RecallCalendarDrawer` and `ReviewTransaction` tests to reflect the relative-offset contract and the removal of the block-height fetch.
- All three affected suites pass (96 tests); `eslint --max-warnings 0` is clean on the changed files.

Closes #308
