### PR TITLE
fix(mobile): hot-key hardware fixes — Android MGF digest, iOS locked-device access, JS fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,26 @@
 # Changelog
 
-## 1.15.9 (2026-07-22)
+## 1.15.10 (TBD)
+
+### Changes
+
+* [CHANGE][mobile] The native hot-key plugins now reject with typed error codes: `HARDWARE_UNAVAILABLE` when the secure hardware (Keystore/StrongBox on Android, Secure Enclave on iOS) genuinely can't be used, and `DEVICE_LOCKED` (iOS) when the unwrap merely ran while the device was locked (`errSecInteractionNotAllowed`, a transient state callers should retry). JS-side report-prompt UI lands separately. The secure-hot-key facade now falls back to the JS (vault-envelope) hot-key implementation when native generation rejects with `HARDWARE_UNAVAILABLE`, so onboarding succeeds on devices without usable secure hardware; per-key operations route by blob format (native `<tag>:<payload>` vs JS hex) instead of by platform.
 
 ### Fixes
 
-* [FIX][extension] **The consumable-notes cache is now scoped per account, so switching accounts no longer auto-consumes the previous account's notes.** The extension cached consumable notes under a single wallet-wide key and the claimable-notes hook ignored the account argument, so after an account switch account A's notes were served to — and auto-consumed under — account B without any user action. The cache read is now guarded by the account the notes belong to and cleared on switch.
+* [FIX][mobile] **iOS hot-key signing no longer fails with `errSecInteractionNotAllowed` (OSStatus -25308) when guardian sync signs while the device is locked.** The Secure Enclave hot key was minted `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, so the ~3s AutoSync tick's unwrap failed any time the screen was off/locked. New keys use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` (usable after the first post-boot unlock, still non-migratable); existing keys keep the old access control until the hot key is rotated.
+
+* [FIX][mobile] **Android hot-key signing no longer fails with `INCOMPATIBLE_MGF_DIGEST`, leaving consume/claim stuck on the pending page.** The Keystore RSA-OAEP wrapper key was authorized for the SHA-256 digest only; pre-Android-13 Keymaster reuses that same digest list to authorize the MGF1 function (default SHA-1) and refuses any OAEP-MGF1 op unless SHA-1 is present, so hardware decrypt threw while software public-key encrypt silently succeeded (generate looked fine, sign failed). The wrapper key now authorizes both SHA-256 and SHA-1 digests, and explicitly authorizes both MGF1 digests on Android 15+ (`setMgf1Digests`). Existing keys minted before this fix must be regenerated (rotate the hot key or re-add the account).
+
+## 1.15.9 (2026-07-22)
+
 ### Features
 
 * [FEATURE][extension] **The custom-transaction confirmation now shows what the transaction actually does instead of an opaque "custom transaction" notice.** The wallet decodes the request for an instant declared preview, then runs a local dry-run (`executeForSummary`, no prove/submit) to show the ground-truth asset changes (what you send / receive), notes consumed/created, and storage impact — with the raw request under an Advanced disclosure. Genuinely-opaque signature requests (blind word / arbitrary / blind-commitment) now carry an explicit "you are blind-signing" warning so they are visually distinct from real transactions.
 
 ### Fixes
 
+* [FIX][extension] **The consumable-notes cache is now scoped per account, so switching accounts no longer auto-consumes the previous account's notes.** The extension cached consumable notes under a single wallet-wide key and the claimable-notes hook ignored the account argument, so after an account switch account A's notes were served to — and auto-consumed under — account B without any user action. The cache read is now guarded by the account the notes belong to and cleared on switch.
 * [FIX][all] **Restoring an encrypted wallet file now writes into the client's active database, so balances appear instead of staying 0.** The restore path imported the miden-client dump into a hardcoded store name (`miden-wallet`) while the running client reads from `MidenClientDB_<network>`, so the restored account/balance state was invisible (sync logged "No account header record found"). Restore now targets the active client's store name.
 * [FIX][all] **Guardian consume/send no longer stays permanently "Failed" after the transaction already landed on chain.** When a guardian value-moving transaction submitted successfully but the local apply step then failed (`ApplyTransactionAfterSubmitFailed`, e.g. the account was briefly locked), the guardian branch cancelled it to a terminal `Failed` state even though the note was consumed on chain — losing track of the funds locally until the next reconcile that never came. Guardian consume/send/swap/execute now mark the transaction `Completed` in that case (matching the non-guardian path), so the next sync reconciles the note via `ConsumedExternal`.
 * [FIX][extension] **The side panel no longer clips its right edge in Brave's narrow sidebar.** The side-panel document hard-clamped its root to `min-width: 360px` with hidden overflow, so any host giving less than 360px (Brave's sidebar, whose icon rail eats width) clipped the balance, Faucet button, and token amounts with no scrollbar. The floor is removed so the layout shrinks to the host viewport.

--- a/android/app/src/main/java/com/miden/wallet/HotKeyPlugin.kt
+++ b/android/app/src/main/java/com/miden/wallet/HotKeyPlugin.kt
@@ -62,6 +62,11 @@ class HotKeyPlugin : Plugin() {
         private const val KEY_ALIAS_PREFIX = "com.miden.wallet.hot."
         private const val OAEP_TRANSFORMATION = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
 
+        // Rejection code for "the device's secure hardware (Keystore/StrongBox)
+        // genuinely could not be used" — distinct from user-cancel / key-not-found.
+        // The JS facade (secure-hot-key) matches on this to surface a report prompt.
+        private const val ERR_HARDWARE_UNAVAILABLE = "HARDWARE_UNAVAILABLE"
+
         // BC's secp256k1 domain parameters; reused by every sign call.
         private val SECP256K1 = SECNamedCurves.getByName("secp256k1")
         private val DOMAIN = ECDomainParameters(SECP256K1.curve, SECP256K1.g, SECP256K1.n, SECP256K1.h)
@@ -117,7 +122,11 @@ class HotKeyPlugin : Plugin() {
             Log.e(TAG, "generateHotKey failed: ${e.message}", e)
             // Best-effort cleanup of the orphan Keystore key we may have just created.
             alias?.let { deleteAliasQuietly(it) }
-            call.reject("Failed to generate hot key: ${e.message}")
+            if (isHardwareUnavailable(e)) {
+                call.reject("Secure hardware unavailable: ${e.message}", ERR_HARDWARE_UNAVAILABLE)
+            } else {
+                call.reject("Failed to generate hot key: ${e.message}")
+            }
         } finally {
             zero(secretBytes)
         }
@@ -196,7 +205,11 @@ class HotKeyPlugin : Plugin() {
             }
         } catch (e: Exception) {
             Log.e(TAG, "signWithHotKey failed: ${e.message}", e)
-            call.reject("Hot-key sign failed: ${e.message}")
+            if (isHardwareUnavailable(e)) {
+                call.reject("Secure hardware unavailable: ${e.message}", ERR_HARDWARE_UNAVAILABLE)
+            } else {
+                call.reject("Hot-key sign failed: ${e.message}")
+            }
         }
     }
 
@@ -470,8 +483,23 @@ class HotKeyPlugin : Plugin() {
             KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
         )
             .setKeySize(2048)
-            .setDigests(KeyProperties.DIGEST_SHA256)
+            // SHA-1 MUST be authorized even though our OAEP main+MGF1 digest is
+            // SHA-256 (see oaepParams). Pre-Android-13 Keymaster has no separate
+            // MGF1-digest tag: it authorizes the MGF1 function against this same
+            // DIGEST list and defaults MGF1 to SHA-1, so it refuses ANY OAEP-MGF1
+            // op unless SHA-1 is present — hardware decrypt throws
+            // INCOMPATIBLE_MGF_DIGEST otherwise (public-key encrypt runs in
+            // software and never hits this, which is why generate "succeeds" but
+            // sign fails). Seen on TEE-only devices (e.g. tablets w/o biometric).
+            .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA1)
             .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+
+        // Android 15+ exposes the dedicated RSA_OAEP_MGF_DIGEST tag, which
+        // defaults to SHA-1 only; MGF1-SHA256 must be authorized explicitly or
+        // decrypt fails the same way.
+        if (Build.VERSION.SDK_INT >= 35) {
+            builder.setMgf1Digests(KeyProperties.DIGEST_SHA1, KeyProperties.DIGEST_SHA256)
+        }
 
         if (strongBox && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             builder.setIsStrongBoxBacked(true)
@@ -479,6 +507,39 @@ class HotKeyPlugin : Plugin() {
 
         gen.initialize(builder.build())
         return gen.generateKeyPair().public
+    }
+
+    /// Classify a caught exception as "secure hardware genuinely unusable"
+    /// (Keystore/Keymaster/StrongBox failure) vs an ordinary error. Walks the
+    /// cause chain because Keymaster errors surface wrapped — e.g. an
+    /// android.security.KeyStoreException (INCOMPATIBLE_MGF_DIGEST and friends)
+    /// arrives as the cause of a ProviderException / crypto exception thrown from
+    /// cipher.doFinal or key generation. Matches by class-name substring and
+    /// message so we don't have to import every vendor-specific exception type.
+    private fun isHardwareUnavailable(e: Throwable): Boolean {
+        var cause: Throwable? = e
+        while (cause != null) {
+            if (cause is StrongBoxUnavailableException) return true
+            val name = cause.javaClass.name
+            if (name.contains("KeyStoreException") ||
+                name.contains("ProviderException") ||
+                name.contains("StrongBox") ||
+                cause is java.security.NoSuchAlgorithmException ||
+                cause is java.security.NoSuchProviderException
+            ) {
+                return true
+            }
+            val msg = cause.message ?: ""
+            if (msg.contains("INCOMPATIBLE_MGF_DIGEST") ||
+                msg.contains("Keymaster") ||
+                msg.contains("Keystore") ||
+                msg.contains("StrongBox")
+            ) {
+                return true
+            }
+            cause = cause.cause
+        }
+        return false
     }
 
     private fun deleteAliasQuietly(alias: String) {

--- a/ios/App/App/HotKeyPlugin.swift
+++ b/ios/App/App/HotKeyPlugin.swift
@@ -91,10 +91,19 @@ public class HotKeyPlugin: CAPPlugin, CAPBridgedPlugin {
         //    reintroduced, background/sync signing must first be routed off the
         //    hot key (or the gate scoped to user-initiated operations only).
         //    The key still never leaves the Secure Enclave.
+        //
+        //    Accessibility is `AfterFirstUnlockThisDeviceOnly`, NOT
+        //    `WhenUnlockedThisDeviceOnly`: the same AutoSync tick also signs
+        //    while the device is locked / screen off, and a WhenUnlocked key
+        //    fails those unwraps with errSecInteractionNotAllowed (-25308).
+        //    AfterFirstUnlock keeps the key usable any time after the first
+        //    post-boot unlock while staying non-migratable (ThisDeviceOnly).
+        //    Keys minted before this change are stuck WhenUnlocked forever —
+        //    SE access control is immutable — until rotated (replace-hot-key).
         var accessError: Unmanaged<CFError>?
         guard let accessControl = SecAccessControlCreateWithFlags(
             kCFAllocatorDefault,
-            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
             .privateKeyUsage,
             &accessError
         ) else {
@@ -125,7 +134,10 @@ public class HotKeyPlugin: CAPPlugin, CAPBridgedPlugin {
         guard let sePrivateKey = SecKeyCreateRandomKey(seKeyAttributes as CFDictionary, &keyError) else {
             zeroBytes(&secretBytes)
             let msg = keyError?.takeRetainedValue().localizedDescription ?? "unknown"
-            call.reject("Failed to generate hot-key SE key: \(msg)")
+            // Secure Enclave genuinely unusable on this device — code it so the JS
+            // facade can surface the report prompt (parity with Android's
+            // ERR_HARDWARE_UNAVAILABLE).
+            call.reject("Secure hardware unavailable: \(msg)", "HARDWARE_UNAVAILABLE")
             return
         }
         guard let sePublicKey = SecKeyCopyPublicKey(sePrivateKey) else {
@@ -257,8 +269,16 @@ public class HotKeyPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.reject("Authentication cancelled", "USER_CANCELLED")
             } else if nsError?.domain == LAError.errorDomain && nsError?.code == LAError.authenticationFailed.rawValue {
                 call.reject("Authentication failed", "AUTH_FAILED")
+            } else if nsError?.code == Int(errSecInteractionNotAllowed) {
+                // -25308: the key's accessibility condition isn't met (device
+                // locked / before first unlock) — a transient state, NOT broken
+                // hardware. Legacy WhenUnlocked keys hit this on the locked-phone
+                // AutoSync tick; the caller should just retry on the next tick.
+                call.reject("Hot key not accessible while device is locked", "DEVICE_LOCKED")
             } else {
-                call.reject("Failed to unwrap hot-key secret: \(msg)")
+                // Not a user-driven cancel/auth failure: the SE couldn't unwrap.
+                // Code it so the JS facade surfaces the report prompt.
+                call.reject("Secure hardware unavailable: \(msg)", "HARDWARE_UNAVAILABLE")
             }
             return
         }
@@ -365,8 +385,13 @@ public class HotKeyPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.reject("Authentication cancelled", "USER_CANCELLED")
             } else if nsError?.domain == LAError.errorDomain && nsError?.code == LAError.authenticationFailed.rawValue {
                 call.reject("Authentication failed", "AUTH_FAILED")
+            } else if nsError?.code == Int(errSecInteractionNotAllowed) {
+                // -25308: accessibility condition not met (device locked) —
+                // transient, not broken hardware. See signWithHotKey.
+                call.reject("Hot key not accessible while device is locked", "DEVICE_LOCKED")
             } else {
-                call.reject("Failed to unwrap hot-key secret: \(msg)")
+                // Not a user-driven cancel/auth failure: the SE couldn't unwrap.
+                call.reject("Secure hardware unavailable: \(msg)", "HARDWARE_UNAVAILABLE")
             }
             return
         }

--- a/src/lib/secure-hot-key/index.test.ts
+++ b/src/lib/secure-hot-key/index.test.ts
@@ -64,8 +64,11 @@ describe('secure-hot-key facade', () => {
 
   it('routes every operation to the native plugin on mobile', async () => {
     mockIsMobile.mockReturnValue(true);
+    // Native ciphertexts are "<b64-tag>:<b64-payload>" — the ':' is what the
+    // per-blob router keys off.
+    const nativeCiphertext = 'dGFn:cGF5bG9hZA==';
     mockNativeGenerateHotKey.mockResolvedValue({
-      ciphertext: 'native-ciphertext',
+      ciphertext: nativeCiphertext,
       publicKeyHex: 'native-public',
       commitmentHex: 'native-commitment'
     });
@@ -74,21 +77,68 @@ describe('secure-hot-key facade', () => {
     mockNativeRevealHotKey.mockResolvedValue('native-secret');
 
     await expect(secureHotKey.generateHotKey()).resolves.toEqual({
-      ciphertext: 'native-ciphertext',
+      ciphertext: nativeCiphertext,
       publicKeyHex: 'native-public',
       commitmentHex: 'native-commitment'
     });
-    await expect(secureHotKey.signHotDigest('native-ciphertext', '0xword')).resolves.toBe('0xnative-signature');
-    await expect(secureHotKey.deleteHotKey('native-ciphertext')).resolves.toBeUndefined();
-    await expect(secureHotKey.revealHotKey('native-ciphertext')).resolves.toBe('native-secret');
+    await expect(secureHotKey.signHotDigest(nativeCiphertext, '0xword')).resolves.toBe('0xnative-signature');
+    await expect(secureHotKey.deleteHotKey(nativeCiphertext)).resolves.toBeUndefined();
+    await expect(secureHotKey.revealHotKey(nativeCiphertext)).resolves.toBe('native-secret');
 
     expect(mockNativeGenerateHotKey).toHaveBeenCalledTimes(1);
-    expect(mockNativeSignHotDigest).toHaveBeenCalledWith('native-ciphertext', '0xword');
-    expect(mockNativeDeleteHotKey).toHaveBeenCalledWith('native-ciphertext');
-    expect(mockNativeRevealHotKey).toHaveBeenCalledWith('native-ciphertext');
+    expect(mockNativeSignHotDigest).toHaveBeenCalledWith(nativeCiphertext, '0xword');
+    expect(mockNativeDeleteHotKey).toHaveBeenCalledWith(nativeCiphertext);
+    expect(mockNativeRevealHotKey).toHaveBeenCalledWith(nativeCiphertext);
     expect(mockJsGenerateHotKey).not.toHaveBeenCalled();
     expect(mockJsSignHotDigest).not.toHaveBeenCalled();
     expect(mockJsDeleteHotKey).not.toHaveBeenCalled();
     expect(mockJsRevealHotKey).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the JS implementation when generate rejects with HARDWARE_UNAVAILABLE on mobile', async () => {
+    mockIsMobile.mockReturnValue(true);
+    mockNativeGenerateHotKey.mockRejectedValue(
+      Object.assign(new Error('Secure hardware unavailable'), { code: 'HARDWARE_UNAVAILABLE' })
+    );
+    mockJsGenerateHotKey.mockResolvedValue({
+      ciphertext: 'deadbeef',
+      publicKeyHex: 'js-public',
+      commitmentHex: 'js-commitment'
+    });
+
+    await expect(secureHotKey.generateHotKey()).resolves.toEqual({
+      ciphertext: 'deadbeef',
+      publicKeyHex: 'js-public',
+      commitmentHex: 'js-commitment'
+    });
+    expect(mockNativeGenerateHotKey).toHaveBeenCalledTimes(1);
+    expect(mockJsGenerateHotKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-throws other native generate errors without falling back', async () => {
+    mockIsMobile.mockReturnValue(true);
+    mockNativeGenerateHotKey.mockRejectedValue(
+      Object.assign(new Error('Hot key not accessible while device is locked'), { code: 'DEVICE_LOCKED' })
+    );
+
+    await expect(secureHotKey.generateHotKey()).rejects.toThrow('device is locked');
+    expect(mockJsGenerateHotKey).not.toHaveBeenCalled();
+  });
+
+  it('routes per-key operations by blob format on mobile (JS-fallback key stays JS)', async () => {
+    mockIsMobile.mockReturnValue(true);
+    mockJsSignHotDigest.mockResolvedValue('0xjs-signature');
+    mockJsDeleteHotKey.mockResolvedValue(undefined);
+    mockJsRevealHotKey.mockResolvedValue('js-secret');
+
+    // Hex blob (no ':') = minted via the JS fallback — must not hit native.
+    await expect(secureHotKey.signHotDigest('deadbeef', '0xword')).resolves.toBe('0xjs-signature');
+    await expect(secureHotKey.deleteHotKey('deadbeef')).resolves.toBeUndefined();
+    await expect(secureHotKey.revealHotKey('deadbeef')).resolves.toBe('js-secret');
+
+    expect(mockJsSignHotDigest).toHaveBeenCalledWith('deadbeef', '0xword');
+    expect(mockNativeSignHotDigest).not.toHaveBeenCalled();
+    expect(mockNativeDeleteHotKey).not.toHaveBeenCalled();
+    expect(mockNativeRevealHotKey).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/secure-hot-key/index.ts
+++ b/src/lib/secure-hot-key/index.ts
@@ -8,7 +8,16 @@
  * serializes an `AuthSecretKey.ecdsaWithRNG(...)` blob and relies on the
  * surrounding vault envelope for at-rest protection.
  *
- * Callers should never need to know which path executed: all three operations
+ * Mobile devices whose secure hardware is genuinely unusable (the native
+ * plugins reject with code HARDWARE_UNAVAILABLE) fall back to the JS
+ * implementation at generate time so onboarding still succeeds — the key is
+ * then only as protected as the vault envelope, same trade-off as extension.
+ * Per-key operations route by blob format, not platform: native ciphertexts
+ * are "<b64-tag>:<b64-payload>" (always contain ':'), JS-fallback ones are
+ * plain hex (never do), so a mobile account minted via the fallback keeps
+ * signing with it while hardware-backed accounts stay native.
+ *
+ * Callers should never need to know which path executed: all operations
  * take/return strings.
  */
 
@@ -19,29 +28,46 @@ import * as nativePlugin from './nativePlugin';
 
 export type { GeneratedHotKey } from './jsFallback';
 
-function impl() {
-  return isMobile() ? nativePlugin : jsFallback;
+// Reject code raised by both native HotKey plugins when Keystore/StrongBox
+// (Android) or the Secure Enclave (iOS) genuinely cannot be used — distinct
+// from transient states (DEVICE_LOCKED) and user-driven ones (USER_CANCELLED).
+const HARDWARE_UNAVAILABLE_CODE = 'HARDWARE_UNAVAILABLE';
+
+function isHardwareUnavailable(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  return Reflect.get(error, 'code') === HARDWARE_UNAVAILABLE_CODE;
+}
+
+function implFor(ciphertext: string) {
+  return ciphertext.includes(':') ? nativePlugin : jsFallback;
 }
 
 export async function generateHotKey() {
-  return impl().generateHotKey();
+  if (!isMobile()) return jsFallback.generateHotKey();
+  try {
+    return await nativePlugin.generateHotKey();
+  } catch (error) {
+    if (!isHardwareUnavailable(error)) throw error;
+    console.warn('[secure-hot-key] secure hardware unavailable, generating JS-fallback hot key:', error);
+    return jsFallback.generateHotKey();
+  }
 }
 
 export async function signHotDigest(ciphertext: string, wordHex: string): Promise<string> {
-  return impl().signHotDigest(ciphertext, wordHex);
+  return implFor(ciphertext).signHotDigest(ciphertext, wordHex);
 }
 
 export async function deleteHotKey(ciphertext: string): Promise<void> {
-  return impl().deleteHotKey(ciphertext);
+  return implFor(ciphertext).deleteHotKey(ciphertext);
 }
 
 /**
  * Unwrap the hot ciphertext and return the raw 32-byte secp256k1 secret hex.
- * On mobile this fires a biometric prompt (same SE/StrongBox unwrap path as
- * `signHotDigest`, minus the actual signing step). On extension/desktop the
- * JS fallback decodes the serialized `AuthSecretKey` and strips the 1-byte
- * scheme prefix so the format matches the native return.
+ * On native-wrapped keys this runs the SE/StrongBox unwrap path (same as
+ * `signHotDigest`, minus the actual signing step). On JS-fallback keys it
+ * decodes the serialized `AuthSecretKey` and strips the 1-byte scheme prefix
+ * so the format matches the native return.
  */
 export async function revealHotKey(ciphertext: string): Promise<string> {
-  return impl().revealHotKey(ciphertext);
+  return implFor(ciphertext).revealHotKey(ciphertext);
 }


### PR DESCRIPTION
## Summary

Three related mobile hot-key (Guardian 3-key) hardware fixes plus a recovery path:

- **Android — `INCOMPATIBLE_MGF_DIGEST` on TEE-only devices.** The Keystore RSA-OAEP wrapper key authorized only the SHA-256 digest; pre-Android-13 Keymaster validates the MGF1 function (default SHA-1) against that same digest list and refuses any OAEP-MGF1 op unless SHA-1 is present — hardware decrypt threw while software public-key encrypt silently succeeded, so `generateHotKey` looked fine and `signWithHotKey` failed, leaving consume/claim stuck on the pending page. The wrapper key now authorizes SHA-256 + SHA-1, and on Android 13+ explicitly authorizes both MGF1 digests via `setMgf1Digests` (the dedicated tag there defaults to SHA-1 only).
- **iOS — `errSecInteractionNotAllowed` (-25308) while locked.** The SE hot key was minted `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, so the ~3s AutoSync guardian-sync unwrap failed whenever the device was locked/screen off. New keys use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` (still non-migratable).
- **Typed error codes.** Both plugins now reject with `HARDWARE_UNAVAILABLE` when the secure hardware genuinely can't be used (Android gets a cause-chain classifier since Keymaster errors arrive wrapped), and iOS additionally codes the transient locked-device state as `DEVICE_LOCKED` so it's never mistaken for broken hardware. The report-prompt UI consuming these codes lands separately (earn-integration branch).
- **Onboarding fallback.** The `secure-hot-key` facade now falls back to the JS (vault-envelope) implementation when native generation rejects with `HARDWARE_UNAVAILABLE`, so onboarding succeeds on devices without usable secure hardware. Per-key ops route by blob format (native `<tag>:<payload>` vs JS hex) instead of platform, so fallback-minted keys keep working alongside hardware-backed ones with no stored state.

## Migration caveats

- Key authorizations/access controls are immutable after creation on both platforms: keys minted before this fix keep the broken behavior until rotated (replace-hot-key) or the account is re-added.

## Test plan

- `yarn jest src/lib/secure-hot-key` — 24/24 pass (new cases: fallback on `HARDWARE_UNAVAILABLE`, re-throw on `DEVICE_LOCKED`, per-blob routing).
- `./gradlew :app:compileDebugKotlin` compiles clean.