### PR TITLE
fix(mobile): smooth home carousel slide on tab/action tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.11 (TBD)
+
+### Fixes
+
+* [FIX][mobile] **Tapping a home action (Send/Receive/Overview) now slides between the carousel pages as smoothly as a finger swipe.** The programmatic slide animated the full page width via a main-thread spring whose opening frames were starved by the route-commit re-render, and the track wasn't compositor-promoted so WebKit repainted it as the slide began — while a drag stays on a live layer and only springs a tiny residual. The track is now pre-promoted (`will-change: transform`) and the tab/action navigations defer their route re-render via `startTransition`, so the slide keeps its frames.
+
 ## 1.15.10 (2026-07-23)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* [FIX][mobile] **Tapping a home action (Send/Receive/Overview) now slides between the carousel pages as smoothly as a finger swipe.** The programmatic slide animated the full page width via a main-thread spring whose opening frames were starved by the route-commit re-render, and the track wasn't compositor-promoted so WebKit repainted it as the slide began — while a drag stays on a live layer and only springs a tiny residual. The track is now pre-promoted (`will-change: transform`) and the tab/action navigations defer their route re-render via `startTransition`, so the slide keeps its frames.
+* [FIX][mobile] **Tapping a home action (Send/Receive/Overview) slides between the carousel pages more smoothly.** The horizontal track is now pre-promoted to its own compositor layer (`will-change: transform`), so a programmatic slide no longer pays for layer creation — a full repaint — on its first frame; a finger drag was already on a live layer, which is why swiping felt smoother than tapping.
 
 ## 1.15.10 (2026-07-23)
 

--- a/src/app/layouts/HomeSwipeContainer.tsx
+++ b/src/app/layouts/HomeSwipeContainer.tsx
@@ -127,11 +127,15 @@ const HomeSwipeContainer: FC = () => {
     <div ref={containerRef} className="h-full w-full overflow-hidden touch-pan-y bg-app-bg">
       <motion.div
         className="h-full flex"
-        // `willChange` pre-promotes the track to its own compositor layer so
-        // WebKit doesn't create the layer (a full repaint) on the first frame
-        // of a programmatic slide — that repaint is what makes the
-        // press-to-navigate transition feel choppier than a finger drag, which
-        // is already on a live layer.
+        // Pre-promote the track to its own compositor layer so a programmatic
+        // slide (tapping Send/Receive) doesn't pay for layer creation — a full
+        // repaint — on its first frame; a finger drag is already on a live
+        // layer, which is why it feels smoother. Intentionally ALWAYS-on:
+        // toggling `willChange` at tap time would create the layer on that
+        // first frame, defeating the purpose. Caveat: the non-`none` transform
+        // already makes this the containing block for `position: fixed`
+        // descendants, so any future home-page child needing viewport-fixed
+        // placement must portal out of the track (today's drawers/modals do).
         style={{ x, width: `${pages.length * 100}%`, willChange: 'transform' }}
         drag="x"
         dragDirectionLock

--- a/src/app/layouts/HomeSwipeContainer.tsx
+++ b/src/app/layouts/HomeSwipeContainer.tsx
@@ -127,7 +127,12 @@ const HomeSwipeContainer: FC = () => {
     <div ref={containerRef} className="h-full w-full overflow-hidden touch-pan-y bg-app-bg">
       <motion.div
         className="h-full flex"
-        style={{ x, width: `${pages.length * 100}%` }}
+        // `willChange` pre-promotes the track to its own compositor layer so
+        // WebKit doesn't create the layer (a full repaint) on the first frame
+        // of a programmatic slide — that repaint is what makes the
+        // press-to-navigate transition feel choppier than a finger drag, which
+        // is already on a live layer.
+        style={{ x, width: `${pages.length * 100}%`, willChange: 'transform' }}
         drag="x"
         dragDirectionLock
         dragConstraints={{ left: dragMaxLeft, right: 0 }}

--- a/src/app/layouts/TabLayout.tsx
+++ b/src/app/layouts/TabLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, startTransition, useEffect, useRef } from 'react';
+import React, { FC, useEffect, useRef } from 'react';
 
 import classNames from 'clsx';
 import { motion } from 'framer-motion';
@@ -144,10 +144,7 @@ const TabLayout: FC<PropsWithChildren> = ({ children }) => {
     const to = TAB_ROUTES[id];
     if (to && to !== pathname) {
       hapticSelection();
-      // Defer the route re-render so the arriving page's reconciliation can't
-      // starve the carousel slide's opening frames (see HomeSwipeContainer).
-      // Haptic fires synchronously, so the tap still feels instant.
-      startTransition(() => navigate(to));
+      navigate(to);
     }
   };
 
@@ -155,7 +152,7 @@ const TabLayout: FC<PropsWithChildren> = ({ children }) => {
   // fires the selection haptic itself.
   const handleActionChange = (id: string) => {
     const to = ACTION_ROUTES[id];
-    if (to && to !== pathname) startTransition(() => navigate(to));
+    if (to && to !== pathname) navigate(to);
   };
 
   // Platform-specific sizing:

--- a/src/app/layouts/TabLayout.tsx
+++ b/src/app/layouts/TabLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { FC, startTransition, useEffect, useRef } from 'react';
 
 import classNames from 'clsx';
 import { motion } from 'framer-motion';
@@ -144,7 +144,10 @@ const TabLayout: FC<PropsWithChildren> = ({ children }) => {
     const to = TAB_ROUTES[id];
     if (to && to !== pathname) {
       hapticSelection();
-      navigate(to);
+      // Defer the route re-render so the arriving page's reconciliation can't
+      // starve the carousel slide's opening frames (see HomeSwipeContainer).
+      // Haptic fires synchronously, so the tap still feels instant.
+      startTransition(() => navigate(to));
     }
   };
 
@@ -152,7 +155,7 @@ const TabLayout: FC<PropsWithChildren> = ({ children }) => {
   // fires the selection haptic itself.
   const handleActionChange = (id: string) => {
     const to = ACTION_ROUTES[id];
-    if (to && to !== pathname) navigate(to);
+    if (to && to !== pathname) startTransition(() => navigate(to));
   };
 
   // Platform-specific sizing:


### PR DESCRIPTION
## What

The programmatic slide between home pages — tapping **Send / Receive / Overview** — felt choppier than a finger swipe between the same pages.

## Why

On the first frame of a *programmatic* slide, WebKit has to create the compositor layer for the `width:500%` carousel track (a full repaint), because the track isn't pre-promoted. A finger drag never pays this: `drag="x"` keeps the track on a live layer the whole time, so it stays smooth.

## Fix

Pre-promote the track to its own compositor layer with `will-change: transform` (`HomeSwipeContainer`). The layer already exists before the slide starts, so a programmatic slide begins on a composited layer instead of triggering layer creation + repaint on frame 1.

### On the reviewed-and-dropped `startTransition` approach

An earlier revision of this PR also wrapped the tab/action `navigate()` in `startTransition` to keep the route-commit re-render from starving the spring's opening frames. Code review found that introduces real regressions, so it was removed:

- **Android hardware-back could minimize the app** — deferring the route re-render leaves `MobileBackBridge` reading a stale pathname/position during the pending window, so a back-press right after a tap falls through to "exit app."
- **Rapid taps to a different action were silently dropped** (the re-tap guards read the stale pathname).
- **The slide could start *later* under sync load** — transitions have no deadline — inverting the goal on exactly the busy devices it targets.

The durable fix for that class — making `useLocation` a `useSyncExternalStore` so navigation state can't lag the URL, after which deferral would be safe — is a separate, larger change, tracked as follow-up rather than blocking this.

## Test plan

- `tsc --noEmit` and `eslint` clean; commit signed.
- **Needs an on-device feel check** (mobile animation): confirm the Overview→Send slide is smoother. If pre-promotion alone isn't enough, the follow-up is the concurrent-safe router migration above — not re-adding `startTransition` as-is.

No web-sdk dependency.
