### PR TITLE
feat(ios): re-enable in-app swap on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.15.11 (TBD)
 
+### Changes
+
+* [CHANGE][ios] **In-app swap is now available on iOS.** The In-Protocol DEX swap — previously disabled on iOS under App Store Review Guideline 3.1.5(iii) — is re-enabled, so the swap tab, the home swipe pane, the `/swap` route, and the featured swap dApps are present on iOS just as on Android, the browser extension, and desktop. Availability stays gated by the single `isSwapEnabled()` flag.
+
 ### Fixes
 
 * [FIX][mobile] **Tapping a home action (Send/Receive/Overview) slides between the carousel pages more smoothly.** The horizontal track is now pre-promoted to its own compositor layer (`will-change: transform`), so a programmatic slide no longer pays for layer creation — a full repaint — on its first frame; a finger drag was already on a live layer, which is why swiping felt smoother than tapping.

--- a/src/app/PageRouter.test.tsx
+++ b/src/app/PageRouter.test.tsx
@@ -396,7 +396,7 @@ describe('app/PageRouter — ready tab & full-screen routes', () => {
     expect(screen.getByTestId('tab-layout')).toContainElement(screen.getByTestId('swap-flow'));
   });
 
-  it('/swap redirects home when swap is disabled (iOS, App Store 3.1.5(iii))', () => {
+  it('/swap redirects home when swap is disabled', () => {
     mockSwapEnabled.value = false;
     renderAt('/swap', ready);
     expect(screen.queryByTestId('swap-flow')).toBeNull();

--- a/src/app/layouts/HomeSwipeContainer.test.tsx
+++ b/src/app/layouts/HomeSwipeContainer.test.tsx
@@ -165,7 +165,7 @@ describe('HomeSwipeContainer', () => {
     expect(getByTestId('page-send')).toHaveAttribute('data-loading', 'false');
   });
 
-  it('drops the Swap pane when swap is disabled (iOS), keeping the other four', () => {
+  it('drops the Swap pane when swap is disabled, keeping the other four', () => {
     mockSwapEnabled.value = false;
     const { getByTestId, queryByTestId } = render(<HomeSwipeContainer />);
     expect(queryByTestId('page-swap')).toBeNull();

--- a/src/app/layouts/TabLayout.test.tsx
+++ b/src/app/layouts/TabLayout.test.tsx
@@ -276,11 +276,11 @@ describe('TabLayout — swap action availability (isSwapEnabled)', () => {
     expect(screen.getByTestId('action-swap')).toBeInTheDocument();
   });
 
-  it('hides the Swap action segment on iOS (App Store 3.1.5(iii))', () => {
+  it('shows the Swap action segment on iOS too (swap re-enabled for distribution)', () => {
     mockPlatform.isIOS = true;
     mockLocation.pathname = '/';
     renderLayout();
-    expect(screen.queryByTestId('action-swap')).toBeNull();
+    expect(screen.getByTestId('action-swap')).toBeInTheDocument();
     // The rest of the action bar is unaffected.
     expect(screen.getByTestId('action-overview')).toBeInTheDocument();
     expect(screen.getByTestId('action-send')).toBeInTheDocument();

--- a/src/lib/dapp-browser/featured-dapps.test.ts
+++ b/src/lib/dapp-browser/featured-dapps.test.ts
@@ -173,7 +173,7 @@ describe('getExploreGridDapps', () => {
     expect(getExploreGridDapps()).toEqual(EXPLORE_GRID_DAPPS);
   });
 
-  it('drops swap/exchange (DEX) dApps when swap is disabled (iOS, App Store 3.1.5(iii))', () => {
+  it('drops swap/exchange (DEX) dApps when swap is disabled', () => {
     mockSwapEnabled.value = false;
     const grid = getExploreGridDapps();
     // 'zoro' (a DEX) is filtered out; the remaining curated apps keep their order.

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,23 +1,7 @@
 import { isSwapEnabled } from './feature-flags';
 
-const mockPlatform = { isIOS: false };
-
-jest.mock('lib/platform', () => ({
-  isIOS: () => mockPlatform.isIOS
-}));
-
 describe('feature-flags — isSwapEnabled', () => {
-  afterEach(() => {
-    mockPlatform.isIOS = false;
-  });
-
-  it('enables swap off-iOS (Android / extension / desktop)', () => {
-    mockPlatform.isIOS = false;
+  it('enables swap on every platform (including iOS)', () => {
     expect(isSwapEnabled()).toBe(true);
-  });
-
-  it('disables swap on iOS (App Store Guideline 3.1.5(iii))', () => {
-    mockPlatform.isIOS = true;
-    expect(isSwapEnabled()).toBe(false);
   });
 });

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,20 +1,16 @@
-import { isIOS } from 'lib/platform';
-
 /**
- * In-app swap (the In-Protocol DEX / PSWAP flow) is disabled on iOS.
+ * In-app swap (the In-Protocol DEX / PSWAP flow) availability.
  *
- * Apple App Review treats an in-app crypto swap as a "cryptocurrency exchange
- * service" under App Store Review Guideline 3.1.5(iii), which requires
- * per-storefront licensing the app does not currently hold. Until that
- * compliance work is done, the iOS build ships as a pure non-custodial wallet
- * with no exchange surface. Every other platform (Android, browser extension,
- * desktop) keeps swap.
+ * Swap is enabled on every platform, including iOS. It was previously disabled
+ * on iOS for App Store Review Guideline 3.1.5(iii) — Apple App Review read an
+ * in-app crypto swap as a "cryptocurrency exchange service" — and is re-enabled
+ * here now that the iOS build ships swap for distribution.
  *
  * This is the single source of truth for swap availability — the swap tab, the
- * home swipe pane, and the `/swap` route all read it. To re-enable swap on iOS
- * (e.g. once it is cleared for distribution, or behind a region/remote flag),
+ * home swipe pane, the `/swap` route, and the featured swap dApps all read it.
+ * To gate swap again (per-platform, per-region, or behind a remote flag),
  * change only this function.
  */
 export function isSwapEnabled(): boolean {
-  return !isIOS();
+  return true;
 }


### PR DESCRIPTION
Re-enables the In-Protocol DEX (PSWAP) swap on iOS, reverting the platform gate added in #355.

`isSwapEnabled()` now returns `true` on every platform (it was `!isIOS()`), so the swap tab, the home swipe pane, the `/swap` route, and the featured swap dApps are present on iOS just as on Android, the browser extension, and desktop. It remains the single source of truth for swap availability, so swap can be re-gated later (per-platform, per-region, or behind a remote flag) by changing only that function.

**Compliance note:** #355 disabled iOS swap for App Store Review Guideline 3.1.5(iii) (Apple reads an in-app crypto swap as an "cryptocurrency exchange service"). This change re-exposes that surface on iOS; it is being re-enabled deliberately for a swap-included iOS distribution build.

- `src/lib/feature-flags.ts`: `isSwapEnabled()` → `true` (drop the `!isIOS()` gate + unused import)
- Tests: `feature-flags.test.ts` asserts enabled on all platforms; `TabLayout.test.tsx` now asserts the Swap segment shows on iOS; the flag-off tests (PageRouter / HomeSwipeContainer / featured-dapps) keep their coverage with the stale "(iOS, 3.1.5)" framing dropped from their names.
- `CHANGELOG.md`: entry under `## 1.15.11 (TBD)`.