### PR TITLE
fix(mobile): hide the Earn screen from the home swipe carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 * [FIX][mobile] **Tapping a home action (Send/Receive/Overview) slides between the carousel pages more smoothly.** The horizontal track is now pre-promoted to its own compositor layer (`will-change: transform`), so a programmatic slide no longer pays for layer creation — a full repaint — on its first frame; a finger drag was already on a live layer, which is why swiping felt smoother than tapping.
+* [FIX][mobile] **The unfinished Earn screen is no longer reachable by swiping between the home pages.** Earn was mounted in the home swipe carousel and appeared when swiping past Receive; it is now feature-gated behind `isEarnEnabled()` (off) — the single source of truth for the home swipe pane and the top action-bar segment — so it stays hidden until the feature ships. Swap remains enabled everywhere.
 
 ## 1.15.10 (2026-07-23)
 

--- a/src/app/layouts/HomeSwipeContainer.test.tsx
+++ b/src/app/layouts/HomeSwipeContainer.test.tsx
@@ -13,6 +13,7 @@ import HomeSwipeContainer from './HomeSwipeContainer';
 const mockNavigate = jest.fn();
 let mockPathname = '/';
 const mockSwapEnabled = { value: true };
+const mockEarnEnabled = { value: false };
 
 const mockAnimateStop = jest.fn();
 const mockAnimate = jest.fn((..._args: unknown[]) => ({ stop: mockAnimateStop }));
@@ -92,7 +93,8 @@ jest.mock('screens/swap-flow/SwapManager', () => ({
 // Swap availability is gated by isSwapEnabled (false on iOS); toggle it to
 // assert the pane is added/removed and the track stays in sync.
 jest.mock('lib/feature-flags', () => ({
-  isSwapEnabled: () => mockSwapEnabled.value
+  isSwapEnabled: () => mockSwapEnabled.value,
+  isEarnEnabled: () => mockEarnEnabled.value
 }));
 
 // ---------------------------------------------------------------------------
@@ -129,6 +131,7 @@ beforeEach(() => {
   mockLastDragConstraints = null;
   mockRoCallback = null;
   mockSwapEnabled.value = true;
+  mockEarnEnabled.value = false;
 });
 
 // Drive the captured ResizeObserver callback to set a positive width.
@@ -151,13 +154,20 @@ function dragEnd(offsetX: number, velocityX = 0) {
 }
 
 describe('HomeSwipeContainer', () => {
-  it('mounts all five home pages in the track', () => {
-    const { getByTestId } = render(<HomeSwipeContainer />);
+  it('mounts the four home pages in the track, with Earn gated off', () => {
+    const { getByTestId, queryByTestId } = render(<HomeSwipeContainer />);
     expect(getByTestId('page-explore')).toBeInTheDocument();
     expect(getByTestId('page-send')).toBeInTheDocument();
     expect(getByTestId('page-receive')).toBeInTheDocument();
-    expect(getByTestId('page-earn')).toBeInTheDocument();
     expect(getByTestId('page-swap')).toBeInTheDocument();
+    // Earn is built but not exposed (isEarnEnabled === false).
+    expect(queryByTestId('page-earn')).toBeNull();
+  });
+
+  it('adds the Earn pane when earn is enabled', () => {
+    mockEarnEnabled.value = true;
+    const { getByTestId } = render(<HomeSwipeContainer />);
+    expect(getByTestId('page-earn')).toBeInTheDocument();
   });
 
   it('passes isLoading={false} to the SendFlow', () => {
@@ -165,18 +175,19 @@ describe('HomeSwipeContainer', () => {
     expect(getByTestId('page-send')).toHaveAttribute('data-loading', 'false');
   });
 
-  it('drops the Swap pane when swap is disabled, keeping the other four', () => {
+  it('drops the Swap pane when swap is disabled, keeping the other three', () => {
     mockSwapEnabled.value = false;
     const { getByTestId, queryByTestId } = render(<HomeSwipeContainer />);
     expect(queryByTestId('page-swap')).toBeNull();
     expect(getByTestId('page-explore')).toBeInTheDocument();
     expect(getByTestId('page-send')).toBeInTheDocument();
     expect(getByTestId('page-receive')).toBeInTheDocument();
-    expect(getByTestId('page-earn')).toBeInTheDocument();
-    // Track math must derive from the 4-page filtered array — not a hardcoded 5 —
-    // so the drag bounds shrink accordingly (a phantom 5th slot would fail here).
+    // Earn is gated off too, so only three panes remain.
+    expect(queryByTestId('page-earn')).toBeNull();
+    // Track math must derive from the 3-page filtered array — not a hardcoded 5 —
+    // so the drag bounds shrink accordingly (a phantom slot would fail here).
     measure(300);
-    expect(mockLastDragConstraints).toEqual({ left: -900, right: 0 }); // -(4 - 1) * 300
+    expect(mockLastDragConstraints).toEqual({ left: -600, right: 0 }); // -(3 - 1) * 300
   });
 
   it('on mount at width 0 sets the motion value directly instead of animating', () => {
@@ -289,14 +300,14 @@ describe('HomeSwipeContainer', () => {
     });
 
     it('cannot advance past the last page', () => {
-      mockPathname = '/swap'; // index 4 (last)
+      mockPathname = '/swap'; // index 3 (last, with Earn gated off)
       render(<HomeSwipeContainer />);
       measure(300);
       mockAnimate.mockClear();
-      dragEnd(-1000); // projected far left but activeIdx === PAGES.length - 1
+      dragEnd(-1000); // projected far left but activeIdx === pages.length - 1
       expect(mockNavigate).not.toHaveBeenCalled();
       // No index change -> snap back animate to the current resting position.
-      expect(mockAnimate).toHaveBeenCalledWith(mockMotionValue, -1200, expect.anything());
+      expect(mockAnimate).toHaveBeenCalledWith(mockMotionValue, -900, expect.anything());
     });
 
     it('cannot go before the first page', () => {
@@ -329,8 +340,8 @@ describe('HomeSwipeContainer', () => {
     it('clamps left to -(pages-1)*width once measured', () => {
       render(<HomeSwipeContainer />);
       measure(300);
-      // 5 pages -> left edge at -(5 - 1) * 300 = -1200
-      expect(mockLastDragConstraints).toEqual({ left: -1200, right: 0 });
+      // 4 pages (Earn gated off, Swap on) -> left edge at -(4 - 1) * 300 = -900
+      expect(mockLastDragConstraints).toEqual({ left: -900, right: 0 });
     });
   });
 

--- a/src/app/layouts/HomeSwipeContainer.tsx
+++ b/src/app/layouts/HomeSwipeContainer.tsx
@@ -6,26 +6,26 @@ import Earn from 'app/pages/Earn';
 import Explore from 'app/pages/Explore';
 import { Receive } from 'app/pages/Receive';
 import { springs } from 'lib/animation';
-import { isSwapEnabled } from 'lib/feature-flags';
+import { isEarnEnabled, isSwapEnabled } from 'lib/feature-flags';
 import { navigate, useLocation } from 'lib/woozie';
 import { SendFlow } from 'screens/send-flow/SendManager';
 import { SwapFlow } from 'screens/swap-flow/SwapManager';
 
 /**
  * Carousel container that mounts the home-group pages (Overview / Send /
- * Receive / Earn / Swap) in a horizontal track and lets the user drag
- * between them with their finger. The page tracks the finger in real
- * time and snaps to the next/previous index on release if dragged or
- * flicked past a threshold; otherwise it snaps back.
+ * Receive / Swap) in a horizontal track and lets the user drag between
+ * them with their finger. The page tracks the finger in real time and
+ * snaps to the next/previous index on release if dragged or flicked past
+ * a threshold; otherwise it snaps back.
  *
  * Pathname is the source of truth for which page is centered — the
  * SegmentedActionBar in TabLayout reads the same path and stays in sync
  * via its framer-motion layoutId pill.
  *
- * Swap is omitted on iOS (App Store Guideline 3.1.5(iii) — see isSwapEnabled).
- * Track length, page widths and the index math all derive from the same
- * filtered `pages` array, so the carousel stays consistent no matter how many
- * pages are present.
+ * The Earn (isEarnEnabled) and Swap (isSwapEnabled) panes are feature-gated
+ * and can each be absent. Track length, page widths and the index math all
+ * derive from the same filtered `pages` array, so the carousel stays
+ * consistent no matter how many panes are present.
  */
 
 interface HomePage {
@@ -49,13 +49,14 @@ const HomeSwipeContainer: FC = () => {
   const x = useMotionValue(0);
   const [width, setWidth] = useState(0);
 
-  // The Swap pane is dropped on iOS; every downstream calculation reads
-  // `pages`, so removing it can't desync the track width / index math.
+  // Earn and Swap panes are feature-gated (isEarnEnabled / isSwapEnabled);
+  // every downstream calculation reads `pages`, so dropping a pane can't
+  // desync the track width / index math.
   const pages: HomePage[] = [
     { id: 'overview', path: '/', node: <Explore /> },
     { id: 'send', path: '/send', node: <SendFlow isLoading={false} /> },
     { id: 'receive', path: '/receive', node: <Receive /> },
-    { id: 'earn', path: '/earn', node: <Earn /> },
+    ...(isEarnEnabled() ? [{ id: 'earn', path: '/earn', node: <Earn /> }] : []),
     ...(isSwapEnabled() ? [{ id: 'swap', path: '/swap', node: <SwapFlow /> }] : [])
   ];
 

--- a/src/app/layouts/TabLayout.tsx
+++ b/src/app/layouts/TabLayout.tsx
@@ -9,7 +9,7 @@ import { Icon, IconName } from 'app/icons/v2';
 import HomeSwipeContainer from 'app/layouts/HomeSwipeContainer';
 import { BottomNav, SegmentedActionBar } from 'components/ui';
 import { springs } from 'lib/animation';
-import { isSwapEnabled } from 'lib/feature-flags';
+import { isEarnEnabled, isSwapEnabled } from 'lib/feature-flags';
 import { hapticSelection } from 'lib/mobile/haptics';
 import { isReturningFromWebview } from 'lib/mobile/webview-state';
 import { isDesktop, isExtension, isMobile } from 'lib/platform';
@@ -116,12 +116,16 @@ const TabLayout: FC<PropsWithChildren> = ({ children }) => {
       label: 'Receive',
       icon: <Icon name={IconName.Receive} className="w-5 h-5" />
     },
-    // {
-    //   id: 'earn',
-    //   label: 'Earn',
-    //   icon: <Icon name={IconName.Earn} className="w-5 h-5" />
-    // },
-    // Swap is hidden on iOS (App Store Guideline 3.1.5(iii) — see isSwapEnabled).
+    // Earn and Swap segments are feature-gated (isEarnEnabled / isSwapEnabled).
+    ...(isEarnEnabled()
+      ? [
+          {
+            id: 'earn',
+            label: 'Earn',
+            icon: <Icon name={IconName.Earn} className="w-5 h-5" />
+          }
+        ]
+      : []),
     ...(isSwapEnabled()
       ? [
           {

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,7 +1,13 @@
-import { isSwapEnabled } from './feature-flags';
+import { isEarnEnabled, isSwapEnabled } from './feature-flags';
 
 describe('feature-flags — isSwapEnabled', () => {
   it('enables swap on every platform (including iOS)', () => {
     expect(isSwapEnabled()).toBe(true);
+  });
+});
+
+describe('feature-flags — isEarnEnabled', () => {
+  it('keeps Earn disabled (built but not yet exposed to users)', () => {
+    expect(isEarnEnabled()).toBe(false);
   });
 });

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -14,3 +14,18 @@
 export function isSwapEnabled(): boolean {
   return true;
 }
+
+/**
+ * In-app Earn (the DeFi vaults / positions flow) availability.
+ *
+ * Earn is built but not yet exposed to users, so it is disabled here — most
+ * visibly it keeps the unfinished Earn pane out of the home swipe carousel,
+ * where it was reachable by swiping.
+ *
+ * This is the single source of truth for Earn visibility — the home swipe pane
+ * and the top action-bar segment both read it. To ship Earn, flip this to true
+ * (the `/earn` routes already exist).
+ */
+export function isEarnEnabled(): boolean {
+  return false;
+}


### PR DESCRIPTION
## What

An unfinished **Earn** screen was reachable by swiping between the home pages — it was mounted unconditionally in the home swipe carousel (`HomeSwipeContainer`), so swiping past Receive landed on it. It shouldn't be user-visible yet.

## Fix

Gate Earn behind a new `isEarnEnabled()` feature flag (returns `false`), mirroring the existing `isSwapEnabled()` pattern as the single source of truth for the two feature-gated home surfaces:
- the home swipe carousel pane (`HomeSwipeContainer`), and
- the top action-bar segment (`TabLayout`) — previously a commented-out block, now uniformly gated by the flag.

The `/earn` routes and the earn-flow screens are untouched, so the feature stays built and one flag flip re-enables it.

**Swap is unaffected** and remains enabled everywhere (`isSwapEnabled()` → true, per #383).

## Test plan

- `tsc --noEmit` + `eslint` clean.
- `HomeSwipeContainer`, `TabLayout`, `feature-flags` suites green (65 tests): the carousel now mounts four panes (Earn absent), the track/index math derives from the filtered array (drag bounds shift to −900 for 4 panes / −600 for 3), and a new test asserts the Earn pane appears when the flag is flipped on.

No web-sdk dependency.
