### PR TITLE
feat(guardian): switch-guardian rotate flow + settings refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* [CHANGE][all] **Switching Guardian is now a dedicated two-step flow.** Guardian settings shows the active operator with a single "Rotate Guardian" action that opens a full-screen picker (`/rotate-guardian`) and a review screen (`/rotate-guardian/review`) summarising current → new operator, which keys sign, and what the old Guardian can no longer do; confirming hands off to the transaction-progress page instead of an in-place modal. Hot-key replacement navigates to the same progress page. Guardian sync now evicts a cached multisig service when the Guardian rejects our signer (401 / `authentication_failed` / `signer_not_authorized`), so a stale mid-rotation binding is rebuilt on the next tick instead of re-signing with it forever.
 * [CHANGE][all] **The Explore screen now shows only the two testnet faucets.** The curated Explore grid is trimmed to the existing Miden faucet plus a new "Forkchoice Faucet" tile (`faucets.forkchoice.xyz`), giving users two sources of testnet MIDEN; the other curated tiles (Zoro, Qash, Miden Name) are no longer shown in the grid.
 
 ## 1.15.11 (2026-07-26)

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -2704,6 +2704,10 @@
     "message": "Versuchen Sie es erneut mit Biometrie",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Gesichtserkennung",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Fingerabdruck",
     "englishSource": "Fingerprint"

--- a/public/_locales/en/en.json
+++ b/public/_locales/en/en.json
@@ -627,6 +627,7 @@
   "biometricAttemptsRemaining": "$count$ attempt(s) remaining",
   "continueWithPassword": "Continue with Password",
   "tryBiometricAgain": "Try Biometric Again",
+  "faceId": "Face ID",
   "fingerprint": "Fingerprint",
   "cameraPermissionDenied": "Camera permission denied",
   "noQrCodeFound": "No QR code found",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -2682,6 +2682,10 @@
     "message": "Try Biometric Again",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Face ID",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Fingerprint",
     "englishSource": "Fingerprint"

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -2741,6 +2741,10 @@
     "message": "Try Biometric Again",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Face ID",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Fingerprint",
     "englishSource": "Fingerprint"

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -2634,6 +2634,10 @@
     "message": "Pruebe biométrico nuevamente",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "identificación facial",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Huella dactilar",
     "englishSource": "Fingerprint"

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -2691,6 +2691,10 @@
     "message": "Essayez à nouveau la biométrie",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Identification du visage",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Empreinte digitale",
     "englishSource": "Fingerprint"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -2704,6 +2704,10 @@
     "message": "生体認証をもう一度試してください",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "顔認証",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "指紋",
     "englishSource": "Fingerprint"

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -2713,6 +2713,10 @@
     "message": "생체인식을 다시 시도해보세요",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "페이스 아이디",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "지문",
     "englishSource": "Fingerprint"

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -2634,6 +2634,10 @@
     "message": "Spróbuj ponownie biometrii",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Identyfikator twarzy",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Odcisk palca",
     "englishSource": "Fingerprint"

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -2681,6 +2681,10 @@
     "message": "Tente biométrico novamente",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "ID facial",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Impressão digital",
     "englishSource": "Fingerprint"

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -2705,6 +2705,10 @@
     "message": "Попробуйте биометрию еще раз",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Идентификатор лица",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Отпечаток пальца",
     "englishSource": "Fingerprint"

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -2692,6 +2692,10 @@
     "message": "Biyometriyi Tekrar Deneyin",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Yüz Kimliği",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Parmak izi",
     "englishSource": "Fingerprint"

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -2714,6 +2714,10 @@
     "message": "Спробуйте знову біометричні дані",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "Face ID",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "Відбиток пальця",
     "englishSource": "Fingerprint"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -2722,6 +2722,10 @@
     "message": "再次尝试生物识别",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "人脸识别",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "指纹",
     "englishSource": "Fingerprint"

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -2713,6 +2713,10 @@
     "message": "再次尝试生物识别",
     "englishSource": "Try Biometric Again"
   },
+  "faceId": {
+    "message": "人脸识别",
+    "englishSource": "Face ID"
+  },
   "fingerprint": {
     "message": "指纹",
     "englishSource": "Fingerprint"

--- a/src/app/PageRouter.test.tsx
+++ b/src/app/PageRouter.test.tsx
@@ -103,6 +103,14 @@ jest.mock('app/pages/OpenSidePanel', () => ({
 }));
 jest.mock('app/pages/Pending', () => ({ Pending: () => <div data-testid="pending" /> }));
 jest.mock('app/pages/Receive', () => ({ Receive: () => <div data-testid="receive" /> }));
+jest.mock('app/pages/RotateGuardian', () => ({
+  __esModule: true,
+  default: () => <div data-testid="rotate-guardian" />
+}));
+jest.mock('app/pages/RotateGuardianReview', () => ({
+  __esModule: true,
+  default: () => <div data-testid="rotate-guardian-review" />
+}));
 jest.mock('app/pages/Settings', () => ({
   __esModule: true,
   default: ({ tabSlug }: { tabSlug?: string }) => <div data-testid="settings" data-tab-slug={tabSlug ?? ''} />
@@ -363,6 +371,16 @@ describe('app/PageRouter — ready tab & full-screen routes', () => {
   it('/pending renders Pending inside FullScreenPage', () => {
     renderAt('/pending', ready);
     expect(screen.getByTestId('full-screen-page')).toContainElement(screen.getByTestId('pending'));
+  });
+
+  it('/rotate-guardian renders RotateGuardian inside FullScreenPage', () => {
+    renderAt('/rotate-guardian', ready);
+    expect(screen.getByTestId('full-screen-page')).toContainElement(screen.getByTestId('rotate-guardian'));
+  });
+
+  it('/rotate-guardian/review renders RotateGuardianReview inside FullScreenPage', () => {
+    renderAt('/rotate-guardian/review', ready);
+    expect(screen.getByTestId('full-screen-page')).toContainElement(screen.getByTestId('rotate-guardian-review'));
   });
 
   it('/history-details/:transactionId passes the id into HistoryDetails', () => {

--- a/src/app/PageRouter.tsx
+++ b/src/app/PageRouter.tsx
@@ -29,6 +29,8 @@ import Browser from './pages/Browser';
 import ForgotPassword from './pages/ForgotPassword/ForgotPassword';
 import ForgotPasswordInfo from './pages/ForgotPassword/ForgotPasswordInfo';
 import ResetRequired from './pages/ResetRequired';
+import RotateGuardian from './pages/RotateGuardian';
+import RotateGuardianReview from './pages/RotateGuardianReview';
 import TokenDetail from './pages/TokenDetail';
 import { resolveRootView } from './root-view';
 import { HistoryDetails } from './templates/history/HistoryDetails';
@@ -160,6 +162,22 @@ const ROUTE_MAP = Woozie.Router.createMap<RouteContext>([
     onlyReady(() => (
       <FullScreenPage>
         <Pending />
+      </FullScreenPage>
+    ))
+  ],
+  [
+    '/rotate-guardian',
+    onlyReady(() => (
+      <FullScreenPage>
+        <RotateGuardian />
+      </FullScreenPage>
+    ))
+  ],
+  [
+    '/rotate-guardian/review',
+    onlyReady(() => (
+      <FullScreenPage>
+        <RotateGuardianReview />
       </FullScreenPage>
     ))
   ],

--- a/src/app/hooks/useCurrentGuardianEndpoint.test.ts
+++ b/src/app/hooks/useCurrentGuardianEndpoint.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { fetchFromStorage, onStorageChanged } from 'lib/miden/front';
+
+import {
+  guardianEndpointHost,
+  guardianOptionForEndpoint,
+  useCurrentGuardianEndpoint
+} from './useCurrentGuardianEndpoint';
+
+jest.mock('lib/miden/front', () => ({
+  fetchFromStorage: jest.fn(),
+  onStorageChanged: jest.fn()
+}));
+
+jest.mock('lib/miden-chain/constants', () => ({
+  GUARDIAN_OPTIONS: [
+    {
+      name: 'Guardian One',
+      endpoint: new Map([
+        ['testnet', 'https://test.guardian.example'],
+        ['devnet', 'https://dev.guardian.example']
+      ])
+    }
+  ]
+}));
+
+jest.mock('lib/settings/constants', () => ({
+  GUARDIAN_URL_STORAGE_KEY: 'guardian_url_setting'
+}));
+
+const mockFetchFromStorage = fetchFromStorage as jest.MockedFunction<typeof fetchFromStorage>;
+const mockOnStorageChanged = onStorageChanged as jest.MockedFunction<typeof onStorageChanged>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchFromStorage.mockResolvedValue(undefined);
+  mockOnStorageChanged.mockReturnValue(jest.fn());
+});
+
+it('loads the stored endpoint and refreshes it on demand', async () => {
+  mockFetchFromStorage.mockResolvedValueOnce('https://first.guardian').mockResolvedValueOnce('https://next.guardian');
+  const { result } = renderHook(() => useCurrentGuardianEndpoint());
+
+  await waitFor(() => expect(result.current.endpoint).toBe('https://first.guardian'));
+  act(() => result.current.refresh());
+  await waitFor(() => expect(result.current.endpoint).toBe('https://next.guardian'));
+  expect(mockFetchFromStorage).toHaveBeenCalledTimes(2);
+});
+
+it('falls back to an empty endpoint when storage rejects', async () => {
+  mockFetchFromStorage.mockRejectedValue(new Error('storage unavailable'));
+  const { result } = renderHook(() => useCurrentGuardianEndpoint());
+
+  await waitFor(() => expect(mockFetchFromStorage).toHaveBeenCalled());
+  expect(result.current.endpoint).toBe('');
+});
+
+it('reacts to storage changes and unsubscribes on unmount', async () => {
+  const unsubscribe = jest.fn();
+  let onChange: ((next: string | null | undefined) => void) | undefined;
+  mockOnStorageChanged.mockImplementation((_key, callback) => {
+    onChange = callback;
+    return unsubscribe;
+  });
+  const { result, unmount } = renderHook(() => useCurrentGuardianEndpoint());
+  await waitFor(() => expect(onChange).toBeDefined());
+
+  act(() => onChange?.('https://changed.guardian'));
+  expect(result.current.endpoint).toBe('https://changed.guardian');
+  act(() => onChange?.(undefined));
+  expect(result.current.endpoint).toBe('');
+
+  unmount();
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+});
+
+it('matches guardian options across network endpoints', () => {
+  expect(guardianOptionForEndpoint('https://dev.guardian.example')?.name).toBe('Guardian One');
+  expect(guardianOptionForEndpoint('https://custom.guardian')).toBeUndefined();
+});
+
+it('formats guardian hosts and preserves invalid custom values', () => {
+  expect(guardianEndpointHost('https://guardian.example/path')).toBe('guardian.example');
+  expect(guardianEndpointHost('custom guardian')).toBe('custom guardian');
+});

--- a/src/app/hooks/useCurrentGuardianEndpoint.ts
+++ b/src/app/hooks/useCurrentGuardianEndpoint.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { fetchFromStorage, onStorageChanged } from 'lib/miden/front';
+import { GUARDIAN_OPTIONS } from 'lib/miden-chain/constants';
+import { GUARDIAN_URL_STORAGE_KEY } from 'lib/settings/constants';
+import type { GuardianOption } from 'lib/shared/types';
+
+export function useCurrentGuardianEndpoint(): { endpoint: string; refresh: () => void } {
+  const [endpoint, setEndpoint] = useState<string>('');
+  const [nonce, setNonce] = useState(0);
+  const refresh = useCallback(() => setNonce(n => n + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchFromStorage<string>(GUARDIAN_URL_STORAGE_KEY)
+      .then(stored => {
+        if (cancelled) return;
+        setEndpoint(stored ?? '');
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setEndpoint('');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [nonce]);
+
+  // Extension builds get storage-change events for free; on mobile/desktop this
+  // is a no-op and the explicit refresh() call after switch handles the update.
+  useEffect(
+    () =>
+      onStorageChanged<string>(GUARDIAN_URL_STORAGE_KEY, next => {
+        setEndpoint(next ?? '');
+      }),
+    []
+  );
+
+  return { endpoint, refresh };
+}
+
+// A provider now maps each supported network to its endpoint there, so match
+// against any of them — the caller only knows the endpoint, not the network.
+export function guardianOptionForEndpoint(endpoint: string): GuardianOption | undefined {
+  return GUARDIAN_OPTIONS.find(o => [...o.endpoint.values()].includes(endpoint));
+}
+
+// "https://guardian.miden.io/foo" -> "guardian.miden.io"; falls back to the raw
+// string for custom endpoints that don't parse as URLs.
+export function guardianEndpointHost(endpoint: string): string {
+  try {
+    return new URL(endpoint).host;
+  } catch {
+    return endpoint;
+  }
+}

--- a/src/app/pages/RotateGuardian.test.tsx
+++ b/src/app/pages/RotateGuardian.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * RotateGuardian — the guardian-rotation picker page. It wraps
+ * `ChooseGuardianScreen`, refuses a no-op switch (same endpoint as the current
+ * one), and otherwise hands the chosen endpoint to the review route as a query
+ * param. Every collaborator is stubbed so only this page's logic is exercised.
+ */
+
+import React from 'react';
+
+import { act, render, screen } from '@testing-library/react';
+
+import RotateGuardian from './RotateGuardian';
+
+const mockUseCurrentGuardianEndpoint = jest.fn();
+jest.mock('app/hooks/useCurrentGuardianEndpoint', () => ({
+  useCurrentGuardianEndpoint: () => mockUseCurrentGuardianEndpoint()
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+jest.mock('app/layouts/PageLayout', () => ({
+  __esModule: true,
+  default: ({ pageTitle, children }: { pageTitle?: React.ReactNode; children?: React.ReactNode }) => (
+    <div data-testid="page-layout">
+      <div data-testid="page-title">{pageTitle}</div>
+      {children}
+    </div>
+  )
+}));
+
+// Captured so tests can drive `onSubmit` directly and assert the props the page
+// hands down (current endpoint highlight + custom-endpoint affordance).
+let chooseProps: { onSubmit?: (p: { guardianId: string; guardianEndpoint: string }) => void } & Record<
+  string,
+  unknown
+> = {};
+jest.mock('screens/onboarding/common/ChooseGuardian', () => ({
+  ChooseGuardianScreen: (props: Record<string, unknown>) => {
+    chooseProps = props;
+    return <div data-testid="choose-guardian" />;
+  }
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('lib/woozie', () => ({ navigate: (arg: unknown) => mockNavigate(arg) }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  chooseProps = {};
+  mockUseCurrentGuardianEndpoint.mockReturnValue({ endpoint: 'https://current.guardian', refresh: jest.fn() });
+});
+
+it('passes the current endpoint down and allows a custom one', () => {
+  render(<RotateGuardian />);
+
+  expect(screen.getByTestId('choose-guardian')).toBeInTheDocument();
+  expect(screen.getByTestId('page-title')).toHaveTextContent('rotateGuardian');
+  expect(chooseProps.currentEndpoint).toBe('https://current.guardian');
+  expect(chooseProps.allowCustomEndpoint).toBe(true);
+});
+
+it('navigates to the review route with the chosen endpoint encoded', () => {
+  render(<RotateGuardian />);
+
+  act(() => chooseProps.onSubmit?.({ guardianId: 'next', guardianEndpoint: 'https://next.guardian/x' }));
+
+  expect(mockNavigate).toHaveBeenCalledWith({
+    pathname: '/rotate-guardian/review',
+    search: `?endpoint=${encodeURIComponent('https://next.guardian/x')}`
+  });
+});
+
+it('refuses a switch to the endpoint already in use', () => {
+  render(<RotateGuardian />);
+
+  act(() => chooseProps.onSubmit?.({ guardianId: 'same', guardianEndpoint: 'https://current.guardian' }));
+
+  expect(mockNavigate).not.toHaveBeenCalled();
+  expect(screen.getByText('guardianEndpointUnchanged')).toBeInTheDocument();
+});
+
+it('clears a stale unchanged-endpoint error once a different guardian is picked', () => {
+  render(<RotateGuardian />);
+
+  act(() => chooseProps.onSubmit?.({ guardianId: 'same', guardianEndpoint: 'https://current.guardian' }));
+  expect(screen.getByText('guardianEndpointUnchanged')).toBeInTheDocument();
+
+  act(() => chooseProps.onSubmit?.({ guardianId: 'next', guardianEndpoint: 'https://next.guardian' }));
+
+  expect(screen.queryByText('guardianEndpointUnchanged')).not.toBeInTheDocument();
+  expect(mockNavigate).toHaveBeenCalledTimes(1);
+});

--- a/src/app/pages/RotateGuardian.tsx
+++ b/src/app/pages/RotateGuardian.tsx
@@ -1,0 +1,38 @@
+import React, { FC, useCallback, useState } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { useCurrentGuardianEndpoint } from 'app/hooks/useCurrentGuardianEndpoint';
+import PageLayout from 'app/layouts/PageLayout';
+import { navigate } from 'lib/woozie';
+import { ChooseGuardianScreen } from 'screens/onboarding/common/ChooseGuardian';
+
+const RotateGuardian: FC = () => {
+  const { t } = useTranslation();
+  const { endpoint: currentEndpoint } = useCurrentGuardianEndpoint();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(
+    ({ guardianEndpoint }: { guardianId: string; guardianEndpoint: string }) => {
+      if (guardianEndpoint === currentEndpoint) {
+        setError(t('guardianEndpointUnchanged'));
+        return;
+      }
+      setError(null);
+      navigate({
+        pathname: '/rotate-guardian/review',
+        search: `?endpoint=${encodeURIComponent(guardianEndpoint)}`
+      });
+    },
+    [currentEndpoint, t]
+  );
+
+  return (
+    <PageLayout pageTitle={<>{t('rotateGuardian')}</>}>
+      <ChooseGuardianScreen onSubmit={handleSubmit} currentEndpoint={currentEndpoint} allowCustomEndpoint />
+      {error && <div className="px-6 pb-6 -mt-2 text-red-500 text-xs text-center select-text">{error}</div>}
+    </PageLayout>
+  );
+};
+
+export default RotateGuardian;

--- a/src/app/pages/RotateGuardianReview.test.tsx
+++ b/src/app/pages/RotateGuardianReview.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * RotateGuardianReview — the confirm screen for a guardian rotation. It reads
+ * the target endpoint off the query string, renders current → new operator
+ * names, labels the hot key by how it's protected on this device, and on
+ * Continue initiates the switch-guardian transaction and hands off to the
+ * generating-transaction page. All collaborators are stubbed so only this
+ * page's logic runs.
+ */
+
+import React from 'react';
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import RotateGuardianReview from './RotateGuardianReview';
+
+const mockUseCurrentGuardianEndpoint = jest.fn();
+const mockGuardianOptionForEndpoint = jest.fn();
+const mockGuardianEndpointHost = jest.fn();
+jest.mock('app/hooks/useCurrentGuardianEndpoint', () => ({
+  useCurrentGuardianEndpoint: () => mockUseCurrentGuardianEndpoint(),
+  guardianOptionForEndpoint: (endpoint: string) => mockGuardianOptionForEndpoint(endpoint),
+  guardianEndpointHost: (endpoint: string) => mockGuardianEndpointHost(endpoint)
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+jest.mock('app/layouts/PageLayout', () => ({
+  __esModule: true,
+  default: ({ pageTitle, children }: { pageTitle?: React.ReactNode; children?: React.ReactNode }) => (
+    <div data-testid="page-layout">
+      <div data-testid="page-title">{pageTitle}</div>
+      {children}
+    </div>
+  )
+}));
+
+jest.mock('app/icons/v2', () => ({
+  Icon: () => <span data-testid="icon" />,
+  IconName: { ArrowDown: 'arrow-down' }
+}));
+
+jest.mock('components/Alert', () => ({
+  Alert: ({ title }: { title?: React.ReactNode }) => <div data-testid="alert">{title}</div>,
+  AlertVariant: { Warning: 'warning' }
+}));
+
+jest.mock('components/Button', () => ({
+  Button: ({ title, onClick, disabled }: { title: string; onClick: () => void; disabled?: boolean }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {title}
+    </button>
+  )
+}));
+
+jest.mock('lib/ui/DetailCard', () => ({
+  DetailCard: ({ children }: { children: React.ReactNode }) => <div data-testid="detail-card">{children}</div>,
+  DetailRow: ({ label, value }: { label: string; value: string }) => (
+    <div data-testid="detail-row" data-label={label}>
+      {value}
+    </div>
+  )
+}));
+
+const mockIsBiometricEnabled = jest.fn();
+const mockCheckBiometricAvailability = jest.fn();
+jest.mock('lib/biometric', () => ({
+  isBiometricEnabled: () => mockIsBiometricEnabled(),
+  checkBiometricAvailability: () => mockCheckBiometricAvailability()
+}));
+
+const mockInitiateSwitch = jest.fn();
+const mockRequestSWProcessing = jest.fn();
+jest.mock('lib/miden/activity', () => ({
+  initiateSwitchGuardianTransaction: (...args: unknown[]) => mockInitiateSwitch(...args),
+  requestSWTransactionProcessing: () => mockRequestSWProcessing()
+}));
+
+jest.mock('lib/miden/front/guardian-sync', () => ({ zustandProvider: { __provider: true } }));
+
+const mockIsExtension = jest.fn();
+jest.mock('lib/platform', () => ({ isExtension: () => mockIsExtension() }));
+
+const mockIsDelegateProofEnabled = jest.fn();
+jest.mock('lib/settings/helpers', () => ({ isDelegateProofEnabled: () => mockIsDelegateProofEnabled() }));
+
+const storeState: { currentAccount: { publicKey: string } | null } = { currentAccount: { publicKey: 'pk_1' } };
+jest.mock('lib/store', () => ({
+  useWalletStore: (selector: (s: typeof storeState) => unknown) => selector(storeState)
+}));
+
+const mockNavigate = jest.fn();
+const mockSearch = { value: '?endpoint=https%3A%2F%2Fnext.guardian' };
+jest.mock('lib/woozie', () => ({
+  navigate: (path: string) => mockNavigate(path),
+  useLocation: () => ({ search: mockSearch.value })
+}));
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  storeState.currentAccount = { publicKey: 'pk_1' };
+  mockSearch.value = '?endpoint=https%3A%2F%2Fnext.guardian';
+  mockUseCurrentGuardianEndpoint.mockReturnValue({ endpoint: 'https://current.guardian', refresh: jest.fn() });
+  mockGuardianOptionForEndpoint.mockImplementation((endpoint: string) =>
+    endpoint === 'https://current.guardian' ? { name: 'Current Op' } : { name: 'Next Op' }
+  );
+  mockGuardianEndpointHost.mockImplementation((endpoint: string) => endpoint);
+  mockIsBiometricEnabled.mockResolvedValue(false);
+  mockCheckBiometricAvailability.mockResolvedValue({ biometryType: 'none' });
+  mockInitiateSwitch.mockResolvedValue('tx-1');
+  mockIsExtension.mockReturnValue(false);
+  mockIsDelegateProofEnabled.mockReturnValue(false);
+});
+
+const clickContinue = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+  });
+};
+
+describe('RotateGuardianReview — rendering', () => {
+  it('renders the current and target operator names', async () => {
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(screen.getByTestId('page-title')).toHaveTextContent('reviewRotation');
+    expect(screen.getByText('Current Op')).toBeInTheDocument();
+    expect(screen.getByText('Next Op')).toBeInTheDocument();
+  });
+
+  it('falls back to the endpoint host for unmatched (custom) operators', async () => {
+    mockGuardianOptionForEndpoint.mockReturnValue(undefined);
+    mockGuardianEndpointHost.mockImplementation((endpoint: string) => `host(${endpoint})`);
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(screen.getByText('host(https://current.guardian)')).toBeInTheDocument();
+    expect(screen.getByText('host(https://next.guardian)')).toBeInTheDocument();
+  });
+
+  it('shows a loading placeholder until the current endpoint resolves', async () => {
+    mockUseCurrentGuardianEndpoint.mockReturnValue({ endpoint: '', refresh: jest.fn() });
+    mockGuardianOptionForEndpoint.mockImplementation((endpoint: string) =>
+      endpoint ? { name: 'Next Op' } : undefined
+    );
+    mockGuardianEndpointHost.mockImplementation((endpoint: string) => endpoint);
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(screen.getByText('loading')).toBeInTheDocument();
+  });
+
+  it('treats a missing endpoint param as empty and disables Continue', async () => {
+    mockSearch.value = '';
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(screen.getByRole('button', { name: 'continue' })).toBeDisabled();
+  });
+
+  it('disables Continue when there is no current account', async () => {
+    storeState.currentAccount = null;
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(screen.getByRole('button', { name: 'continue' })).toBeDisabled();
+  });
+});
+
+describe('RotateGuardianReview — hot key label', () => {
+  const hotKeyValue = () =>
+    screen.getAllByTestId('detail-row').find(el => el.getAttribute('data-label') === 'walletKeyHot')?.textContent;
+
+  it('defaults to password when biometrics are off', async () => {
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(hotKeyValue()).toBe('password');
+    expect(mockCheckBiometricAvailability).not.toHaveBeenCalled();
+  });
+
+  it('labels a face-capable device with Face ID', async () => {
+    mockIsBiometricEnabled.mockResolvedValue(true);
+    mockCheckBiometricAvailability.mockResolvedValue({ biometryType: 'face' });
+    render(<RotateGuardianReview />);
+
+    await waitFor(() => expect(hotKeyValue()).toBe('faceId'));
+  });
+
+  it('labels any other enrolled biometric as a fingerprint', async () => {
+    mockIsBiometricEnabled.mockResolvedValue(true);
+    mockCheckBiometricAvailability.mockResolvedValue({ biometryType: 'touch' });
+    render(<RotateGuardianReview />);
+
+    await waitFor(() => expect(hotKeyValue()).toBe('fingerprint'));
+  });
+
+  it('keeps the password fallback when availability reports none', async () => {
+    mockIsBiometricEnabled.mockResolvedValue(true);
+    mockCheckBiometricAvailability.mockResolvedValue({ biometryType: 'none' });
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(hotKeyValue()).toBe('password');
+  });
+
+  it('keeps the password fallback when the biometric probe throws', async () => {
+    mockIsBiometricEnabled.mockRejectedValue(new Error('no biometric stack'));
+    render(<RotateGuardianReview />);
+    await flush();
+
+    expect(hotKeyValue()).toBe('password');
+  });
+
+  it('does not label after unmount (cancelled probe)', async () => {
+    let resolveAvailability: (v: { biometryType: string }) => void = () => {};
+    mockIsBiometricEnabled.mockResolvedValue(true);
+    mockCheckBiometricAvailability.mockReturnValue(
+      new Promise<{ biometryType: string }>(resolve => {
+        resolveAvailability = resolve;
+      })
+    );
+    const { unmount } = render(<RotateGuardianReview />);
+    unmount();
+
+    await act(async () => {
+      resolveAvailability({ biometryType: 'face' });
+    });
+
+    // Nothing to assert on the DOM — the guard exists so React doesn't warn on
+    // a post-unmount setState; reaching here without a throw is the assertion.
+    expect(mockCheckBiometricAvailability).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('RotateGuardianReview — submit', () => {
+  it('initiates the switch and navigates to the transaction page', async () => {
+    render(<RotateGuardianReview />);
+    await flush();
+    await clickContinue();
+
+    expect(mockInitiateSwitch).toHaveBeenCalledWith('pk_1', 'https://next.guardian', false, { __provider: true });
+    expect(mockRequestSWProcessing).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/generating-transaction-full/tx-1');
+  });
+
+  it('nudges the service worker on extension builds', async () => {
+    mockIsExtension.mockReturnValue(true);
+    render(<RotateGuardianReview />);
+    await flush();
+    await clickContinue();
+
+    expect(mockRequestSWProcessing).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the delegate-proving preference', async () => {
+    mockIsDelegateProofEnabled.mockReturnValue(true);
+    render(<RotateGuardianReview />);
+    await flush();
+    await clickContinue();
+
+    expect(mockInitiateSwitch).toHaveBeenCalledWith('pk_1', 'https://next.guardian', true, { __provider: true });
+  });
+
+  it('surfaces an Error rejection and stays on the page', async () => {
+    mockInitiateSwitch.mockRejectedValue(new Error('guardian refused'));
+    render(<RotateGuardianReview />);
+    await flush();
+    await clickContinue();
+
+    expect(screen.getByText('guardian refused')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('stringifies a non-Error rejection', async () => {
+    mockInitiateSwitch.mockRejectedValue('plain string boom');
+    render(<RotateGuardianReview />);
+    await flush();
+    await clickContinue();
+
+    expect(screen.getByText('plain string boom')).toBeInTheDocument();
+  });
+
+  it('shows the loading label and blocks re-entry while a submit is in flight', async () => {
+    let resolveInitiate: (v: string) => void = () => {};
+    mockInitiateSwitch.mockReturnValue(
+      new Promise<string>(resolve => {
+        resolveInitiate = resolve;
+      })
+    );
+    render(<RotateGuardianReview />);
+    await flush();
+    await clickContinue();
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('loading');
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      resolveInitiate('tx-2');
+    });
+
+    expect(mockInitiateSwitch).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/generating-transaction-full/tx-2');
+  });
+});

--- a/src/app/pages/RotateGuardianReview.tsx
+++ b/src/app/pages/RotateGuardianReview.tsx
@@ -1,0 +1,133 @@
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import {
+  guardianEndpointHost,
+  guardianOptionForEndpoint,
+  useCurrentGuardianEndpoint
+} from 'app/hooks/useCurrentGuardianEndpoint';
+import { Icon, IconName } from 'app/icons/v2';
+import PageLayout from 'app/layouts/PageLayout';
+import { Alert, AlertVariant } from 'components/Alert';
+import { Button } from 'components/Button';
+import { checkBiometricAvailability, isBiometricEnabled } from 'lib/biometric';
+import { initiateSwitchGuardianTransaction, requestSWTransactionProcessing } from 'lib/miden/activity';
+import { zustandProvider } from 'lib/miden/front/guardian-sync';
+import { isExtension } from 'lib/platform';
+import { isDelegateProofEnabled } from 'lib/settings/helpers';
+import { useWalletStore } from 'lib/store';
+import { DetailCard, DetailRow } from 'lib/ui/DetailCard';
+import { navigate, useLocation } from 'lib/woozie';
+
+const RotateGuardianReview: FC = () => {
+  const { t } = useTranslation();
+  const { search } = useLocation();
+  const { endpoint: currentEndpoint } = useCurrentGuardianEndpoint();
+  const currentAccount = useWalletStore(s => s.currentAccount);
+
+  const newEndpoint = useMemo(() => new URLSearchParams(search).get('endpoint') ?? '', [search]);
+
+  const currentName = guardianOptionForEndpoint(currentEndpoint)?.name ?? guardianEndpointHost(currentEndpoint);
+  const newName = guardianOptionForEndpoint(newEndpoint)?.name ?? guardianEndpointHost(newEndpoint);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // The hot key co-signs from the unlocked vault; surface how it's protected
+  // on this device (biometric flavor or password) like the design's key rows.
+  const [hotKeyLabel, setHotKeyLabel] = useState(() => t('password'));
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        if (!(await isBiometricEnabled())) return;
+        const availability = await checkBiometricAvailability();
+        if (cancelled) return;
+        if (availability.biometryType === 'face') setHotKeyLabel(t('faceId'));
+        else if (availability.biometryType !== 'none') setHotKeyLabel(t('fingerprint'));
+      } catch {
+        // Keep the password fallback.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const handleContinue = useCallback(async () => {
+    if (!currentAccount || !newEndpoint || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const txId = await initiateSwitchGuardianTransaction(
+        currentAccount.publicKey,
+        newEndpoint,
+        isDelegateProofEnabled(),
+        zustandProvider
+      );
+      if (isExtension()) requestSWTransactionProcessing();
+      navigate(`/generating-transaction-full/${encodeURIComponent(txId)}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [currentAccount, newEndpoint, submitting]);
+
+  return (
+    <PageLayout pageTitle={<>{t('reviewRotation')}</>}>
+      <div className="h-full overflow-y-auto">
+        <div className="w-full max-w-sm mx-auto px-4 pb-8 flex flex-col min-h-full">
+          <div className="rounded-2xl bg-surface-interactive px-4 py-8 flex flex-col items-center">
+            <span className="px-3 py-1 rounded-lg bg-white dark:bg-grey-800 text-sm font-medium text-text-tertiary-token">
+              {t('currentLabel')}
+            </span>
+            <h2 className="mt-3 text-3xl font-semibold font-heading text-heading-gray text-center break-all">
+              {currentName || t('loading')}
+            </h2>
+            <div className="my-5 w-10 h-10 rounded-lg bg-primary-500 flex items-center justify-center">
+              <Icon name={IconName.ArrowDown} fill="white" size="sm" />
+            </div>
+            <span className="px-3 py-1 rounded-lg bg-white dark:bg-grey-800 text-sm font-medium text-text-tertiary-token">
+              {t('newLabel')}
+            </span>
+            <h2 className="mt-3 text-3xl font-semibold font-heading text-heading-gray text-center break-all">
+              {newName}
+            </h2>
+          </div>
+
+          <div className="mt-4">
+            <DetailCard>
+              <DetailRow label={t('walletKeyHot')} value={hotKeyLabel} />
+              <DetailRow label={t('recoveryPhraseCold')} value={t('required')} isLast />
+            </DetailCard>
+          </div>
+
+          <Alert
+            variant={AlertVariant.Warning}
+            className="mt-4"
+            title={
+              <span className="block">
+                <span className="block text-sm font-semibold text-heading-gray">{t('oldGuardianCantBlockTitle')}</span>
+                <span className="block mt-1">{t('oldGuardianCantBlockBody')}</span>
+              </span>
+            }
+          />
+
+          {error && <div className="mt-3 text-red-500 text-xs select-text">{error}</div>}
+
+          <div className="mt-auto pt-6">
+            <Button
+              title={submitting ? t('loading') : t('continue')}
+              onClick={handleContinue}
+              disabled={submitting || !currentAccount || !newEndpoint}
+            />
+          </div>
+        </div>
+      </div>
+    </PageLayout>
+  );
+};
+
+export default RotateGuardianReview;

--- a/src/app/templates/GuardianReplaceHotKey.test.tsx
+++ b/src/app/templates/GuardianReplaceHotKey.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+
+import { isExtension } from 'lib/platform';
 
 import GuardianReplaceHotKey from './GuardianReplaceHotKey';
 
@@ -52,13 +54,16 @@ jest.mock('lib/miden/activity', () => ({
 
 jest.mock('lib/miden/front/guardian-sync', () => ({ zustandProvider: { __provider: true } }));
 
-const mockIsExtension = jest.fn();
-jest.mock('lib/platform', () => ({ isExtension: () => mockIsExtension() }));
+jest.mock('lib/platform', () => ({ isExtension: jest.fn() }));
+const mockIsExtension = isExtension as jest.MockedFunction<typeof isExtension>;
 
 const mockIsDelegateProofEnabled = jest.fn();
 jest.mock('lib/settings/helpers', () => ({
   isDelegateProofEnabled: () => mockIsDelegateProofEnabled()
 }));
+
+const mockNavigate = jest.fn();
+jest.mock('lib/woozie', () => ({ navigate: (...a: unknown[]) => mockNavigate(...a) }));
 
 // Store that satisfies both the hook-selector call form and `.getState()`.
 const mockState: any = {
@@ -177,7 +182,7 @@ describe('GuardianReplaceHotKey — rotation', () => {
     await click(); // second tap → rotation
   };
 
-  it('completes a rotation: opens the tx modal and shows the success message', async () => {
+  it('completes a rotation and navigates to transaction progress', async () => {
     render(<GuardianReplaceHotKey />);
 
     await confirmRotate();
@@ -185,15 +190,12 @@ describe('GuardianReplaceHotKey — rotation', () => {
     // Cold-signed rotation: publicKey, delegate flag (false), provider.
     expect(mockInitiate).toHaveBeenCalledTimes(1);
     expect(mockInitiate).toHaveBeenCalledWith('pk_1', false, { __provider: true });
-    expect(mockState.openTransactionModal).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/generating-transaction-full/tx-1');
     // Non-extension build skips the service-worker processing nudge.
     expect(mockRequestSWProcessing).not.toHaveBeenCalled();
-    expect(mockWaitForCompletion).toHaveBeenCalledWith('tx-1');
-
-    expect(screen.getByText('hotKeyRotated')).toBeInTheDocument();
-    // confirming cleared on success → confirmation copy hidden, label reset.
-    expect(screen.queryByText('replaceHotKeyConfirmation')).not.toBeInTheDocument();
-    expect(label()).toBe('replaceHotKey');
+    // The screen remains armed for confirmation while navigation takes over.
+    expect(screen.getByText('replaceHotKeyConfirmation')).toBeInTheDocument();
+    expect(label()).toBe('confirmReplaceHotKey');
     expect(fsbHolder.props.loading).toBe(false);
   });
 
@@ -213,12 +215,12 @@ describe('GuardianReplaceHotKey — rotation', () => {
     await confirmRotate();
 
     expect(mockRequestSWProcessing).toHaveBeenCalledTimes(1);
-    expect(screen.getByText('hotKeyRotated')).toBeInTheDocument();
+    expect(mockNavigate).toHaveBeenCalledWith('/generating-transaction-full/tx-1');
   });
 
   it('marks the button loading while the rotation is in flight', async () => {
-    const gate = deferred<{ status: string }>();
-    mockWaitForCompletion.mockReturnValue(gate.promise);
+    const gate = deferred<string>();
+    mockInitiate.mockReturnValue(gate.promise);
     render(<GuardianReplaceHotKey />);
 
     await click(); // confirming
@@ -234,28 +236,15 @@ describe('GuardianReplaceHotKey — rotation', () => {
     await flush();
 
     expect(fsbHolder.props.loading).toBe(true);
-    expect(screen.queryByText('hotKeyRotated')).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
 
     // Resolve the in-flight tx → success, loading cleared.
     await act(async () => {
-      gate.resolve({ status: 'ok' });
+      gate.resolve('tx-1');
     });
     await flush();
 
-    expect(screen.getByText('hotKeyRotated')).toBeInTheDocument();
-    expect(fsbHolder.props.loading).toBe(false);
-  });
-
-  it('surfaces a chain error carried on the completion result and stays confirming', async () => {
-    mockWaitForCompletion.mockResolvedValue({ errorMessage: 'chain rejected the rotation' });
-    render(<GuardianReplaceHotKey />);
-
-    await confirmRotate();
-
-    expect(screen.getByText('chain rejected the rotation')).toBeInTheDocument();
-    expect(screen.queryByText('hotKeyRotated')).not.toBeInTheDocument();
-    // errorMessage branch returns before clearing confirming.
-    expect(label()).toBe('confirmReplaceHotKey');
+    expect(mockNavigate).toHaveBeenCalledWith('/generating-transaction-full/tx-1');
     expect(fsbHolder.props.loading).toBe(false);
   });
 
@@ -266,7 +255,7 @@ describe('GuardianReplaceHotKey — rotation', () => {
     await confirmRotate();
 
     expect(screen.getByText('initiate exploded')).toBeInTheDocument();
-    expect(screen.queryByText('hotKeyRotated')).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('stringifies a non-Error rejection', async () => {
@@ -279,8 +268,8 @@ describe('GuardianReplaceHotKey — rotation', () => {
   });
 
   it('clears a prior error when a fresh rotation is submitted', async () => {
-    // First rotation fails with a chain error (leaves component confirming).
-    mockWaitForCompletion.mockResolvedValueOnce({ errorMessage: 'first boom' });
+    // First rotation fails (leaves component confirming).
+    mockInitiate.mockRejectedValueOnce(new Error('first boom'));
     render(<GuardianReplaceHotKey />);
 
     await confirmRotate();
@@ -291,44 +280,6 @@ describe('GuardianReplaceHotKey — rotation', () => {
     await click();
 
     expect(screen.queryByText('first boom')).not.toBeInTheDocument();
-    expect(screen.getByText('hotKeyRotated')).toBeInTheDocument();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Success animation → onClose plumbing.
-// ---------------------------------------------------------------------------
-describe('GuardianReplaceHotKey — onClose', () => {
-  const confirmRotate = async () => {
-    await click();
-    await click();
-  };
-
-  it('invokes onClose when the success message finishes animating', async () => {
-    const onClose = jest.fn();
-    render(<GuardianReplaceHotKey onClose={onClose} />);
-
-    await confirmRotate();
-    const success = screen.getByText('hotKeyRotated');
-
-    act(() => {
-      fireEvent.animationEnd(success);
-    });
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not crash on the success animation end when onClose is omitted', async () => {
-    render(<GuardianReplaceHotKey />);
-
-    await confirmRotate();
-    const success = screen.getByText('hotKeyRotated');
-
-    // `onClose?.()` — optional-chaining no-op, must not throw.
-    expect(() =>
-      act(() => {
-        fireEvent.animationEnd(success);
-      })
-    ).not.toThrow();
+    expect(mockNavigate).toHaveBeenCalledWith('/generating-transaction-full/tx-1');
   });
 });

--- a/src/app/templates/GuardianReplaceHotKey.tsx
+++ b/src/app/templates/GuardianReplaceHotKey.tsx
@@ -3,33 +3,25 @@ import React, { FC, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import FormSubmitButton from 'app/atoms/FormSubmitButton';
-import {
-  initiateReplaceHotKeyTransaction,
-  requestSWTransactionProcessing,
-  waitForTransactionCompletion
-} from 'lib/miden/activity';
+import { initiateReplaceHotKeyTransaction, requestSWTransactionProcessing } from 'lib/miden/activity';
 import { zustandProvider } from 'lib/miden/front/guardian-sync';
 import { isExtension } from 'lib/platform';
 import { isDelegateProofEnabled } from 'lib/settings/helpers';
 import { useWalletStore } from 'lib/store';
-
-type Props = {
-  onClose?: () => void;
-};
+import { navigate } from 'lib/woozie';
 
 /**
  * Proactive hot-key rotation. Cold-signed (recovery key); the on-chain proposal
  * swaps the hot signer commitment in-place via update_signers. The seed phrase
  * is NOT required — the cold key derived at create time is already in the vault.
  */
-const GuardianReplaceHotKey: FC<Props> = ({ onClose }) => {
+const GuardianReplaceHotKey: FC = () => {
   const { t } = useTranslation();
   const currentAccount = useWalletStore(s => s.currentAccount);
 
   const [confirming, setConfirming] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
 
   const onClick = useCallback(async () => {
     if (!currentAccount) return;
@@ -39,23 +31,14 @@ const GuardianReplaceHotKey: FC<Props> = ({ onClose }) => {
     }
     setSubmitting(true);
     setError(null);
-    setSuccess(false);
     try {
       const txId = await initiateReplaceHotKeyTransaction(
         currentAccount.publicKey,
         isDelegateProofEnabled(),
         zustandProvider
       );
-      useWalletStore.getState().openTransactionModal();
       if (isExtension()) requestSWTransactionProcessing();
-
-      const result = await waitForTransactionCompletion(txId);
-      if ('errorMessage' in result) {
-        setError(result.errorMessage);
-        return;
-      }
-      setSuccess(true);
-      setConfirming(false);
+      navigate(`/generating-transaction-full/${encodeURIComponent(txId)}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -68,9 +51,7 @@ const GuardianReplaceHotKey: FC<Props> = ({ onClose }) => {
       <p className="text-sm text-heading-gray font-medium mb-1">{t('replaceHotKey')}</p>
       <p className="text-xs text-heading-gray mb-3 select-text">{t('replaceHotKeyDescription')}</p>
 
-      {confirming && !success && (
-        <div className="text-xs text-heading-gray mb-3 select-text">{t('replaceHotKeyConfirmation')}</div>
-      )}
+      {confirming && <div className="text-xs text-heading-gray mb-3 select-text">{t('replaceHotKeyConfirmation')}</div>}
 
       <FormSubmitButton
         type="button"
@@ -89,12 +70,6 @@ const GuardianReplaceHotKey: FC<Props> = ({ onClose }) => {
       </FormSubmitButton>
 
       {error && <div className="mt-3 text-red-600 text-sm font-medium select-text">{error}</div>}
-
-      {success && (
-        <div className="mt-3 text-green-600 text-sm font-medium" onAnimationEnd={() => onClose?.()}>
-          {t('hotKeyRotated')}
-        </div>
-      )}
     </div>
   );
 };

--- a/src/app/templates/GuardianSettings.test.tsx
+++ b/src/app/templates/GuardianSettings.test.tsx
@@ -1,452 +1,62 @@
 import React from 'react';
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import GuardianSettings from './GuardianSettings';
 
-// ---------------------------------------------------------------------------
-// Mocks.
-//
-// GuardianSettings composes a lot of native/store-backed surface. We isolate
-// the component under test by stubbing every collaborator so the only real code
-// exercised (and measured) is GuardianSettings.tsx itself:
-//   - `ChooseGuardianScreen` is captured so tests can drive `onSubmit` directly
-//     and assert the `submitLabel` the component computes.
-//   - `GuardianReplaceHotKey` (a sibling with its own native deps) is a stub.
-//   - `lib/miden/activity` / `lib/miden/front` / store are jest.fn()s the tests
-//     script per-case.
-// ---------------------------------------------------------------------------
+const mockUseCurrentGuardianEndpoint = jest.fn();
+const mockGuardianOptionForEndpoint = jest.fn();
+jest.mock('app/hooks/useCurrentGuardianEndpoint', () => ({
+  useCurrentGuardianEndpoint: () => mockUseCurrentGuardianEndpoint(),
+  guardianOptionForEndpoint: (endpoint: string) => mockGuardianOptionForEndpoint(endpoint)
+}));
 
-// i18n: identity translator so assertions can match on the raw keys.
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }));
 
-// Capture the latest props ChooseGuardianScreen receives so tests can invoke
-// its `onSubmit` (the sole driver of GuardianSettings' submit flow) and read the
-// computed `submitLabel`.
-const mockHolder: { chooseProps: any } = { chooseProps: null };
-jest.mock('screens/onboarding/common/ChooseGuardian', () => ({
-  ChooseGuardianScreen: (props: any) => {
-    mockHolder.chooseProps = props;
-    // Only the computed submit label is rendered as text. The endpoint value is
-    // read off the captured props (below) instead of rendered, so it can't
-    // collide with the component's own "current endpoint" paragraph.
-    return (
-      <div data-testid="choose-guardian">
-        <span data-testid="submit-label">{props.submitLabel}</span>
-      </div>
-    );
-  }
+jest.mock('components/Button', () => ({
+  Button: ({ title, onClick }: { title: string; onClick: () => void }) => <button onClick={onClick}>{title}</button>
 }));
 
-// Sibling with native deps of its own — stub it, and surface the `onClose` it
-// receives so we can confirm the prop is threaded through.
-jest.mock('app/templates/GuardianReplaceHotKey', () => ({
-  __esModule: true,
-  default: ({ onClose }: { onClose?: () => void }) => (
-    <button data-testid="replace-hot-key" onClick={() => onClose?.()}>
-      replace-hot-key
-    </button>
-  )
-}));
+const mockHapticLight = jest.fn();
+jest.mock('lib/mobile/haptics', () => ({ hapticLight: () => mockHapticLight() }));
 
-const mockInitiate = jest.fn();
-const mockRequestSWProcessing = jest.fn();
-const mockWaitForCompletion = jest.fn();
-jest.mock('lib/miden/activity', () => ({
-  initiateSwitchGuardianTransaction: (...a: unknown[]) => mockInitiate(...a),
-  requestSWTransactionProcessing: (...a: unknown[]) => mockRequestSWProcessing(...a),
-  waitForTransactionCompletion: (...a: unknown[]) => mockWaitForCompletion(...a)
-}));
-
-const mockFetchFromStorage = jest.fn();
-const mockOnStorageChanged = jest.fn();
-// The last storage-change callback registered by the hook, so tests can fire it.
-let mockStorageCb: ((next: string | null | undefined) => void) | null = null;
-const mockUnsubscribe = jest.fn();
-jest.mock('lib/miden/front', () => ({
-  fetchFromStorage: (...a: unknown[]) => mockFetchFromStorage(...a),
-  onStorageChanged: (key: string, cb: (next: string | null | undefined) => void) => {
-    mockStorageCb = cb;
-    return mockOnStorageChanged(key, cb);
-  }
-}));
-
-jest.mock('lib/miden/front/guardian-sync', () => ({ zustandProvider: { __provider: true } }));
-
-jest.mock('lib/miden-chain/constants', () => ({ DEFAULT_GUARDIAN_ENDPOINT: 'https://default.guardian' }));
-
-jest.mock('lib/settings/constants', () => ({ GUARDIAN_URL_STORAGE_KEY: 'guardian_url_setting' }));
-
-const mockIsExtension = jest.fn();
-jest.mock('lib/platform', () => ({ isExtension: () => mockIsExtension() }));
-
-const mockIsDelegateProofEnabled = jest.fn();
-const mockSanitize = jest.fn();
-jest.mock('lib/settings/helpers', () => ({
-  isDelegateProofEnabled: () => mockIsDelegateProofEnabled(),
-  sanitizeGuardianUrl: (v: string) => mockSanitize(v)
-}));
-
-// Store that satisfies both the hook-selector call form and `.getState()`.
-const mockState: any = {
-  currentAccount: { publicKey: 'pk_1', guardianEndpoint: 'https://guardian.one' },
-  openTransactionModal: jest.fn()
-};
-jest.mock('lib/store', () => ({
-  useWalletStore: Object.assign((selector?: (s: any) => unknown) => (selector ? selector(mockState) : mockState), {
-    getState: () => mockState
-  })
-}));
-
-// ---------------------------------------------------------------------------
-// Helpers.
-// ---------------------------------------------------------------------------
-const CURRENT = 'https://guardian.one';
-const NEW = 'https://guardian.two';
-
-function deferred<T>() {
-  let resolve!: (v: T) => void;
-  let reject!: (e: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-const flush = () =>
-  act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-  });
-
-// Drive the captured ChooseGuardianScreen.onSubmit (the only entry into
-// GuardianSettings' submit logic).
-const submit = async (guardianEndpoint: string, guardianId = 'g1') => {
-  await act(async () => {
-    mockHolder.chooseProps.onSubmit({ guardianId, guardianEndpoint });
-  });
-  await flush();
-};
-
-const label = () => screen.getByTestId('submit-label').textContent;
+const mockNavigate = jest.fn();
+jest.mock('lib/woozie', () => ({ navigate: (path: string) => mockNavigate(path) }));
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockStorageCb = null;
-  mockHolder.chooseProps = null;
-  mockState.currentAccount = { publicKey: 'pk_1', guardianEndpoint: CURRENT };
-  mockState.openTransactionModal = jest.fn();
-  mockIsExtension.mockReturnValue(false);
-  mockIsDelegateProofEnabled.mockReturnValue(false);
-  // Default: identity sanitizer, so currentEndpoint mirrors the store value.
-  mockSanitize.mockImplementation((v: string) => v);
-  mockFetchFromStorage.mockResolvedValue(undefined);
-  mockOnStorageChanged.mockReturnValue(mockUnsubscribe);
-  mockInitiate.mockResolvedValue('tx-1');
-  mockWaitForCompletion.mockResolvedValue({ status: 'ok' });
+  mockUseCurrentGuardianEndpoint.mockReturnValue({ endpoint: 'https://guardian.one', refresh: jest.fn() });
+  mockGuardianOptionForEndpoint.mockReturnValue({ name: 'Guardian One' });
 });
 
-// ---------------------------------------------------------------------------
-// Rendering / current-endpoint display.
-// ---------------------------------------------------------------------------
-describe('GuardianSettings — rendering', () => {
-  it('shows the per-account guardian endpoint and the default switch label', async () => {
-    render(<GuardianSettings />);
-    await flush();
+it('renders the configured guardian name', () => {
+  render(<GuardianSettings />);
 
-    // Per-account endpoint wins → no legacy storage read.
-    expect(mockFetchFromStorage).not.toHaveBeenCalled();
-    expect(screen.getByText(CURRENT)).toBeInTheDocument();
-    expect(label()).toBe('switchGuardian');
-    // Props threaded into the ChooseGuardianScreen.
-    expect(mockHolder.chooseProps.currentEndpoint).toBe(CURRENT);
-    expect(mockHolder.chooseProps.hideHeader).toBe(true);
-    expect(mockHolder.chooseProps.allowCustomEndpoint).toBe(true);
-    expect(screen.getByTestId('replace-hot-key')).toBeInTheDocument();
-  });
-
-  it('falls back to the loading label when the resolved endpoint is empty', async () => {
-    // Force the hook to return an empty string so `currentEndpoint || t('loading')`
-    // takes the loading branch.
-    mockSanitize.mockReturnValue('');
-    render(<GuardianSettings />);
-    await flush();
-
-    // The endpoint paragraph renders the loading key.
-    expect(screen.getAllByText('loading').length).toBeGreaterThan(0);
-  });
+  expect(mockGuardianOptionForEndpoint).toHaveBeenCalledWith('https://guardian.one');
+  expect(screen.getByText('Guardian One')).toBeInTheDocument();
 });
 
-// ---------------------------------------------------------------------------
-// useCurrentGuardianEndpoint — legacy fallback branch.
-// ---------------------------------------------------------------------------
-describe('GuardianSettings — legacy guardian endpoint fallback', () => {
-  beforeEach(() => {
-    // Account predates the per-account field → hook consults legacy storage.
-    mockState.currentAccount = { publicKey: 'pk_1', guardianEndpoint: undefined };
-  });
+it('labels an unmatched endpoint as a custom guardian', () => {
+  mockGuardianOptionForEndpoint.mockReturnValue(undefined);
+  render(<GuardianSettings />);
 
-  it('reads a stored legacy endpoint and subscribes to storage changes', async () => {
-    mockFetchFromStorage.mockResolvedValue('https://legacy.stored');
-    render(<GuardianSettings />);
-    await flush();
-
-    expect(mockFetchFromStorage).toHaveBeenCalledWith('guardian_url_setting');
-    expect(mockOnStorageChanged).toHaveBeenCalledWith('guardian_url_setting', expect.any(Function));
-    expect(screen.getByText('https://legacy.stored')).toBeInTheDocument();
-  });
-
-  it('falls back to the default endpoint when nothing is stored', async () => {
-    mockFetchFromStorage.mockResolvedValue(undefined); // stored ?? null -> null
-    render(<GuardianSettings />);
-    await flush();
-
-    expect(screen.getByText('https://default.guardian')).toBeInTheDocument();
-  });
-
-  it('falls back to the default endpoint when the storage read rejects', async () => {
-    mockFetchFromStorage.mockRejectedValue(new Error('storage boom'));
-    render(<GuardianSettings />);
-    await flush();
-
-    expect(screen.getByText('https://default.guardian')).toBeInTheDocument();
-  });
-
-  it('reacts to storage-change events (set then clear)', async () => {
-    mockFetchFromStorage.mockResolvedValue(undefined);
-    render(<GuardianSettings />);
-    await flush();
-    expect(mockStorageCb).toBeTruthy();
-
-    // A change event pushes a new endpoint.
-    await act(async () => {
-      mockStorageCb!('https://changed.endpoint');
-    });
-    expect(screen.getByText('https://changed.endpoint')).toBeInTheDocument();
-
-    // Clearing (undefined -> null) reverts to the default.
-    await act(async () => {
-      mockStorageCb!(undefined);
-    });
-    expect(screen.getByText('https://default.guardian')).toBeInTheDocument();
-  });
-
-  it('unsubscribes from storage changes on unmount', async () => {
-    const { unmount } = render(<GuardianSettings />);
-    await flush();
-
-    expect(mockUnsubscribe).not.toHaveBeenCalled();
-    act(() => {
-      unmount();
-    });
-    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
-  });
+  expect(screen.getByText('customGuardian')).toBeInTheDocument();
 });
 
-// ---------------------------------------------------------------------------
-// handleSubmit — guards and the two-stage confirm flow.
-// ---------------------------------------------------------------------------
-describe('GuardianSettings — submit guards', () => {
-  it('does nothing when there is no current account', async () => {
-    mockState.currentAccount = null;
-    render(<GuardianSettings />);
-    await flush();
+it('shows loading while the guardian endpoint is unresolved', () => {
+  mockUseCurrentGuardianEndpoint.mockReturnValue({ endpoint: '', refresh: jest.fn() });
+  mockGuardianOptionForEndpoint.mockReturnValue(undefined);
+  render(<GuardianSettings />);
 
-    await submit(NEW);
-
-    expect(mockInitiate).not.toHaveBeenCalled();
-    expect(label()).toBe('switchGuardian');
-    // No confirmation text since submit was a no-op.
-    expect(screen.queryByText('switchGuardianConfirmation')).not.toBeInTheDocument();
-  });
-
-  it('rejects an unchanged endpoint with an error and clears any pending state', async () => {
-    render(<GuardianSettings />);
-    await flush();
-
-    // Enter confirming with a different endpoint first...
-    await submit(NEW);
-    expect(label()).toBe('confirmSwitchGuardian');
-
-    // ...then submit the CURRENT endpoint: guarded as unchanged, pending reset.
-    await submit(CURRENT);
-
-    expect(mockInitiate).not.toHaveBeenCalled();
-    expect(screen.getByText('guardianEndpointUnchanged')).toBeInTheDocument();
-    expect(label()).toBe('switchGuardian'); // confirming cleared
-  });
-
-  it('requires a second confirming tap on the same endpoint before switching', async () => {
-    render(<GuardianSettings />);
-    await flush();
-
-    // First tap: enters confirming, shows confirmation copy, no tx yet.
-    await submit(NEW);
-    expect(mockInitiate).not.toHaveBeenCalled();
-    expect(label()).toBe('confirmSwitchGuardian');
-    expect(screen.getByText('switchGuardianConfirmation')).toBeInTheDocument();
-
-    // Second tap on the SAME endpoint: fires the switch.
-    await submit(NEW);
-    await flush();
-    expect(mockInitiate).toHaveBeenCalledTimes(1);
-  });
-
-  it('re-confirms (without switching) when a different endpoint is chosen while confirming', async () => {
-    render(<GuardianSettings />);
-    await flush();
-
-    await submit(NEW); // pending = NEW
-    expect(label()).toBe('confirmSwitchGuardian');
-
-    // Different endpoint while confirming → pendingEndpoint !== guardianEndpoint,
-    // so it re-arms confirmation instead of switching.
-    const OTHER = 'https://guardian.three';
-    await submit(OTHER);
-    expect(mockInitiate).not.toHaveBeenCalled();
-    expect(label()).toBe('confirmSwitchGuardian');
-
-    // Now a matching second tap on OTHER actually switches.
-    await submit(OTHER);
-    await flush();
-    expect(mockInitiate).toHaveBeenCalledTimes(1);
-    expect(mockInitiate).toHaveBeenCalledWith('pk_1', OTHER, false, expect.anything());
-  });
+  expect(screen.getByText('loading')).toBeInTheDocument();
 });
 
-// ---------------------------------------------------------------------------
-// runSwitch — success, extension SW processing, errors.
-// ---------------------------------------------------------------------------
-describe('GuardianSettings — runSwitch', () => {
-  const confirmSwitch = async (endpoint = NEW) => {
-    await submit(endpoint); // first tap → confirming
-    await submit(endpoint); // second tap → runSwitch
-    await flush();
-  };
+it('fires haptics and navigates to guardian rotation', () => {
+  render(<GuardianSettings />);
+  fireEvent.click(screen.getByRole('button', { name: 'rotateGuardian' }));
 
-  it('completes a switch: opens the tx modal and shows the success message', async () => {
-    mockIsDelegateProofEnabled.mockReturnValue(true);
-    render(<GuardianSettings />);
-    await flush();
-
-    await confirmSwitch();
-
-    expect(mockInitiate).toHaveBeenCalledWith('pk_1', NEW, true, { __provider: true });
-    expect(mockState.openTransactionModal).toHaveBeenCalledTimes(1);
-    // Non-extension build skips the service-worker processing nudge.
-    expect(mockRequestSWProcessing).not.toHaveBeenCalled();
-    expect(mockWaitForCompletion).toHaveBeenCalledWith('tx-1');
-    expect(screen.getByText('guardianSwitched')).toBeInTheDocument();
-    // Confirmation copy hidden once success shows.
-    expect(screen.queryByText('switchGuardianConfirmation')).not.toBeInTheDocument();
-    expect(label()).toBe('switchGuardian'); // pending cleared
-  });
-
-  it('requests service-worker processing on extension builds', async () => {
-    mockIsExtension.mockReturnValue(true);
-    render(<GuardianSettings />);
-    await flush();
-
-    await confirmSwitch();
-
-    expect(mockRequestSWProcessing).toHaveBeenCalledTimes(1);
-    expect(screen.getByText('guardianSwitched')).toBeInTheDocument();
-  });
-
-  it('shows the loading label while the switch is in flight', async () => {
-    const gate = deferred<{ status: string }>();
-    mockWaitForCompletion.mockReturnValue(gate.promise);
-    render(<GuardianSettings />);
-    await flush();
-
-    await submit(NEW); // confirming
-    // Second tap kicks off runSwitch; it parks on waitForTransactionCompletion.
-    await submit(NEW);
-    await flush();
-
-    expect(label()).toBe('loading');
-    expect(screen.queryByText('guardianSwitched')).not.toBeInTheDocument();
-
-    // Resolve the in-flight tx → success.
-    await act(async () => {
-      gate.resolve({ status: 'ok' });
-    });
-    await flush();
-    expect(screen.getByText('guardianSwitched')).toBeInTheDocument();
-  });
-
-  it('surfaces a chain error carried on the completion result', async () => {
-    mockWaitForCompletion.mockResolvedValue({ errorMessage: 'chain rejected the switch' });
-    render(<GuardianSettings />);
-    await flush();
-
-    await confirmSwitch();
-
-    expect(screen.getByText('chain rejected the switch')).toBeInTheDocument();
-    expect(screen.queryByText('guardianSwitched')).not.toBeInTheDocument();
-  });
-
-  it('surfaces a thrown Error message', async () => {
-    mockInitiate.mockRejectedValue(new Error('initiate exploded'));
-    render(<GuardianSettings />);
-    await flush();
-
-    await confirmSwitch();
-
-    expect(screen.getByText('initiate exploded')).toBeInTheDocument();
-    expect(screen.queryByText('guardianSwitched')).not.toBeInTheDocument();
-  });
-
-  it('stringifies a non-Error rejection', async () => {
-    mockInitiate.mockRejectedValue('plain string failure');
-    render(<GuardianSettings />);
-    await flush();
-
-    await confirmSwitch();
-
-    expect(screen.getByText('plain string failure')).toBeInTheDocument();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Success animation → onClose plumbing.
-// ---------------------------------------------------------------------------
-describe('GuardianSettings — onClose', () => {
-  const confirmSwitch = async (endpoint = NEW) => {
-    await submit(endpoint);
-    await submit(endpoint);
-    await flush();
-  };
-
-  it('invokes onClose when the success message finishes animating', async () => {
-    const onClose = jest.fn();
-    render(<GuardianSettings onClose={onClose} />);
-    await flush();
-
-    await confirmSwitch();
-    const success = screen.getByText('guardianSwitched');
-
-    act(() => {
-      fireEvent.animationEnd(success);
-    });
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not crash on the success animation end when onClose is omitted', async () => {
-    render(<GuardianSettings />);
-    await flush();
-
-    await confirmSwitch();
-    const success = screen.getByText('guardianSwitched');
-
-    // `onClose?.()` — optional-chaining no-op, must not throw.
-    expect(() =>
-      act(() => {
-        fireEvent.animationEnd(success);
-      })
-    ).not.toThrow();
-  });
+  expect(mockHapticLight).toHaveBeenCalledTimes(1);
+  expect(mockNavigate).toHaveBeenCalledWith('/rotate-guardian');
 });

--- a/src/app/templates/GuardianSettings.tsx
+++ b/src/app/templates/GuardianSettings.tsx
@@ -1,177 +1,41 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
-import GuardianReplaceHotKey from 'app/templates/GuardianReplaceHotKey';
-import {
-  initiateSwitchGuardianTransaction,
-  requestSWTransactionProcessing,
-  waitForTransactionCompletion
-} from 'lib/miden/activity';
-import { fetchFromStorage, onStorageChanged } from 'lib/miden/front';
-import { zustandProvider } from 'lib/miden/front/guardian-sync';
-import { DEFAULT_GUARDIAN_ENDPOINT } from 'lib/miden-chain/constants';
-import { isExtension } from 'lib/platform';
-import { GUARDIAN_URL_STORAGE_KEY } from 'lib/settings/constants';
-import { isDelegateProofEnabled, sanitizeGuardianUrl } from 'lib/settings/helpers';
-import { useWalletStore } from 'lib/store';
-import { ChooseGuardianScreen } from 'screens/onboarding/common/ChooseGuardian';
+import { guardianOptionForEndpoint, useCurrentGuardianEndpoint } from 'app/hooks/useCurrentGuardianEndpoint';
+import { ReactComponent as GuardianAvatar } from 'app/icons/onboarding/guardian-avatar.svg';
+import { Button } from 'components/Button';
+import { hapticLight } from 'lib/mobile/haptics';
+import { navigate } from 'lib/woozie';
 
-type Props = {
-  onClose?: () => void;
-};
-
-const GuardianSettings: FC<Props> = ({ onClose }) => {
+const GuardianSettings: FC = () => {
   const { t } = useTranslation();
-  const currentEndpoint = useCurrentGuardianEndpoint();
-  const [submitSuccess, setSubmitSuccess] = useState(false);
-  // Two-stage submit: first tap validates + enters confirming, second tap fires the tx.
-  // switch_guardian requires the cold key (co-signed by the current guardian),
-  // so the confirmation step mirrors the cold-signing acknowledgement pattern.
-  const [pendingEndpoint, setPendingEndpoint] = useState<string | null>(null);
-  // `confirming` is fully derived from `pendingEndpoint` — a pending endpoint IS
-  // the confirming state — so the two can never drift out of sync.
-  const confirming = pendingEndpoint !== null;
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { endpoint: currentEndpoint } = useCurrentGuardianEndpoint();
 
-  const currentAccount = useWalletStore(s => s.currentAccount);
+  const option = guardianOptionForEndpoint(currentEndpoint);
+  const guardianName = option?.name ?? (currentEndpoint ? t('customGuardian') : t('loading'));
 
-  const runSwitch = useCallback(
-    async (newEndpoint: string) => {
-      if (!currentAccount) return;
-      setSubmitting(true);
-      setError(null);
-      setSubmitSuccess(false);
-      try {
-        const txId = await initiateSwitchGuardianTransaction(
-          currentAccount.publicKey,
-          newEndpoint,
-          isDelegateProofEnabled(),
-          zustandProvider
-        );
-        useWalletStore.getState().openTransactionModal();
-        if (isExtension()) requestSWTransactionProcessing();
-
-        const result = await waitForTransactionCompletion(txId);
-        if ('errorMessage' in result) {
-          setError(result.errorMessage);
-          return;
-        }
-
-        setSubmitSuccess(true);
-        setPendingEndpoint(null);
-        // No manual refresh needed: completing the switch persists the new endpoint
-        // and broadcasts `accountsUpdated`, so `useCurrentGuardianEndpoint` (a reactive
-        // store selector) re-renders the "Current guardian" display on its own.
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        setError(message);
-      } finally {
-        setSubmitting(false);
-      }
-    },
-    [currentAccount]
-  );
-
-  const handleSubmit = useCallback(
-    ({ guardianEndpoint }: { guardianId: string; guardianEndpoint: string }) => {
-      if (submitting || !currentAccount) return;
-      setSubmitSuccess(false);
-
-      if (guardianEndpoint === currentEndpoint) {
-        setError(t('guardianEndpointUnchanged'));
-        setPendingEndpoint(null);
-        return;
-      }
-
-      setError(null);
-
-      if (!confirming || pendingEndpoint !== guardianEndpoint) {
-        setPendingEndpoint(guardianEndpoint);
-        return;
-      }
-
-      void runSwitch(guardianEndpoint);
-    },
-    [confirming, currentAccount, currentEndpoint, pendingEndpoint, runSwitch, submitting, t]
-  );
+  const handleRotate = () => {
+    hapticLight();
+    navigate('/rotate-guardian');
+  };
 
   return (
-    <div className="w-full max-w-sm p-2 mx-auto">
-      <div className="mb-4">
-        <p className="text-sm text-heading-gray font-medium mb-1">{t('currentGuardianEndpoint')}</p>
-        <p className="text-sm text-black break-all select-text">{currentEndpoint || t('loading')}</p>
+    <div className="w-full flex flex-col">
+      <div className="flex flex-col items-center pt-2">
+        <div className="w-16 h-16 rounded-10 bg-grey-100 dark:bg-grey-800 flex items-center justify-center">
+          <GuardianAvatar className="w-14 h-14" />
+        </div>
+        <h2 className="mt-3 text-xl font-bold font-heading text-heading-gray">{guardianName}</h2>
       </div>
 
-      <ChooseGuardianScreen
-        onSubmit={handleSubmit}
-        currentEndpoint={currentEndpoint}
-        hideHeader
-        allowCustomEndpoint
-        submitLabel={submitting ? t('loading') : confirming ? t('confirmSwitchGuardian') : t('switchGuardian')}
-      />
+      <hr className="my-4" />
 
-      {confirming && !submitting && !submitSuccess && (
-        <div className="text-xs text-heading-gray mt-3 select-text">{t('switchGuardianConfirmation')}</div>
-      )}
-
-      {error && <div className="mt-3 text-red-500 text-xs select-text">{error}</div>}
-
-      {submitSuccess && (
-        <div className="mt-4 text-green-600 text-sm font-medium" onAnimationEnd={() => onClose?.()}>
-          {t('guardianSwitched')}
-        </div>
-      )}
-
-      <hr className="my-6" />
-
-      <GuardianReplaceHotKey onClose={onClose} />
+      <div className="mt-6">
+        <Button title={t('rotateGuardian')} onClick={handleRotate} />
+      </div>
     </div>
   );
 };
 
 export default GuardianSettings;
-
-// A wallet has a single Guardian account, so the current account's
-// `guardianEndpoint` IS the wallet's guardian. Read it straight off the store as
-// a reactive selector: when a switch persists the new endpoint and broadcasts
-// `accountsUpdated`, this re-renders on its own — no manual storage read/refresh.
-//
-// For accounts created before the per-account field existed, mirror
-// `resolveGuardianEndpoint`'s fallback to the legacy global
-// `GUARDIAN_URL_STORAGE_KEY`, otherwise the "Current guardian" display (and the
-// unchanged-endpoint guard) would misreport a legacy custom operator as the
-// default one.
-function useCurrentGuardianEndpoint(): string {
-  const accountEndpoint = useWalletStore(s => s.currentAccount?.guardianEndpoint);
-  const [legacyEndpoint, setLegacyEndpoint] = useState<string | null>(null);
-
-  useEffect(() => {
-    // The per-account field always wins; only consult the legacy global key when
-    // the account predates it.
-    if (accountEndpoint) {
-      setLegacyEndpoint(null);
-      return;
-    }
-    let active = true;
-    fetchFromStorage<string>(GUARDIAN_URL_STORAGE_KEY)
-      .then(stored => {
-        if (active) setLegacyEndpoint(stored ?? null);
-      })
-      .catch(() => {
-        if (active) setLegacyEndpoint(null);
-      });
-    // Extension builds get storage-change events for free; on mobile/desktop this
-    // is a no-op cleanup.
-    const unsubscribe = onStorageChanged<string>(GUARDIAN_URL_STORAGE_KEY, next => {
-      setLegacyEndpoint(next ?? null);
-    });
-    return () => {
-      active = false;
-      unsubscribe();
-    };
-  }, [accountEndpoint]);
-
-  return sanitizeGuardianUrl(accountEndpoint || legacyEndpoint || DEFAULT_GUARDIAN_ENDPOINT);
-}

--- a/src/lib/miden/front/guardian-sync.test.ts
+++ b/src/lib/miden/front/guardian-sync.test.ts
@@ -32,8 +32,19 @@ jest.mock('lib/store', () => ({
 }));
 
 const mockGetOrCreateMultisigService = jest.fn();
+const mockClearGuardianServiceFor = jest.fn();
 jest.mock('./guardian-manager', () => ({
-  getOrCreateMultisigService: (...args: unknown[]) => mockGetOrCreateMultisigService(...args)
+  getOrCreateMultisigService: (...args: unknown[]) => mockGetOrCreateMultisigService(...args),
+  clearGuardianServiceFor: (...args: unknown[]) => mockClearGuardianServiceFor(...args)
+}));
+
+// Only the auth-rejection predicate is needed here; stubbing the module keeps
+// the WASM-backed guardian barrel out of this frontend-only suite.
+jest.mock('lib/miden/guardian', () => ({
+  isGuardianAuthRejection: (err: unknown) => {
+    if (typeof err !== 'object' || err === null) return false;
+    return ('status' in err ? err.status : undefined) === 401;
+  }
 }));
 
 // The self-heal hook dynamic-imports this; stub it so the sync test stays focused
@@ -136,6 +147,32 @@ describe('syncGuardianAccounts', () => {
 
     await expect(syncGuardianAccounts()).resolves.toBeUndefined();
     expect(goodSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the cached service when the guardian rejects our signer (auth failure)', async () => {
+    storeState.accounts = [{ publicKey: 'guardian-auth', type: WalletType.Guardian, hotPublicKey: 'hot-auth' }];
+    mockGetOrCreateMultisigService.mockResolvedValue({
+      sync: jest.fn(async () => {
+        throw Object.assign(new Error('unauthorized'), { status: 401 });
+      })
+    });
+
+    await expect(syncGuardianAccounts()).resolves.toBeUndefined();
+
+    expect(mockClearGuardianServiceFor).toHaveBeenCalledWith('guardian-auth');
+  });
+
+  it('keeps the cached service for non-auth sync failures', async () => {
+    storeState.accounts = [{ publicKey: 'guardian-other', type: WalletType.Guardian, hotPublicKey: 'hot-other' }];
+    mockGetOrCreateMultisigService.mockResolvedValue({
+      sync: jest.fn(async () => {
+        throw new Error('transient rpc blip');
+      })
+    });
+
+    await expect(syncGuardianAccounts()).resolves.toBeUndefined();
+
+    expect(mockClearGuardianServiceFor).not.toHaveBeenCalled();
   });
 
   it('skips Guardian accounts that still require hot-key rotation (post-recovery, pre-activation)', async () => {

--- a/src/lib/miden/front/guardian-sync.ts
+++ b/src/lib/miden/front/guardian-sync.ts
@@ -1,7 +1,8 @@
+import { isGuardianAuthRejection } from 'lib/miden/guardian';
 import { useWalletStore } from 'lib/store';
 import { WalletType } from 'screens/onboarding/types';
 
-import { getOrCreateMultisigService, type GuardianAccountProvider } from './guardian-manager';
+import { clearGuardianServiceFor, getOrCreateMultisigService, type GuardianAccountProvider } from './guardian-manager';
 
 /**
  * Default GuardianAccountProvider backed by the Zustand store. Frontend-only —
@@ -77,6 +78,15 @@ export async function syncGuardianAccounts(): Promise<void> {
         await ensureGuardianProcedureThresholds(account.publicKey, undefined, zustandProvider);
       }
     } catch (error) {
+      // An auth rejection means the cached service's bound signer and the
+      // guardian's registered signer set disagree (e.g. mid-rotation the
+      // service was built from a pre-rotation on-chain account, pairing the
+      // new hot pubkey with the old commitment). Evict it so the next tick
+      // rebuilds against freshly-synced on-chain state instead of re-signing
+      // with the same stale binding every ~3s forever.
+      if (isGuardianAuthRejection(error)) {
+        clearGuardianServiceFor(account.publicKey);
+      }
       console.error(`[Guardian Sync] Error syncing Guardian account ${account.publicKey}:`, error);
     }
   }

--- a/src/lib/miden/guardian/index.test.ts
+++ b/src/lib/miden/guardian/index.test.ts
@@ -11,7 +11,7 @@
  * All external collaborators are stubbed to keep tests hermetic.
  */
 
-import { MultisigService } from './index';
+import { isGuardianAuthRejection, MultisigService } from './index';
 
 const mockFetchFromStorage = jest.fn();
 jest.mock('../front/storage', () => ({
@@ -162,6 +162,26 @@ const makeMultisig = (overrides: Partial<Record<string, unknown>> = {}) => ({
   registerOnGuardian: jest.fn(async () => {}),
   guardianPublicKey: 'old-pubkey',
   ...overrides
+});
+
+describe('isGuardianAuthRejection', () => {
+  it('recognises a 401 status', () => {
+    expect(isGuardianAuthRejection(Object.assign(new Error('nope'), { status: 401 }))).toBe(true);
+  });
+
+  it('recognises the guardian auth error codes', () => {
+    expect(isGuardianAuthRejection({ code: 'authentication_failed' })).toBe(true);
+    expect(isGuardianAuthRejection({ code: 'signer_not_authorized' })).toBe(true);
+  });
+
+  it('rejects non-auth errors and non-objects', () => {
+    expect(isGuardianAuthRejection(Object.assign(new Error('boom'), { status: 500 }))).toBe(false);
+    expect(isGuardianAuthRejection({ code: 'conflict' })).toBe(false);
+    expect(isGuardianAuthRejection(new Error('plain'))).toBe(false);
+    expect(isGuardianAuthRejection('401')).toBe(false);
+    expect(isGuardianAuthRejection(null)).toBe(false);
+    expect(isGuardianAuthRejection(undefined)).toBe(false);
+  });
 });
 
 describe('MultisigService', () => {

--- a/src/lib/miden/guardian/index.ts
+++ b/src/lib/miden/guardian/index.ts
@@ -24,6 +24,20 @@ import { fetchFromStorage } from '../front/storage';
 import { accountIdStringToSdk } from '../sdk/helpers';
 import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
 
+/**
+ * Structural GuardianHttpError auth-rejection check (401 /
+ * `authentication_failed` / `signer_not_authorized`). Duck-typed rather than
+ * `instanceof GuardianHttpError` so it survives test mocks of the multisig
+ * client and any duplicate-package instance of the error class (same
+ * convention as the 409 check in `./serialize.ts`).
+ */
+export const isGuardianAuthRejection = (err: unknown): boolean => {
+  if (typeof err !== 'object' || err === null) return false;
+  const status = 'status' in err ? err.status : undefined;
+  const code = 'code' in err ? err.code : undefined;
+  return status === 401 || code === 'authentication_failed' || code === 'signer_not_authorized';
+};
+
 const MAX_SYNC_RETRIES = 30;
 const SYNC_RETRY_DELAY_MS = 1000;
 // The guardian typically re-canonicalizes an accepted delta within ~2-10 ticks,
@@ -304,6 +318,13 @@ export class MultisigService {
           await delay(SYNC_RETRY_DELAY_MS);
           continue;
         }
+
+        // Auth rejections (401 / authentication_failed / signer_not_authorized)
+        // are NOT self-healed here: never push local state to a guardian that
+        // just refused our signer — if our binding is the stale side, the
+        // caller-level cache eviction (guardian-sync) rebuilds it; if the
+        // guardian is the stale side, that's an operator/registration problem
+        // to surface, not overwrite. Rethrow like any other error.
 
         // `multisig.syncState` refuses to overwrite local state while the guardian
         // is still canonicalizing a delta it just accepted: its stored blob lags the


### PR DESCRIPTION
Extracts the remaining guardian UI/sync work from `utk-bridge-integration` as a standalone PR off `main`.

## What's included

- **Rotate-guardian flow**: new `/rotate-guardian` (reuses `ChooseGuardianScreen` with the current endpoint highlighted) and `/rotate-guardian/review` (operator summary, biometric hint, submit → `/generating-transaction-full/:txId`) pages, with `useCurrentGuardianEndpoint` resolving the per-account endpoint.
- **`GuardianSettings` / `GuardianReplaceHotKey`** refresh from the branch (both dropped their unused `onClose` props — no call-site changes needed on main).
- **Auth-rejection service eviction**: `isGuardianAuthRejection` in the guardian lib + guardian-sync now evicts the cached MultisigService on a guardian 401/session rejection so the next tick rebuilds and re-authenticates instead of failing forever on a stale session.
- Routes, tests (the pages had none on the source branch — written new), one missing i18n key (`faceId`, a latent raw-key bug on the branch itself).

## Deliberately not included

- Sync-speed tuning (`3d0d4af2`) — verified already on main independently.
- `midenRpcEndpoint` / `abandonCandidate` guardian lib changes — they need multisig-client 0.16 and live on PR #392.
- `src/lib/miden/transaction/` untouched (owned by #392).

## Verification

- `tsc --noEmit` clean; eslint + `lint:i18n` clean
- `yarn test:coverage`: 468 suites / 6394 tests pass, 97.20% statements (gate 95%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)