### PR TITLE
fix(test): ReviewSwap test used props removed by the swap refactor (broke main typecheck)

### DIFF
--- a/src/screens/swap-flow/ReviewSwap.test.tsx
+++ b/src/screens/swap-flow/ReviewSwap.test.tsx
@@ -183,7 +183,7 @@ describe('ReviewSwap', () => {
     });
 
     it('colours the solver-fee note with a theme token that flips in dark mode, not a hardcoded light hex', () => {
-      renderComponent({ offerPrice: 2, requestPrice: 1 });
+      renderComponent({ swapEta: etaWithRate('2') });
 
       // The note sits on the dark app background in dark mode, so its colour must
       // come from a token that flips. `text-heading-gray` (--color-text-secondary)


### PR DESCRIPTION
## Problem
`Build Production` / the `Test` job is red on `main` with a TypeScript error:

```
src/screens/swap-flow/ReviewSwap.test.tsx:186:25 - error TS2353: Object literal may only specify known properties, and 'offerPrice' does not exist in type 'Partial<ReviewSwapProps>'.
```

## Root cause — merge skew, not a code bug
The In-Protocol-DEX swap refactor (#291, landed via #262) changed `ReviewSwap` to derive its rate from `swapEta.marketPrice` and **removed the `offerPrice`/`requestPrice` props**. #373 ("flip hardcoded light colors to theme tokens in dark mode") was branched before that refactor and added a test calling `renderComponent({ offerPrice: 2, requestPrice: 1 })`. Its own PR CI was green against its old base; squash-merged onto current `main` (post-#262) those props no longer exist → type error.

Build Production history confirms the boundary: green on `ce9630621` (#262) and `e1c2bff16` (#368), red starting `8d5004a69` (#373).

## Fix
Modernize the one test to the current props — `renderComponent({ swapEta: etaWithRate('2') })`, matching its sibling tests, which produces the same `swapSolverFeeNote_5%` note. #373's actual change (the note now uses `text-heading-gray`, `ReviewSwap.tsx:137`) is untouched and the test's colour assertion still passes.

- `tsc --noEmit`: 0 errors
- `ReviewSwap.test.tsx`: 22/22 pass