### PR TITLE
fix(e2e): keep Bridge/Mobile E2E green (path-safe bridge-out titles + dedicated bridge-in config)

### DIFF
--- a/.github/workflows/e2e-bridge-in.yml
+++ b/.github/workflows/e2e-bridge-in.yml
@@ -191,7 +191,7 @@ jobs:
         # Anvil (+ the Epoch spec its own fake allocator). --retries=2 absorbs
         # flaky CDP setup on macos-26 AND transient relay rate-limit trips on the
         # connect step; each attempt is a fresh wallet + pairing + Anvil.
-        run: yarn playwright test --config playwright.ios.config.ts bridge-in-deposit --retries=2
+        run: yarn playwright test --config playwright.ios.bridge-in.config.ts --retries=2
 
       - name: Upload artifacts
         if: always()

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:e2e:mobile": "yarn test:e2e:mobile:build && playwright test --config playwright.ios.config.ts",
     "test:e2e:mobile:run": "playwright test --config playwright.ios.config.ts",
     "test:e2e:mobile:guardian:run": "playwright test --config playwright.ios.guardian.config.ts",
+    "test:e2e:mobile:bridge-in:run": "playwright test --config playwright.ios.bridge-in.config.ts",
     "test:e2e:mobile:testnet": "cross-env E2E_NETWORK=testnet yarn test:e2e:mobile",
     "test:e2e:mobile:devnet": "cross-env E2E_NETWORK=devnet yarn test:e2e:mobile",
     "test:e2e:mobile:localhost": "cross-env E2E_NETWORK=localhost yarn test:e2e:mobile",

--- a/playwright.ios.bridge-in.config.ts
+++ b/playwright.ios.bridge-in.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+import base from './playwright.ios.config';
+
+// Same harness as the iOS E2E config, but runs ONLY the bridge-in specs (which
+// the base iOS config ignores). The deposit specs boot a local Anvil and use a
+// WalletConnect counterparty that the standard mobile suite doesn't set up, so
+// they run here in the dedicated Bridge-IN E2E job. Mirrors
+// playwright.ios.guardian.config.ts. Run with: yarn test:e2e:mobile:bridge-in:run.
+export default defineConfig({
+  ...base,
+  testIgnore: undefined,
+  testMatch: '**/bridge-in-*.ios.spec.ts'
+});

--- a/playwright.ios.config.ts
+++ b/playwright.ios.config.ts
@@ -9,9 +9,11 @@ import { defineConfig } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './playwright/e2e/ios/tests',
-  // Guardian specs run via playwright.ios.guardian.config.ts (dedicated run);
-  // keep them out of the standard iOS suite.
-  testIgnore: '**/guardian-*.ios.spec.ts',
+  // Guardian specs run via playwright.ios.guardian.config.ts and bridge-in specs
+  // via playwright.ios.bridge-in.config.ts (dedicated runs with their own setup —
+  // the bridge-in deposit specs need a local Anvil this suite doesn't provide);
+  // keep both out of the standard iOS suite.
+  testIgnore: ['**/guardian-*.ios.spec.ts', '**/bridge-in-*.ios.spec.ts'],
   // 25 min per test. WASM prove on the simulator is slow (~60-90s per consume),
   // and on degraded macos-26 runners BOTH the two-sim `_simPair` setup (capped
   // at 13 min, see SETUP_DEADLINE_MS) and the test body's simctl/WASM ops crawl.
@@ -20,7 +22,7 @@ export default defineConfig({
   // assertion is relaxed — this is purely tolerance for degraded-runner IO).
   timeout: 1_500_000,
   expect: {
-    timeout: 60_000,
+    timeout: 60_000
   },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
@@ -30,12 +32,12 @@ export default defineConfig({
   reporter: [
     ['list'],
     ['json', { outputFile: 'test-results-ios/results.json' }],
-    ['html', { outputFolder: 'test-results-ios/html', open: 'never' }],
+    ['html', { outputFolder: 'test-results-ios/html', open: 'never' }]
   ],
   globalSetup: './playwright/e2e/ios/fixtures/global-setup.ts',
   globalTeardown: './playwright/e2e/ios/fixtures/global-teardown.ts',
   use: {
     actionTimeout: 30_000,
-    navigationTimeout: 90_000,
-  },
+    navigationTimeout: 90_000
+  }
 });

--- a/playwright/e2e/tests/bridge/bridge-out-agglayer.spec.ts
+++ b/playwright/e2e/tests/bridge/bridge-out-agglayer.spec.ts
@@ -23,7 +23,7 @@ import { newEvmDestination } from '../../helpers/sepolia';
  * flag so the CLI-minted balance is found). Requires public Miden testnet + the
  * delegated prover, so this is testnet/nightly, not a per-PR gate.
  */
-test.describe('bridge-out: Miden -> EVM (Slow / AggLayer)', () => {
+test.describe('bridge-out Miden to EVM (Slow AggLayer)', () => {
   test.describe.configure({ mode: 'serial' });
 
   const TOKEN_SYMBOL = 'AGG';

--- a/playwright/e2e/tests/bridge/bridge-out-epoch.spec.ts
+++ b/playwright/e2e/tests/bridge/bridge-out-epoch.spec.ts
@@ -16,7 +16,7 @@ import { newEvmDestination, sepoliaPublicClient, usdcBalanceOf, waitForUsdcAbove
  * reachability (Miden testnet + the hosted Epoch allocator/solver + a Sepolia
  * RPC), so this suite is testnet/nightly, not a per-PR gate.
  */
-test.describe('bridge-out: Miden -> Sepolia (Fast / Epoch)', () => {
+test.describe('bridge-out Miden to Sepolia (Fast Epoch)', () => {
   test.describe.configure({ mode: 'serial' });
 
   const TOKEN_SYMBOL = 'BRDG';


### PR DESCRIPTION
Fixes the two deterministic bridge-e2e harness failures on main (both from #262; the bridge tests themselves pass — the core wallet suite is green). The flaky Bridge-IN E2E (WalletConnect relay timeout, hidden feature) is a separate known non-blocker.

## 1. Bridge E2E (Chrome) — artifact upload failed on a `:` in the test title
Both bridge-out tests **pass** ("real USDC arrives on Sepolia"), but `upload-artifact@v4` rejects the Playwright output path derived from `bridge-out: Miden -> EVM (...)` (invalid chars `:` and `>`). Renamed the two `describe` titles to path-safe text (`bridge-out Miden to EVM (Slow AggLayer)`, `bridge-out Miden to Sepolia (Fast Epoch)`).

## 2. Mobile E2E (testnet) — bridge-in deposit specs ran without Anvil
The general iOS suite globbed `bridge-in-*.ios.spec.ts`, whose deposit specs `spawn anvil` — but only the dedicated Bridge-IN E2E job installs Foundry → `spawn anvil ENOENT`. Fixed exactly like the guardian specs: excluded `bridge-in-*` from `playwright.ios.config.ts`, added a dedicated `playwright.ios.bridge-in.config.ts` (`testMatch: bridge-in-*`), and pointed `e2e-bridge-in.yml` at it (now runs all bridge-in specs, no coverage dropped).

Verified locally with `playwright test --list`: the general config lists 0 bridge-in specs; the dedicated config lists only the 4 bridge-in specs. eslint + prettier clean.

Note: the bridge/mobile E2E only run on push-to-main, so this PR's own checks won't exercise them — they'll validate on main after merge.