### PR TITLE
fix(e2e): retry the full WalletConnect handshake to de-flake Bridge-IN E2E

### DIFF
--- a/playwright/e2e/ios/helpers/wc-counterparty.ts
+++ b/playwright/e2e/ios/helpers/wc-counterparty.ts
@@ -24,9 +24,7 @@ const RELAY_URL = process.env.WC_RELAY_URL ?? 'wss://relay.walletconnect.org';
 // (WC_COUNTERPARTY_PROJECT_ID) so CI can halve per-projectId relay load and cut
 // the chance of tripping the free-tier rate limit that connection bursts hit.
 const PROJECT_ID =
-  process.env.WC_COUNTERPARTY_PROJECT_ID ??
-  process.env.WALLETCONNECT_PROJECT_ID ??
-  'b54ef53f878d160bf63c6eae3a567e67';
+  process.env.WC_COUNTERPARTY_PROJECT_ID ?? process.env.WALLETCONNECT_PROJECT_ID ?? 'b54ef53f878d160bf63c6eae3a567e67';
 const ANVIL_RPC = process.env.E2E_EVM_RPC_URL ?? 'http://127.0.0.1:8545';
 const CHAIN_ID = 11155111;
 // Anvil's first deterministic dev account (pre-funded with 10000 ETH).
@@ -74,6 +72,7 @@ export class WcCounterparty {
   }
 
   async start(): Promise<void> {
+    if (this.client) return; // idempotent — connectWithRetry may call this too
     this.client = await SignClient.init({
       projectId: PROJECT_ID,
       relayUrl: RELAY_URL,
@@ -118,6 +117,65 @@ export class WcCounterparty {
 
   async pair(uri: string): Promise<void> {
     await this.client.pair({ uri });
+  }
+
+  /**
+   * Robust connect: run the full WalletConnect handshake — fetch a fresh `wc:`
+   * URI from the app, pair, wait for the session to be approved, and confirm the
+   * app reports connected — retrying the WHOLE handshake with backoff.
+   *
+   * The public relay rate-limits connection bursts and its subscribe can time out
+   * ("Subscribing to <topic> failed, please try again"), which can hit the URI
+   * fetch OR the pair/approve step. Retrying only the URI fetch (as the specs did
+   * inline) left the subscribe timeout fatal — the cause of the intermittent
+   * Bridge-IN E2E failures. A dedicated `WC_COUNTERPARTY_PROJECT_ID` (see the note
+   * at the top of this file) halves per-projectId relay load and is the durable
+   * infra-side fix; this keeps the handshake resilient in the meantime.
+   */
+  async connectWithRetry(
+    getUri: () => Promise<string>,
+    verifyAppConnected: () => Promise<boolean>,
+    opts: { attempts?: number; backoffMs?: number; sessionTimeoutMs?: number } = {}
+  ): Promise<void> {
+    const { attempts = 5, backoffMs = 15_000, sessionTimeoutMs = 45_000 } = opts;
+    await this.start();
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        const uri = await getUri();
+        if (!uri.startsWith('wc:')) throw new Error(`expected a wc: pairing URI, got "${uri}"`);
+        await this.pair(uri);
+        // The relay subscribe inside pair/approve can stall without erroring;
+        // bound the wait so a stall triggers a retry instead of hanging.
+        await Promise.race([
+          this.connected,
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(new Error(`WC session not approved within ${sessionTimeoutMs}ms (relay subscribe timeout?)`)),
+              sessionTimeoutMs
+            )
+          )
+        ]);
+        for (let poll = 0; poll < 30; poll++) {
+          if (await verifyAppConnected()) return;
+          await this.sleep(2000);
+        }
+        throw new Error('WC session approved but the app never reported connected');
+      } catch (err) {
+        lastErr = err;
+        if (attempt === attempts) {
+          throw new Error(
+            `WalletConnect handshake failed after ${attempts} attempts (public relay subscribe/rate-limit): ${String(lastErr)}`
+          );
+        }
+        await this.sleep(backoffMs);
+      }
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   private async handleRequest(event: {

--- a/playwright/e2e/ios/tests/bridge-in-deposit-epoch.ios.spec.ts
+++ b/playwright/e2e/ios/tests/bridge-in-deposit-epoch.ios.spec.ts
@@ -2,7 +2,13 @@ import { decodeFunctionData } from 'viem';
 
 import { expect, test } from '../fixtures/two-simulators';
 import { AnvilInstance } from '../helpers/anvil';
-import { MOCK_COMPACT_ADDRESS, MOCK_USDC_ADDRESS, installMockCompact, installMockUsdc, readCompactDepositCount } from '../helpers/evm-doubles';
+import {
+  MOCK_COMPACT_ADDRESS,
+  MOCK_USDC_ADDRESS,
+  installMockCompact,
+  installMockUsdc,
+  readCompactDepositCount
+} from '../helpers/evm-doubles';
 import { FakeEpochAllocator } from '../helpers/fake-epoch-allocator';
 import { WcCounterparty } from '../helpers/wc-counterparty';
 
@@ -78,7 +84,6 @@ test.describe('Bridge-IN deposit (Epoch/USDC, full real UI)', () => {
     const cp = new WcCounterparty();
     let addressA: string;
     let faucetHex: string;
-    let uri: string;
     let bridgeTxId: string;
 
     await steps.step('create_wallet', async () => {
@@ -94,25 +99,12 @@ test.describe('Bridge-IN deposit (Epoch/USDC, full real UI)', () => {
 
     try {
       await steps.step('connect_evm', async () => {
-        await cp.start();
-        // Retry-guarded connect (public relay rate-limits connection bursts).
-        let lastErr: unknown;
-        for (let attempt = 1; attempt <= 5; attempt++) {
-          try {
-            uri = await walletA.reownConnectUri();
-            break;
-          } catch (err) {
-            lastErr = err;
-            if (attempt === 5) throw err;
-            await walletA.delay(15_000);
-          }
-        }
-        expect(uri, `wc: pairing URI (last error: ${String(lastErr)})`).toContain('wc:');
-        await cp.pair(uri!);
-        await cp.connected;
-        await expect
-          .poll(async () => (await walletA.reownState()).connected, { timeout: 60_000, intervals: [2000] })
-          .toBe(true);
+        // Retries the whole WC handshake (URI fetch + pair + approve) with backoff
+        // — the public relay's subscribe intermittently times out mid-handshake.
+        await cp.connectWithRetry(
+          () => walletA.reownConnectUri(),
+          async () => (await walletA.reownState()).connected
+        );
       });
 
       await steps.step('deposit_via_ui', async () => {

--- a/playwright/e2e/ios/tests/bridge-in-deposit.ios.spec.ts
+++ b/playwright/e2e/ios/tests/bridge-in-deposit.ios.spec.ts
@@ -78,7 +78,6 @@ test.describe('Bridge-IN deposit (AggLayer/ETH, full real UI)', () => {
     const cp = new WcCounterparty();
     let addressA: string;
     let faucetHex: string;
-    let uri: string;
 
     await steps.step('create_wallet', async () => {
       const a = await walletA.createNewWallet();
@@ -95,29 +94,14 @@ test.describe('Bridge-IN deposit (AggLayer/ETH, full real UI)', () => {
 
     try {
       await steps.step('connect_evm', async () => {
-        await cp.start();
         // The public relay rate-limits connection bursts on the shared free-tier
-        // projectId; the app's relay socket can fail to come up (`Web socket is
-        // not connected`). reown reconnects every 5s in the background, so retry
-        // the socket-dependent connectUri a few times before giving up — this is
-        // the CI-reliability guard for the relay dependency.
-        let lastErr: unknown;
-        for (let attempt = 1; attempt <= 5; attempt++) {
-          try {
-            uri = await walletA.reownConnectUri();
-            break;
-          } catch (err) {
-            lastErr = err;
-            if (attempt === 5) throw err;
-            await walletA.delay(15_000);
-          }
-        }
-        expect(uri, `wc: pairing URI (last error: ${String(lastErr)})`).toContain('wc:');
-        await cp.pair(uri!);
-        await cp.connected;
-        await expect
-          .poll(async () => (await walletA.reownState()).connected, { timeout: 60_000, intervals: [2000] })
-          .toBe(true);
+        // projectId and its subscribe can time out mid-handshake, so retry the
+        // WHOLE handshake (URI fetch + pair + approve) with backoff — the
+        // CI-reliability guard for the relay dependency.
+        await cp.connectWithRetry(
+          () => walletA.reownConnectUri(),
+          async () => (await walletA.reownState()).connected
+        );
       });
 
       await steps.step('deposit_via_ui', async () => {

--- a/playwright/e2e/ios/tests/bridge-in-wc-pairing.ios.spec.ts
+++ b/playwright/e2e/ios/tests/bridge-in-wc-pairing.ios.spec.ts
@@ -16,7 +16,6 @@ test.describe('Bridge-IN WalletConnect pairing (real relay handshake)', () => {
 
   test('the app pairs with a headless WC counterparty and reports connected', async ({ walletA, walletB, steps }) => {
     const cp = new WcCounterparty();
-    let uri: string;
 
     await steps.step('create_wallet', async () => {
       await walletA.createNewWallet();
@@ -24,25 +23,18 @@ test.describe('Bridge-IN WalletConnect pairing (real relay handshake)', () => {
     });
 
     try {
-      await steps.step('start_counterparty', async () => {
-        await cp.start();
-      });
-
-      await steps.step('app_creates_pairing', async () => {
-        uri = await walletA.reownConnectUri();
-        expect(uri, 'wc: pairing URI').toContain('wc:');
-      });
-
-      await steps.step('counterparty_pairs_and_approves', async () => {
-        await cp.pair(uri!);
-        await cp.connected; // resolves once the session is approved
+      await steps.step('connect', async () => {
+        // Full WC handshake with retry — the public relay's subscribe can time out
+        // mid-handshake on the shared free-tier projectId.
+        await cp.connectWithRetry(
+          () => walletA.reownConnectUri(),
+          async () => (await walletA.reownState()).connected
+        );
       });
 
       await steps.step('app_reports_connected', async () => {
-        await expect
-          .poll(async () => (await walletA.reownState()).connected, { timeout: 60_000, intervals: [2000] })
-          .toBe(true);
         const state = await walletA.reownState();
+        expect(state.connected, 'app reports connected').toBe(true);
         expect(state.address?.toLowerCase(), 'connected account').toBe(cp.address.toLowerCase());
         expect(state.chainId, 'connected chain').toBe(11155111);
       });


### PR DESCRIPTION
Roots out the Bridge-IN E2E flakiness (`Subscribing to <topic> failed, please try again` → job red) instead of masking it.

## Cause
The bridge-in specs open a real WalletConnect session through the headless counterparty (`wc-counterparty.ts`), which rides the **public relay** on the **shared free-tier projectId**. The relay rate-limits connection bursts and its subscribe intermittently times out **mid-handshake** (inside `pair()`/`approve()`). The specs only retried the **URI fetch** — so a subscribe timeout in pair/approve was fatal.

## Fix
Added `WcCounterparty.connectWithRetry(getUri, verifyAppConnected)` that retries the **whole** handshake — fresh URI → pair → wait-for-approval (bounded, so a stall retries instead of hangs) → confirm the app reports connected — with backoff (5 × 15s). Replaced the duplicated inline connect blocks in all three bridge-in specs (`deposit`, `deposit-epoch`, `wc-pairing`) with it, and made `start()` idempotent.

Verified: `tsc` clean, eslint clean, `playwright --list` lists all bridge-in specs.

## Durable infra follow-up (needs a human)
The counterparty already reads `WC_COUNTERPARTY_PROJECT_ID` (falls back to the shared id). Provisioning a **dedicated** WalletConnect Cloud projectId and setting it as a CI secret would halve per-projectId relay load and further cut rate-limit timeouts — the real infra-side fix this retry complements.

Note: Bridge-IN E2E runs on push-to-main only, so this PR's checks won't exercise it — it validates on main after merge.