### PR TITLE
ci: make Bridge-IN E2E non-blocking (dead WalletConnect projectId)

### DIFF
--- a/.github/workflows/e2e-bridge-in.yml
+++ b/.github/workflows/e2e-bridge-in.yml
@@ -191,6 +191,16 @@ jobs:
         # Anvil (+ the Epoch spec its own fake allocator). --retries=2 absorbs
         # flaky CDP setup on macos-26 AND transient relay rate-limit trips on the
         # connect step; each attempt is a fresh wallet + pairing + Anvil.
+        #
+        # NON-BLOCKING for now: bridge-in is hidden from users (see
+        # isBridgeDepositEnabled) and its WalletConnect handshake rides the public
+        # relay on the shared free-tier projectId, which is currently rejected with
+        # WS close 3000 ("Project not found") — a suspended/rate-limited projectId,
+        # not a code bug. Provision a dedicated WalletConnect Cloud projectId and
+        # set it as the WALLETCONNECT_PROJECT_ID / WC_COUNTERPARTY_PROJECT_ID CI
+        # secrets, then REMOVE this continue-on-error to make the suite blocking
+        # again. Tracked as a follow-up.
+        continue-on-error: true
         run: yarn playwright test --config playwright.ios.bridge-in.config.ts --retries=2
 
       - name: Upload artifacts


### PR DESCRIPTION
Makes the **Bridge-IN E2E** job non-blocking (`continue-on-error` on the test step) so it stops reding main.

## Why
Bridge-IN E2E fails on `WS close 3000 ("Project not found")` — the WalletConnect relay **rejects the app's projectId** (the shared free-tier fallback `b54ef53f…`, since no `WALLETCONNECT_PROJECT_ID` secret is set). It's a suspended/rate-limited projectId, **not a code bug**, and no retry can fix a rejected projectId. It has **never passed on main**. Bridge-in itself is hidden from users (`isBridgeDepositEnabled`), so this tests a non-shipping feature.

## Durable follow-up (needs a human)
Provision a dedicated WalletConnect Cloud projectId and set it as the `WALLETCONNECT_PROJECT_ID` / `WC_COUNTERPARTY_PROJECT_ID` CI secrets, then **remove the `continue-on-error`** to make the suite blocking again. Tracked as a follow-up issue.