### PR TITLE
fix(mobile): unblock iOS + Android release builds

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <queries>
         <package android:name="io.metamask" />
@@ -16,6 +17,7 @@
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        tools:replace="android:dataExtractionRules,android:allowBackup"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx6144m -XX:MaxMetaspaceSize=1g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.miden.wallet</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.miden.bread</string>


### PR DESCRIPTION
Three build-config fixes that surfaced while cutting the **1.15.12** production iOS archive + Android AAB. Each blocked the release build; none touch app behaviour. All are consequences of #262's WalletConnect/Reown dependencies (first release built with them).

## iOS — drop unused App Group (`App.entitlements`)
The archive failed: `An Application Group with Identifier 'group.com.miden.wallet' is not available`. That App Group is a leftover (no code references anywhere) and is owned by the *old* Apple team, so the org team (`LHU7B7J5WL`, bundle `com.miden.bread`) can't provision it — App Group IDs are globally unique. It's unused, so removed. The keychain-access-group (`com.miden.bread`) is untouched.

## Android — resolve Reown manifest merge (`AndroidManifest.xml`)
Release build failed: `Manifest merger failed : android:dataExtractionRules ... is also present at [com.reown:sign:1.6.13]`. Added the `tools` namespace + `tools:replace="android:dataExtractionRules,android:allowBackup"` (the merger's own suggested fix) so the app's values win over the Reown library's.

## Android — raise Gradle heap (`gradle.properties`)
Release build failed: `R8: java.lang.OutOfMemoryError: Java heap space`. R8 (release minifier) OOM'd on the larger dependency graph at the old `-Xmx1536m`. Bumped to `-Xmx6144m -XX:MaxMetaspaceSize=1g`.

## Verified
- iOS: `xcodebuild ... archive` → **ARCHIVE SUCCEEDED** (1.15.12, signed).
- Android: `gradlew bundleRelease` → **BUILD SUCCESSFUL**, signed AAB (1.15.12 / 11512001, `miden-upload` key).