### PR TITLE
chore(extension): drop unused tabs permission from manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.13 (TBD)
+
+### Changes
+
+- [CHANGE][extension] **Dropped the `tabs` permission from the extension manifest.** Nothing in the wallet reads other tabs' URLs/titles — `tabs.create/query/update/remove` and matching our own extension-page URLs work without it — so the permission was pure over-privilege (its "Read your browsing history" install warning was already subsumed by the content-script warning).
+
 ## 1.15.12 (2026-07-28)
 
 ### Features

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -13,7 +13,7 @@
   "__chrome|firefox|opera__homepage_url": "https://miden.fi",
   "short_name": "Bread",
 
-  "permissions": ["storage", "clipboardWrite", "unlimitedStorage", "activeTab", "tabs", "notifications", "alarms", "sidePanel", "offscreen"],
+  "permissions": ["storage", "clipboardWrite", "unlimitedStorage", "activeTab", "notifications", "alarms", "sidePanel", "offscreen"],
   "host_permissions": [
     "http://localhost/*",
     "https://faucet-api.forkchoice.xyz/*",


### PR DESCRIPTION
Closes #255

## What

Removes the `tabs` permission from the extension manifest. Nothing in the wallet uses what it gates (reading other tabs' `url`/`title`/`favIconUrl`):

- `tabs.create` / `update` / `remove` / `getCurrent` never required it.
- The side-panel handoff's `tabs.query` only counts tabs in the window.
- The onboarding-tab refocus in `env.ts` only matches the extension's **own** `fullpage.html` URLs, which Chrome exposes without the permission.

## Why the remaining install warnings can't be removed

The three warnings reported in #255 map to permissions we genuinely need:

- **"Read and change all your data on all websites"** — the content script matching `https://*/*` that injects the wallet provider so dapps/wallet-adapter can discover the wallet. Inherent to being an injected wallet; MetaMask, Phantom, etc. show the same warning. Click-to-inject or optional host permissions would break automatic dapp detection.
- **"Display notifications"** — `notifications`, used as the fallback for transaction/sync notifications where the web `Notification` API is denied (notably Brave).
- **"Modify data you copy and paste"** — `clipboardWrite`. There's a case for dropping it (our copy actions run inside user gestures, which work without it), but the seed-phrase clipboard wipe in `SeedPhraseInput` relies on guaranteed writes and could silently fail without the permission — a breaking change we're not taking here.

So this PR trims the permission list to least-privilege but leaves the visible warning set unchanged (the `tabs` warning was already subsumed by the all-websites one); the remaining prompts are expected and industry-standard for a wallet.