### PR TITLE
Fix missing faucet tile on mobile Explore grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.14 (TBD)
+
+### Fixes
+
+- [FIX][mobile] **The Explore page now shows both faucet tiles.** The grid was rendering through a stale `id`-based filter (`swap-faucet`/`faucet`) that no longer matched the curated `EXPLORE_GRID_DAPPS` set (`faucet` + `forkchoice-faucet`), so only the first faucet tile appeared. The grid now renders `getExploreGridDapps()` directly.
+
 ## 1.15.13 (TBD)
 
 ### Fixes

--- a/src/app/pages/Browser/DappLauncher/AppsGrid.tsx
+++ b/src/app/pages/Browser/DappLauncher/AppsGrid.tsx
@@ -30,8 +30,6 @@ interface AppCardProps {
   onOpen: (url: string) => void;
 }
 
-const getFaucetDapps = () => getExploreGridDapps().filter(dapp => dapp.id === 'swap-faucet' || dapp.id === 'faucet');
-
 const AppCard: FC<AppCardProps> = ({ dapp, onOpen }) => {
   const [iconBroken, setIconBroken] = useState(false);
   const springs = useSprings();
@@ -93,7 +91,7 @@ const AppCard: FC<AppCardProps> = ({ dapp, onOpen }) => {
 
 export const AppsGrid: FC<AppsGridProps> = ({ onOpen }) => (
   <section className="grid grid-cols-2 gap-3 px-4">
-    {getFaucetDapps().map(dapp => (
+    {getExploreGridDapps().map(dapp => (
       <AppCard key={dapp.id} dapp={dapp} onOpen={onOpen} />
     ))}
   </section>


### PR DESCRIPTION
## Problem

On mobile, the Explore page showed only **one** faucet tile instead of two.

## Root cause

`AppsGrid.tsx` rendered through a stale `id`-based filter:

```ts
getExploreGridDapps().filter(dapp => dapp.id === 'swap-faucet' || dapp.id === 'faucet')
```

The curated grid `EXPLORE_GRID_DAPPS` is `['faucet', 'forkchoice-faucet']`, but the filter's ids had drifted — `swap-faucet` no longer exists and `forkchoice-faucet` isn't listed — so only `faucet` matched and the second tile was dropped.

## Fix

Delete the stale `getFaucetDapps` helper and render `getExploreGridDapps()` directly. It *is* the curated faucet grid by definition (`getExploreGridDapps(): FeaturedDapp[]` returns exactly those two, and neither is an exchange so both survive the swap-disabled path). This removes the root cause (a brittle hardcoded id list) rather than patching the filter, and the file's own header comment ("the two faucet apps from \`EXPLORE_GRID_DAPPS\`") is now literally accurate.

## Verification

- `getExploreGridDapps` returns `FeaturedDapp[]` → the call site is type-identical to the removed helper.
- No test referenced `getFaucetDapps`/`AppsGrid`; `featured-dapps.test.ts` asserts the underlying grid data, which is unchanged and now matches what renders.
- Both faucet tiles (`Faucet` + `Forkchoice Faucet`) now render.