### PR TITLE
Route guardian local proving to the native prover on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.14 (TBD)
+
+### Fixes
+
+- [FIX][mobile] **Guardian transactions with local (non-delegated) proving no longer freeze the UI on iOS.** The guardian pipeline drives the raw client directly, and its local-proving branch always used the single-threaded WASM prover — which on iOS WKWebView runs on the main thread and locks the UI for the whole multi-second prove (~13s). It now routes to the native Rust prover on mobile (off the main thread), matching the non-guardian path and the guardian delegated-proving fallback.
+
 ## 1.15.13 (TBD)
 
 ### Fixes

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -594,7 +594,17 @@ const generateGuardianTransaction = async (
       await setTransactionStage(transaction.id, 'proving');
       let provenTx;
       if (!transaction.delegateTransaction) {
-        provenTx = await executedTx.prove({ prover: TransactionProver.newLocalProver() });
+        // Local (non-delegated) proving. The guardian pipeline drives the raw
+        // client directly, whose default local prover is the single-threaded
+        // WASM one — which on iOS WKWebView runs on the main thread and freezes
+        // the UI for the whole multi-second prove. Route to the native Rust
+        // prover on mobile (off the main thread via @miden/native-prover),
+        // exactly like `proveWithFallback`'s localProverFactory and the
+        // delegated fallback below; WASM local prover elsewhere.
+        const localProver = isMobile()
+          ? TransactionProver.newCallbackProver(buildNativeProverCallback())
+          : TransactionProver.newLocalProver();
+        provenTx = await executedTx.prove({ prover: localProver });
       } else {
         // Delegated (remote) proving. The client's default prover is the remote
         // gRPC prover on every platform, and its ~10s deadline is too tight for a

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -113,6 +113,19 @@ jest.mock('../sdk/native-prover-mobile', () => ({
   buildNativeProverCallback: jest.fn(() => async () => new Uint8Array())
 }));
 
+// isMobile is toggled per-test (default false = the desktop/extension env the
+// rest of the suite assumes). Only `isMobile` is overridden; every other
+// platform predicate keeps its real (jsdom = false) behavior. It must be a
+// hoisted `var`: some modules call isMobile() at load time (e.g. cancel.ts), so
+// the holder has to be defined (falsy) before the suite body runs — a const/let
+// would be in the temporal dead zone at that point.
+// eslint-disable-next-line no-var
+var mockPlatformIsMobile = false;
+jest.mock('lib/platform', () => ({
+  ...jest.requireActual('lib/platform'),
+  isMobile: () => mockPlatformIsMobile
+}));
+
 jest.mock('shared/logger', () => ({
   logger: { warning: jest.fn(), error: jest.fn(), info: jest.fn() }
 }));
@@ -393,6 +406,71 @@ describe('generateTransaction — Guardian routing', () => {
     expect(abandonCandidate).not.toHaveBeenCalled();
     expect(txStore.find(row => row.id === txId)?.status).toBe(ITransactionStatus.Completed);
     warnSpy.mockRestore();
+  });
+
+  it('Guardian send (local proving on mobile): routes to the native callback prover, never main-thread WASM', async () => {
+    // Regression: the guardian pipeline drives the raw client directly, whose
+    // default local prover is the single-threaded WASM one — on iOS WKWebView
+    // that runs on the main thread and freezes the UI for the whole multi-second
+    // prove. The non-delegated (local) guardian prove must route to the native
+    // Rust prover (newCallbackProver), mirroring proveWithFallback's
+    // localProverFactory and the delegated fallback above. isMobile is flipped
+    // inside an isolated module registry so the flag doesn't leak to other tests.
+    const txId = 'send-guardian-mobile-local';
+    const result = makeResult();
+    txStore.push({
+      id: txId,
+      type: 'send',
+      accountId: 'guardian-acc',
+      status: ITransactionStatus.Queued,
+      secondaryAccountId: 'recipient',
+      faucetId: 'faucet',
+      amount: '1000',
+      delegateTransaction: false,
+      initiatedAt: Math.floor(Date.now() / 1000)
+    });
+
+    const multisigService = {
+      createSendProposal: jest.fn(async () => ({ id: 'prop-1' })),
+      signAndCreateTransactionRequest: jest.fn(async () => ({
+        serialize: () => new Uint8Array([1]),
+        authArg: () => undefined
+      })),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      client: makeClientApi(result)
+    });
+
+    const provider = makeGuardianProvider(true);
+    const signCallback = jest.fn(async () => new Uint8Array([2]));
+
+    mockPlatformIsMobile = true;
+    try {
+      await generateTransaction(
+        {
+          id: txId,
+          type: 'send',
+          accountId: 'guardian-acc',
+          secondaryAccountId: 'recipient',
+          faucetId: 'faucet',
+          amount: '1000',
+          delegateTransaction: false
+        } as never,
+        signCallback,
+        false,
+        provider
+      );
+    } finally {
+      mockPlatformIsMobile = false;
+    }
+
+    // The local guardian prove picked the native callback prover, not the
+    // main-thread WASM local prover.
+    expect(TransactionProver.newCallbackProver).toHaveBeenCalledTimes(1);
+    expect(TransactionProver.newLocalProver).not.toHaveBeenCalled();
   });
 
   it('Guardian send: a still-pending 409 (delta not yet canonicalized) requeues instead of failing', async () => {


### PR DESCRIPTION
## Problem

On iOS, switching a **guardian (multisig) account** to **local (non-delegated) proving** froze the UI for ~13s during the prove.

## Root cause

The guardian pipeline (`generateGuardianTransaction`) drives the raw client directly. Its delegated branch was already hardened to use the native prover on mobile, but its **local-proving branch hardcoded the single-threaded WASM prover** with no `isMobile()` check:

```ts
if (!transaction.delegateTransaction) {
  provenTx = await executedTx.prove({ prover: TransactionProver.newLocalProver() }); // WASM, main thread
}
```

On iOS WKWebView, `newLocalProver()` runs WASM single-threaded **on the JS main thread**, blocking the UI for the whole multi-second prove. (Non-guardian paths already route through `proveWithFallback`, which picks the native prover on mobile — so this was guardian-specific.)

## Fix

Route the guardian local branch to the native Rust prover on mobile, mirroring `proveWithFallback`'s `localProverFactory` and the delegated fallback three lines below:

```ts
const localProver = isMobile()
  ? TransactionProver.newCallbackProver(buildNativeProverCallback())  // native, off-thread
  : TransactionProver.newLocalProver();
provenTx = await executedTx.prove({ prover: localProver });
```

## Verification

- **On-device (iPhone 17 Pro Max, iOS 26, testnet):** guardian local prove now goes through `[MidenNativeProver] prove()` and returns in **~795ms off the main thread** (`prove() success, output=91276 bytes`), UI responsive — vs the ~13s main-thread WASM freeze before.
- New regression test pins the mobile branch (`isMobile=true` ⇒ `newCallbackProver` used, `newLocalProver` not); all 40 guardian tests pass.
- Full coverage suite clears the 95% gate (95.37% stmts / 95.38% branches / 95.46% funcs / 95.37% lines).
- Lint clean.