### PR TITLE
Re-enable bridge-in (Receive from EVM) — 1.15.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.16 (TBD)
+
+### Features
+
+- [FEATURE][mobile][desktop] **Re-enabled bridge-in (Receive from EVM).** The "Cross Chain" deposit entry on the Receive page and the `/bridge/deposit` flow now ship to users — previously hidden behind a launch flag (`isBridgeDepositEnabled` gated on `MIDEN_E2E_TEST` / `MIDEN_ENABLE_BRIDGE_UI`).
+
 ## 1.15.15 (2026-07-30)
 
 ### Features

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.miden.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11515001
-        versionName "1.15.15"
+        versionCode 11516001
+        versionName "1.15.16"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.15.15",
+  "version": "1.15.16",
   "private": true,
   "engines": {
     "node": ">=22.0.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bread Wallet by Miden",
-  "version": "1.15.15",
+  "version": "1.15.16",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",

--- a/src/lib/browser-info.test.ts
+++ b/src/lib/browser-info.test.ts
@@ -92,6 +92,13 @@ describe('isSafeBrowserVersion', () => {
       // and `NaN >= 11` is false.
       expect(loadWith({ userAgent: IE_NO_RV })).toBe(false);
     });
+
+    it('falls back to an empty version when a Trident UA has no rv token', () => {
+      // Engine resolves to "Trident" (so the trident->IE branch is taken) but
+      // `/rv[ :]+(\d+)/` finds nothing, so `tem` is null and version comes from
+      // the `tem?.[1] ?? ''` fallback -> parseInt('') is NaN -> unsafe.
+      expect(loadWith({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Trident/7.0) like Gecko' })).toBe(false);
+    });
   });
 
   describe('Chromium-based re-brands', () => {

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -7,30 +7,15 @@ describe('feature-flags — isSwapEnabled', () => {
 });
 
 describe('feature-flags — isBridgeDepositEnabled', () => {
-  const original = {
-    e2e: process.env.MIDEN_E2E_TEST,
-    dev: process.env.MIDEN_ENABLE_BRIDGE_UI
-  };
-  afterEach(() => {
+  it('enables the receive-from-EVM deposit UI on every platform, regardless of env', () => {
+    const original = {
+      e2e: process.env.MIDEN_E2E_TEST,
+      dev: process.env.MIDEN_ENABLE_BRIDGE_UI
+    };
+    delete process.env.MIDEN_E2E_TEST;
+    delete process.env.MIDEN_ENABLE_BRIDGE_UI;
+    expect(isBridgeDepositEnabled()).toBe(true);
     process.env.MIDEN_E2E_TEST = original.e2e;
     process.env.MIDEN_ENABLE_BRIDGE_UI = original.dev;
-  });
-
-  it('hides the receive-from-EVM deposit UI by default (production)', () => {
-    delete process.env.MIDEN_E2E_TEST;
-    delete process.env.MIDEN_ENABLE_BRIDGE_UI;
-    expect(isBridgeDepositEnabled()).toBe(false);
-  });
-
-  it('stays enabled in the E2E build so the bridge-in e2e keeps exercising it', () => {
-    process.env.MIDEN_E2E_TEST = 'true';
-    delete process.env.MIDEN_ENABLE_BRIDGE_UI;
-    expect(isBridgeDepositEnabled()).toBe(true);
-  });
-
-  it('can be force-enabled via the MIDEN_ENABLE_BRIDGE_UI dev override', () => {
-    delete process.env.MIDEN_E2E_TEST;
-    process.env.MIDEN_ENABLE_BRIDGE_UI = 'true';
-    expect(isBridgeDepositEnabled()).toBe(true);
   });
 });

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -18,22 +18,17 @@ export function isSwapEnabled(): boolean {
 /**
  * Receive-from-EVM bridge deposit (bridge-IN) availability.
  *
- * The deposit entry — the "Cross Chain" button on the Receive page and the
- * `/bridge/deposit` screen — is hidden from users pending launch, like Earn.
- * Unlike Earn it stays enabled in the E2E build (`MIDEN_E2E_TEST=true`) so the
- * bridge-in e2e jobs keep exercising the flow with zero test changes, and can be
- * force-enabled in a dev / staging build via `MIDEN_ENABLE_BRIDGE_UI` for manual
- * testing.
+ * Enabled on every platform — the "Cross Chain" deposit button on the Receive
+ * page and the `/bridge/deposit` screen now ship to users (previously hidden
+ * pending launch behind `MIDEN_E2E_TEST` / `MIDEN_ENABLE_BRIDGE_UI`).
  *
  * This is the single source of truth for the deposit entry — the Receive "Cross
  * Chain" button and the `/bridge/deposit` route both read it. Send-to-EVM
  * (bridge-OUT) is intentionally NOT gated: it has no discoverable entry point
- * (it only triggers when a user types a 0x recipient address). To ship the
- * deposit UI, make this return true unconditionally.
- *
- * Both env vars are statically replaced by Vite (`define`), so a production
- * build compiles this to a constant `false` and the entry points never render.
+ * (it only triggers when a user types a 0x recipient address). To gate the
+ * deposit UI again (per-platform, per-region, or behind a remote flag), change
+ * only this function.
  */
 export function isBridgeDepositEnabled(): boolean {
-  return process.env.MIDEN_E2E_TEST === 'true' || process.env.MIDEN_ENABLE_BRIDGE_UI === 'true';
+  return true;
 }

--- a/src/lib/miden/activity/connectivity-classify.test.ts
+++ b/src/lib/miden/activity/connectivity-classify.test.ts
@@ -12,7 +12,10 @@ describe('isLikelyNetworkError', () => {
     'transport error: closed stream',
     'rpc error: deadline exceeded',
     'prover responded with status code 502: Bad Gateway',
-    'service unavailable 503'
+    'service unavailable 503',
+    // 'status code' phrase without a 5xx number — falls past the numeric check
+    // to the explicit 'status code' keyword.
+    'unexpected status code from the gateway'
   ])('returns true for %p', message => {
     expect(isLikelyNetworkError(new Error(message))).toBe(true);
   });

--- a/src/lib/miden/swap/tokens.test.ts
+++ b/src/lib/miden/swap/tokens.test.ts
@@ -118,4 +118,10 @@ describe('deriveRequestAmount', () => {
   it('returns empty when the quote rounds away to zero at the token precision', () => {
     expect(deriveRequestAmount('0.0001', '0.0001', 2)).toBe('');
   });
+
+  it('returns empty when the fair quote is non-positive', () => {
+    // A negative offered amount is truthy (passes the earlier `!offered` guard)
+    // but produces a negative quote, so the `quote <= 0` guard returns ''.
+    expect(deriveRequestAmount('-5', '2', SWAP_TOKEN_DECIMALS)).toBe('');
+  });
 });

--- a/src/lib/wallet-prompts.test.ts
+++ b/src/lib/wallet-prompts.test.ts
@@ -80,6 +80,16 @@ describe('wallet prompts', () => {
     );
   });
 
+  it('coerces a non-object prompts field on an object value to an empty prompt set', () => {
+    // The value itself is an object (so it isn't short-circuited at the top),
+    // but its `prompts` field is missing / not a record — drop it rather than
+    // iterating a non-object.
+    expect(normalizeWalletPromptStorage({ prompts: null })).toEqual(EMPTY_WALLET_PROMPT_STORAGE);
+    expect(normalizeWalletPromptStorage({ prompts: 'not-an-object' })).toEqual(EMPTY_WALLET_PROMPT_STORAGE);
+    expect(normalizeWalletPromptStorage({ prompts: 5 })).toEqual(EMPTY_WALLET_PROMPT_STORAGE);
+    expect(normalizeWalletPromptStorage({})).toEqual(EMPTY_WALLET_PROMPT_STORAGE);
+  });
+
   it('normalizes pending-note prompt state and valid unique dismissed note ids', () => {
     expect(
       normalizeWalletPromptStorage({


### PR DESCRIPTION
## What

Re-enables the **bridge-in / Receive-from-EVM deposit** UI for users. It was hidden behind a launch flag; `isBridgeDepositEnabled()` now returns `true` unconditionally (same shape as `isSwapEnabled()`), so the Receive page's **"Cross Chain"** deposit entry and the `/bridge/deposit` flow ship to users.

## Details

- `src/lib/feature-flags.ts` — `isBridgeDepositEnabled()` was gated on `MIDEN_E2E_TEST` / `MIDEN_ENABLE_BRIDGE_UI` (compiled to a constant `false` in production builds). Now returns `true`. This is the single source of truth — both the Receive "Cross Chain" button (`Receive/AddressTab.tsx`) and the `/bridge/deposit` route (`PageRouter.tsx`) read it, so no other changes are needed. Bridge-OUT (send to a 0x address) was never gated and is unaffected.
- Updated `feature-flags.test.ts` to assert it's enabled regardless of env.
- **Version bump 1.15.15 → 1.15.16** (package.json + manifest + Android `versionName`/`versionCode` 11516001).

## Verification

Flag unit test passes; lint clean. The bridge-in flow itself is already covered by the existing bridge-in E2E suite (which ran with the flag on via `MIDEN_E2E_TEST`).