### PR TITLE
feat(send): add "Never" expiration option to send plain P2ID notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.16 (TBD)
+
+### Features
+
+- [FEATURE][all] **Send a plain P2ID note ("Never" expiration).** The send flow always attached a reclaim/expiration height (defaulting to 7 days → a P2IDE note), with no way to remove it. The "Expiration Date" picker now offers a **"Never"** option that clears the reclaim height, so the send goes out as a plain **P2ID** note (recipient keeps it; the sender has no recall window). Default behaviour (7-day recall → P2IDE) is unchanged unless the user picks "Never".
+
 ## 1.15.15 (2026-07-30)
 
 ### Features

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -2870,6 +2870,10 @@
     "message": "In 2 Wochen",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Niemals",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 Min",
     "englishSource": "30 mins"

--- a/public/_locales/en/en.json
+++ b/public/_locales/en/en.json
@@ -645,6 +645,7 @@
   "tomorrow": "Tomorrow",
   "inAWeek": "In a week",
   "in2Weeks": "In 2 weeks",
+  "never": "Never",
   "30mins": "30 mins",
   "1hour": "1 hour",
   "5hours": "5 hours",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -2871,6 +2871,10 @@
     "message": "In 2 weeks",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Never",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 mins",
     "englishSource": "30 mins"

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -2925,6 +2925,10 @@
     "message": "In 2 weeks",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Never",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 mins",
     "englishSource": "30 mins"

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -2775,6 +2775,10 @@
     "message": "en 2 semanas",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Nunca",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 minutos",
     "englishSource": "30 mins"

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -2845,6 +2845,10 @@
     "message": "Dans 2 semaines",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Jamais",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 minutes",
     "englishSource": "30 mins"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -2885,6 +2885,10 @@
     "message": "2週間後",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "一度もない",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30分",
     "englishSource": "30 mins"

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -2876,6 +2876,10 @@
     "message": "2주 안에",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "절대",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30분",
     "englishSource": "30 mins"

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -2808,6 +2808,10 @@
     "message": "Za 2 tygodnie",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Nigdy",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 minut",
     "englishSource": "30 mins"

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -2826,6 +2826,10 @@
     "message": "Em 2 semanas",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Nunca",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 minutos",
     "englishSource": "30 mins"

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -2862,6 +2862,10 @@
     "message": "Через 2 недели",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Никогда",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 минут",
     "englishSource": "30 mins"

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -2861,6 +2861,10 @@
     "message": "2 hafta içinde",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Asla",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 dakika",
     "englishSource": "30 mins"

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -2880,6 +2880,10 @@
     "message": "Через 2 тижні",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "Ніколи",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30 хв",
     "englishSource": "30 mins"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -2870,6 +2870,10 @@
     "message": "2周内",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "绝不",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30分钟",
     "englishSource": "30 mins"

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -2861,6 +2861,10 @@
     "message": "2周内",
     "englishSource": "In 2 weeks"
   },
+  "never": {
+    "message": "绝不",
+    "englishSource": "Never"
+  },
   "30mins": {
     "message": "30分钟",
     "englishSource": "30 mins"

--- a/src/screens/send-flow/RecallCalendarDrawer.test.tsx
+++ b/src/screens/send-flow/RecallCalendarDrawer.test.tsx
@@ -104,6 +104,7 @@ const makeProps = (overrides: Partial<Props> = {}): Props => ({
   onRecallBlocksChange: jest.fn(),
   onRecallDateChange: jest.fn(),
   onRecallTimeChange: jest.fn(),
+  onRecallNever: jest.fn(),
   ...overrides
 });
 
@@ -283,6 +284,16 @@ describe('RecallCalendarDrawer', () => {
     const blocksArg = (props.onRecallBlocksChange as jest.Mock).mock.calls[0][0];
     expect(typeof blocksArg).toBe('string');
     expect(Number(blocksArg)).toBeGreaterThan(12345);
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('the "Never" option clears the reclaim height (→ P2ID) and closes the drawer', async () => {
+    const props = makeProps({ recallDate: new Date('2035-06-15T00:00:00') });
+    await renderDrawer(props);
+
+    fireEvent.click(screen.getByText('never'));
+
+    expect(props.onRecallNever).toHaveBeenCalledTimes(1);
     expect(props.onOpenChange).toHaveBeenCalledWith(false);
   });
 

--- a/src/screens/send-flow/RecallCalendarDrawer.tsx
+++ b/src/screens/send-flow/RecallCalendarDrawer.tsx
@@ -35,6 +35,8 @@ export interface RecallCalendarDrawerProps {
   onRecallBlocksChange: (blocks: string) => void;
   onRecallDateChange: (date: Date | undefined) => void;
   onRecallTimeChange: (time: string) => void;
+  /** Clear the reclaim height entirely — sends a plain P2ID note (no recall window). */
+  onRecallNever: () => void;
 }
 
 /**
@@ -50,7 +52,8 @@ export const RecallCalendarDrawer: React.FC<RecallCalendarDrawerProps> = ({
   recallTime,
   onRecallBlocksChange,
   onRecallDateChange,
-  onRecallTimeChange
+  onRecallTimeChange,
+  onRecallNever
 }) => {
   const { t } = useTranslation();
   const [syncHeight, setSyncHeight] = useState(0);
@@ -149,6 +152,19 @@ export const RecallCalendarDrawer: React.FC<RecallCalendarDrawerProps> = ({
               </button>
             ))}
           </div>
+
+          {/* No expiration — clears the reclaim height so the send goes out as a
+              plain P2ID note (recipient keeps it; the sender has no recall window). */}
+          <button
+            type="button"
+            className="w-full mt-2 py-2.5 rounded-[10px] border border-border-card text-heading-gray text-sm font-medium hover:bg-input-bg transition-colors cursor-pointer"
+            onClick={() => {
+              onRecallNever();
+              onOpenChange(false);
+            }}
+          >
+            {t('never')}
+          </button>
         </div>
       </DrawerContent>
     </Drawer>

--- a/src/screens/send-flow/ReviewTransaction.tsx
+++ b/src/screens/send-flow/ReviewTransaction.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { RpcClient } from '@miden-sdk/miden-sdk/lazy';
 import { addDays, format, formatDistanceToNow } from 'date-fns';
@@ -129,6 +129,13 @@ export const ReviewTransaction: React.FC = () => {
   const [recallTime, setRecallTime] = useState('12:00');
   const [recallBlocks, setRecallBlocks] = useState<string | undefined>(undefined);
   const [showCalendar, setShowCalendar] = useState(false);
+  // "Never" = no reclaim height → the send goes out as a plain P2ID note. Tracked
+  // separately from `recallDate` (undefined both before seeding AND when "Never" is
+  // chosen) so the expiration label can tell the two apart.
+  const [recallNever, setRecallNever] = useState(false);
+  // Marks the recall height as user-chosen (a date or "Never") so the async
+  // default-seeding effect below never clobbers an explicit choice (race guard).
+  const recallTouchedRef = useRef(false);
 
   // Default every same-chain send to a 7-day reclaim (expiration) height. Fetch
   // the current block height once on mount and seed recallDate/recallBlocks. The
@@ -139,10 +146,10 @@ export const ReviewTransaction: React.FC = () => {
     let cancelled = false;
     ensureSdkWasmReady()
       .then(() => {
-        if (cancelled) return;
+        if (cancelled || recallTouchedRef.current) return;
         const rpc = new RpcClient(getRpcEndpoint());
         return rpc.getBlockHeaderByNumber().then(header => {
-          if (cancelled) return;
+          if (cancelled || recallTouchedRef.current) return;
           const date = addDays(new Date(), 7);
           setRecallDate(date);
           setRecallTime(format(date, 'HH:mm'));
@@ -154,6 +161,24 @@ export const ReviewTransaction: React.FC = () => {
       cancelled = true;
     };
   }, [isBridge]);
+
+  // Recall-height handlers. All mark the choice as user-made so the seeding
+  // effect above won't overwrite it. "Never" clears the height entirely → P2ID.
+  const handleRecallDateChange = useCallback((date: Date | undefined) => {
+    recallTouchedRef.current = true;
+    if (date) setRecallNever(false);
+    setRecallDate(date);
+  }, []);
+  const handleRecallBlocksChange = useCallback((blocks: string) => {
+    recallTouchedRef.current = true;
+    setRecallBlocks(blocks);
+  }, []);
+  const handleRecallNever = useCallback(() => {
+    recallTouchedRef.current = true;
+    setRecallNever(true);
+    setRecallDate(undefined);
+    setRecallBlocks(undefined);
+  }, []);
 
   // Leaving review = leaving the send flow: drop any cached speculative prove
   // and mark in-flight ones stale. (SendManager's typing-time speculation
@@ -297,7 +322,9 @@ export const ReviewTransaction: React.FC = () => {
         const rel = formatDistanceToNow(recallDate, { addSuffix: true });
         return rel.charAt(0).toUpperCase() + rel.slice(1);
       })()
-    : t('none');
+    : recallNever
+      ? t('never')
+      : t('none');
 
   // Agglayer carries the bridgeable token 1:1; the Fast route forward-quotes the
   // USDC output. Show a skeleton only while the Fast quote is still loading.
@@ -369,9 +396,10 @@ export const ReviewTransaction: React.FC = () => {
           onOpenChange={setShowCalendar}
           recallDate={recallDate}
           recallTime={recallTime}
-          onRecallBlocksChange={setRecallBlocks}
-          onRecallDateChange={setRecallDate}
+          onRecallBlocksChange={handleRecallBlocksChange}
+          onRecallDateChange={handleRecallDateChange}
           onRecallTimeChange={setRecallTime}
+          onRecallNever={handleRecallNever}
         />
       )}
     </div>


### PR DESCRIPTION
Closes #421

## What

Adds a **"Never"** option to the send flow's expiration/recall picker, so a user can send a plain **P2ID** note (no reclaim window) instead of always getting a **P2IDE**.

## Why

Every same-chain send auto-attaches a reclaim height (default 7 days → P2IDE), and the "Expiration Date" drawer only let you *change* the date — never remove it. So there was no way to send a plain P2ID from the UI.

## How

- **`RecallCalendarDrawer`** — new `onRecallNever` prop + a **"Never"** button that clears the reclaim height and closes the drawer.
- **`ReviewTransaction`** — a `recallNever` state (plus a `recallTouchedRef` guard so the async 7-day default-seeding effect never clobbers an explicit "Never" choice, even under the fetch race); the expiration label renders "Never"; the send passes `recallBlocks = undefined`, which the SDK already turns into a plain P2ID (`newSendTransactionRequest(..., null, null)`). **No SDK change required.**
- **i18n** — added `never` to `public/_locales/en/en.json`.

Default behaviour (7-day recall → P2IDE) is unchanged unless the user explicitly picks "Never".

## Testing

- `yarn ts` clean; `yarn lint:i18n` clean.
- New unit test: the "Never" option calls `onRecallNever` and closes the drawer.
- Existing `RecallCalendarDrawer` (27) and `ReviewTransaction` (26) suites pass.
