### PR TITLE
fix(mobile): bridge-in EVM connect hang on iOS (non-plain icons arg) + dedupe @capacitor/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.15.18 (TBD)
+
+### Fixes
+
+- [FIX][mobile] **Bridge-in "Cross Chain" no longer hangs forever on "Preparing connection…" (iOS).** The native WalletConnect `configure` call passed `icons: APP_METADATA.icons`, but that shared `APP_METADATA` object is also handed to the web `@reown/appkit` modal (`createAppKit`), which wraps it in a reactive proxy in place — so `APP_METADATA.icons` is no longer a plain array. Capacitor's iOS bridge **silently drops** a plugin call whose arguments contain such a non-plain array, so `configure` never reached the native plugin and its promise hung forever, blocking `present()` and leaving the EVM connect stuck on "Preparing connection…". The arguments now pass a fresh plain array (`icons: [...APP_METADATA.icons]`), so the call serializes cleanly across the bridge. (The web E2E suite missed this because it drives the `connectUri` test hook, not the UI `configure` path.)
+- [FIX][mobile] **Deduplicate `@capacitor/core` in the mobile bundle.** Without a `resolve.dedupe` entry, Rollup inlined a second copy of the Capacitor runtime into the walletconnect chunk; only one `createCapacitor()` becomes the live `window.Capacitor`, so any plugin that resolved against the other copy dispatched into a dead bridge. Added `resolve.dedupe: ['@capacitor/core']` in `vite.mobile.config.ts` (the same guard the repo already applies to `dexie` / `@miden-sdk`).
+
 ## 1.15.17 (2026-08-02)
 
 ### Fixes

--- a/src/lib/walletconnect/useNativeReown.ts
+++ b/src/lib/walletconnect/useNativeReown.ts
@@ -15,16 +15,19 @@ let configurePromise: Promise<void> | null = null;
 
 export function configureNativeReown(): Promise<void> {
   if (!configurePromise) {
-    // Reset the cache on rejection: a rejected promise is truthy and would be
-    // returned by every later call, permanently poisoning EVM/bridge connect
-    // after a single transient boot failure (native plugin not yet ready /
-    // relay offline). Nulling it on failure lets the next call retry cleanly.
     configurePromise = NativeReown.configure({
       projectId: WC_PROJECT_ID,
       appName: APP_METADATA.name,
       appDescription: APP_METADATA.description,
       appUrl: APP_METADATA.url,
-      icons: APP_METADATA.icons,
+      // `APP_METADATA` is also handed to the web @reown/appkit modal
+      // (`createAppKit` in ./appkit), which reactively wraps the object in place —
+      // so `APP_METADATA.icons` is no longer a plain array. Capacitor's iOS bridge
+      // SILENTLY DROPS a native plugin call whose arguments contain such a non-plain
+      // array: `configure` never reaches native and its promise hangs forever,
+      // leaving EVM/bridge connect stuck on "Preparing connection…". Spread into a
+      // fresh plain array so the arguments serialize cleanly across the bridge.
+      icons: [...APP_METADATA.icons],
       verifyUrl: 'verify.walletconnect.com',
       nativeRedirect: NATIVE_REDIRECT,
       linkMode: false,
@@ -32,6 +35,10 @@ export function configureNativeReown(): Promise<void> {
       methods: ['eth_sendTransaction', 'personal_sign', 'eth_signTypedData'],
       events: ['chainChanged', 'accountsChanged']
     }).catch(err => {
+      // Reset the cache on rejection: a rejected promise is truthy and would be
+      // returned by every later call, permanently poisoning EVM/bridge connect
+      // after a single transient boot failure (native plugin not yet ready /
+      // relay offline). Nulling it on failure lets the next call retry cleanly.
       configurePromise = null;
       throw err;
     });

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -164,6 +164,14 @@ export default defineConfig({
   },
 
   resolve: {
+    // @capacitor/core MUST resolve to a single instance. Without this, Rollup
+    // inlines a second copy of the Capacitor runtime into the walletconnect
+    // chunk; that second `createCapacitor()` is NOT the one wired to
+    // `window.Capacitor`, so `registerPlugin('Reown')` on it dispatches into a
+    // dead bridge and every native Reown call hangs forever (bridge/EVM connect
+    // stuck on "Preparing connection…"). Deduping collapses it to the live
+    // runtime. (Same class of bug as the dexie/@miden-sdk duplication.)
+    dedupe: ['@capacitor/core'],
     // NOTE: the eager→lazy @miden-sdk/miden-sdk redirect is done by the
     // `miden-sdk-eager-to-lazy` plugin above (resolveId), NOT here. A
     // resolve.alias entry can't win: @miden-sdk/vite-plugin installs its own


### PR DESCRIPTION
## Problem

On iOS, bridge-in ("Receive → Cross Chain" / `/bridge/deposit`) got permanently stuck on **"Preparing connection…"** when tapping *Open Wallet*. The native WalletConnect `present()` awaits `configureNativeReown()`, whose promise never settled.

## Root cause

`configureNativeReown()` passed `icons: APP_METADATA.icons` to the native Reown plugin. That **same `APP_METADATA` object** is also handed to the web `@reown/appkit` modal (`createAppKit({ metadata: APP_METADATA })` in `appkit.tsx`), and `@reown/appkit` **reactively wraps the object in place** — so `APP_METADATA.icons` is no longer a plain array (it *looks* like an `Array` and isn't frozen, but it's a reactive proxy).

**Capacitor's iOS bridge silently drops a plugin call whose arguments contain such a non-plain array.** So `Reown.configure(...)` never reached the native method (native `configureStage` stayed `"none"`), its promise hung forever, `present()` waited on it, and the UI sat on "Preparing connection…".

This was maddening to pin down because every "same object / same args" comparison contradicted itself — calling `configure` from the debugger (with plain literal args) worked, while the app (with the wrapped `icons`) hung. Proven conclusively: `configure(JSON.parse(JSON.stringify(cfgArgs)))` — a plain copy — resolves and native reaches `configured: true`; the original hangs. The web E2E suite missed it because it drives the `connectUri` test hook, not the UI `configure` path.

## Fixes

1. **`icons: [...APP_METADATA.icons]`** — pass a fresh plain array so the args serialize cleanly across the bridge. (The one-line fix for the hang.)
2. **`resolve.dedupe: ['@capacitor/core']`** in `vite.mobile.config.ts` — found while investigating: Rollup was inlining a *second* copy of the Capacitor runtime into the walletconnect chunk (only one `createCapacitor()` is wired to `window.Capacitor`). Same latent duplicate-runtime bug the repo already guards against for `dexie` / `@miden-sdk`.

## Verification

Verified on a physical iPad (iPadOS 18.6):
- Native `configure` now dispatches and runs end-to-end (`configureStage: "resolved"`, `configured: true`).
- Full `present()` flow completes — `AppKit.present` fires and the WalletConnect wallet picker appears instead of the stuck "Preparing connection…".
- Re-verified with the clean (debug-free) build.
