### PR TITLE
feat: enable Earn deposits on Guardian accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - [FIX][mobile] **Bridge-in "Cross Chain" no longer hangs forever on "Preparing connection…" (iOS).** The native WalletConnect `configure` call passed `icons: APP_METADATA.icons`, but that shared `APP_METADATA` object is also handed to the web `@reown/appkit` modal (`createAppKit`), which wraps it in a reactive proxy in place — so `APP_METADATA.icons` is no longer a plain array. Capacitor's iOS bridge **silently drops** a plugin call whose arguments contain such a non-plain array, so `configure` never reached the native plugin and its promise hung forever, blocking `present()` and leaving the EVM connect stuck on "Preparing connection…". The arguments now pass a fresh plain array (`icons: [...APP_METADATA.icons]`), so the call serializes cleanly across the bridge. (The web E2E suite missed this because it drives the `connectUri` test hook, not the UI `configure` path.)
 - [FIX][mobile] **Deduplicate `@capacitor/core` in the mobile bundle.** Without a `resolve.dedupe` entry, Rollup inlined a second copy of the Capacitor runtime into the walletconnect chunk; only one `createCapacitor()` becomes the live `window.Capacitor`, so any plugin that resolved against the other copy dispatched into a dead bridge. Added `resolve.dedupe: ['@capacitor/core']` in `vite.mobile.config.ts` (the same guard the repo already applies to `dexie` / `@miden-sdk`).
 
+### Features
+
+- [FEATURE][all] **Earn deposits now work on Guardian accounts.** Opening an Earn position from a Guardian account was blocked with "Earn deposits aren't available on Guardian accounts yet" because the collateral must be a recallable **P2IDE** note (with a reclaim height) and the multisig client's send proposal is P2ID-only. The deposit now routes through a custom proposal built from a P2IDE send request to the Epoch allocator — the same mechanism that made guardian sends recallable in 1.15.17 — converting the relative recall offset to an absolute height at build time and reusing the persisted request bytes across propose/sign/retry. The Deposit CTA is no longer gated on account type.
+
 ## 1.15.17 (2026-08-02)
 
 ### Fixes

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -3669,10 +3669,6 @@
     "message": "Fehlgeschlagen",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Auf Guardian-Konten sind noch keine Einzahlungen möglich. Wechseln Sie zum Einzahlen zu einem Standardkonto.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Gelder zurückfordern",
     "englishSource": "Reclaim funds"

--- a/public/_locales/en/en.json
+++ b/public/_locales/en/en.json
@@ -816,7 +816,6 @@
   "bridgeRowVia": "Via $provider$ → $network$",
   "bridgeInProgress": "In progress",
   "bridgeFailed": "Failed",
-  "earnDepositGuardianUnsupported": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit.",
   "reclaimFunds": "Reclaim funds",
   "reclaiming": "Reclaiming…",
   "reclaimableAfterBlock": "Funds reclaimable after block",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -3616,10 +3616,6 @@
     "message": "Failed",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Reclaim funds",
     "englishSource": "Reclaim funds"

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -3670,10 +3670,6 @@
     "message": "Failed",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Reclaim funds",
     "englishSource": "Reclaim funds"

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -3616,10 +3616,6 @@
     "message": "Fallido",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Los depósitos ganados aún no están disponibles en las cuentas de Guardian. Cambie a una cuenta estándar para depositar.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Reclamar fondos",
     "englishSource": "Reclaim funds"

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -3668,10 +3668,6 @@
     "message": "Échoué",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Les dépôts gagnés ne sont pas encore disponibles sur les comptes Guardian. Passez à un compte standard pour effectuer un dépôt.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Récupérer des fonds",
     "englishSource": "Reclaim funds"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -3669,10 +3669,6 @@
     "message": "失敗した",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Guardian アカウントではまだデポジットの獲得は利用できません。入金するには標準口座に切り替えてください。",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "資金を回収する",
     "englishSource": "Reclaim funds"

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -3669,10 +3669,6 @@
     "message": "실패한",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Guardian 계정에서는 아직 적립금을 사용할 수 없습니다. 입금하려면 일반 계좌로 전환하세요.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "자금 회수",
     "englishSource": "Reclaim funds"

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -3616,10 +3616,6 @@
     "message": "Przegrany",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Zarabiaj wpłaty nie są jeszcze dostępne na kontach Guardian. Przejdź na konto standardowe, aby dokonać wpłaty.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Odzyskaj środki",
     "englishSource": "Reclaim funds"

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -3667,10 +3667,6 @@
     "message": "Fracassado",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Os depósitos para ganhos ainda não estão disponíveis nas contas do Guardian. Mude para uma conta padrão para depositar.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Recuperar fundos",
     "englishSource": "Reclaim funds"

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -3670,10 +3670,6 @@
     "message": "Неуспешный",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Заработок на депозитах пока недоступен на счетах Guardian. Переключитесь на стандартный счет для внесения депозита.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Возврат средств",
     "englishSource": "Reclaim funds"

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -3669,10 +3669,6 @@
     "message": "Arızalı",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Para yatırma özelliği henüz Guardian hesaplarında mevcut değil. Para yatırmak için standart bir hesaba geçin.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Fonları geri alın",
     "englishSource": "Reclaim funds"

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -3670,10 +3670,6 @@
     "message": "Не вдалося",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Заробляти депозити ще не доступні для облікових записів Guardian. Перейдіть на стандартний рахунок для депозиту.",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "Повернути кошти",
     "englishSource": "Reclaim funds"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -3669,10 +3669,6 @@
     "message": "失败的",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Guardian 账户尚不支持赚取存款。切换至标准账户进行存款。",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "收回资金",
     "englishSource": "Reclaim funds"

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -3669,10 +3669,6 @@
     "message": "失败的",
     "englishSource": "Failed"
   },
-  "earnDepositGuardianUnsupported": {
-    "message": "Guardian 账户尚不支持赚取存款。切换至标准账户进行存款。",
-    "englishSource": "Earn deposits aren’t available on Guardian accounts yet. Switch to a standard account to deposit."
-  },
   "reclaimFunds": {
     "message": "收回资金",
     "englishSource": "Reclaim funds"

--- a/src/lib/epoch/earn.test.ts
+++ b/src/lib/epoch/earn.test.ts
@@ -1,11 +1,9 @@
 import { updateEarnDepositStatus } from 'lib/miden/activity';
-import { isGuardianAccount } from 'lib/miden/front/guardian-manager';
 import * as Repo from 'lib/miden/repo';
 
 import { getCurrentMidenBlock } from './chain';
 import {
   EARN_DESTINATION_CHAIN_ID,
-  GUARDIAN_EARN_DEPOSIT_UNSUPPORTED,
   openEarnPosition,
   pollEarnIntentStatus,
   reconcileEarnDeposits,
@@ -27,7 +25,6 @@ jest.mock('./chain', () => ({
 jest.mock('./earn-note', () => ({ createEarnP2IDNote: jest.fn() }));
 jest.mock('./sdk', () => ({ getEpochReadOnlySdk: jest.fn() }));
 jest.mock('lib/miden/activity', () => ({ updateEarnDepositStatus: jest.fn() }));
-jest.mock('lib/miden/front/guardian-manager', () => ({ isGuardianAccount: jest.fn() }));
 jest.mock('lib/miden/repo', () => ({ transactions: { filter: jest.fn(), where: jest.fn() } }));
 
 const SEPOLIA = EARN_DESTINATION_CHAIN_ID;
@@ -268,68 +265,53 @@ describe('reconcileEarnDeposits', () => {
   });
 });
 
-const mockIsGuardian = isGuardianAccount as jest.MockedFunction<typeof isGuardianAccount>;
 const mockGetBlock = getCurrentMidenBlock as jest.MockedFunction<typeof getCurrentMidenBlock>;
 
 /**
- * The guardian refusal and the amount/address validation are the wallet's only
- * guard against minting a non-recallable P2ID collateral note (funds locked with
- * no reclaim path) — a regression that dropped either would strand user funds, so
- * each guard gets an explicit test that fails if the guard is removed.
+ * The amount/address validation is the wallet's only guard against minting a
+ * collateral note for a zero/invalid deposit — a regression that dropped either
+ * would strand user funds, so each guard gets an explicit test that fails if the
+ * guard is removed. (Guardian accounts are supported: the collateral note is a
+ * recallable P2IDE built as a custom proposal in `generateTransaction` — covered
+ * by transactions.guardian.test.ts, not here.)
  */
 describe('openEarnPosition guards', () => {
-  // Shared reference so the `isGuardian` call assertion can match the exact
-  // provider object without reading it back off the `as never` deps cast.
-  const guardianProvider = {};
   const baseArgs = () => ({
     amount: 1_000_000n,
     evmAddress: SPONSOR,
     senderPublicKey: 'mtst1sender',
-    deps: { signTransaction: jest.fn(), guardianProvider } as never,
+    deps: { signTransaction: jest.fn(), guardianProvider: {} } as never,
     onRowCreated: jest.fn()
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsGuardian.mockResolvedValue(false);
     mockGetBlock.mockResolvedValue(1000);
   });
 
-  it('refuses a guardian account before any SDK or quote work', async () => {
-    mockIsGuardian.mockResolvedValue(true);
-
-    await expect(openEarnPosition(baseArgs())).rejects.toThrow(GUARDIAN_EARN_DEPOSIT_UNSUPPORTED);
-
-    // No collateral note may be minted and no read-only SDK spun up for a guardian.
-    expect(mockGetSdk).not.toHaveBeenCalled();
-  });
-
-  it('rejects a non-positive deposit amount before touching the guardian provider', async () => {
+  it('rejects a non-positive deposit amount before any SDK work', async () => {
     await expect(openEarnPosition({ ...baseArgs(), amount: 0n })).rejects.toThrow(
       'Deposit amount must be greater than zero.'
     );
 
-    expect(mockIsGuardian).not.toHaveBeenCalled();
     expect(mockGetSdk).not.toHaveBeenCalled();
   });
 
-  it('rejects an invalid EVM address before touching the guardian provider', async () => {
+  it('rejects an invalid EVM address before any SDK work', async () => {
     await expect(openEarnPosition({ ...baseArgs(), evmAddress: 'not-an-address' })).rejects.toThrow(
       'valid EVM address'
     );
 
-    expect(mockIsGuardian).not.toHaveBeenCalled();
     expect(mockGetSdk).not.toHaveBeenCalled();
   });
 
-  it('lets a non-guardian account past the guard and into SDK setup', async () => {
+  it('lets a valid deposit past the guards and into SDK setup', async () => {
     const args = baseArgs();
-    // Fail at the first SDK call so the assertion is only that the guard was cleared.
+    // Fail at the first SDK call so the assertion is only that the guards were cleared.
     mockGetSdk.mockResolvedValue({ getTaskData: jest.fn().mockRejectedValue(new Error('stop')) } as never);
 
     await expect(openEarnPosition(args)).rejects.toThrow('stop');
 
-    expect(mockIsGuardian).toHaveBeenCalledWith(args.senderPublicKey, guardianProvider);
     expect(mockGetSdk).toHaveBeenCalledWith(SPONSOR);
   });
 });

--- a/src/lib/epoch/earn.ts
+++ b/src/lib/epoch/earn.ts
@@ -9,7 +9,6 @@ import { keccak256, toBytes } from 'viem';
 
 import { updateEarnDepositStatus } from 'lib/miden/activity';
 import { type IEarnDepositExtraInputs, ITransactionStatus } from 'lib/miden/db/types';
-import { isGuardianAccount } from 'lib/miden/front/guardian-manager';
 import * as Repo from 'lib/miden/repo';
 
 import { normalizeMidenIdToHex } from './bridge';
@@ -308,31 +307,6 @@ export function pollEarnIntentStatus(args: {
   }
 }
 
-/**
- * Why Guardian (multisig) accounts cannot open Earn positions yet.
- *
- * The Epoch mandate advertises the collateral note as a **P2IDE with an absolute
- * `midenReclaimHeight`** (see `buildEarnTaskDataParams`) — that reclaim height is
- * both what the allocator validates and the user's only escape hatch if the
- * lending leg never settles. The Guardian proposal API
- * (`@openzeppelin/miden-multisig-client`) exposes only `createP2idProposal`
- * (recipient/faucet/amount — no reclaim height) plus the structural proposals and
- * `createCustomProposal(requestBytes)`; there is NO P2IDE / recall-height
- * proposal. Routing an earn deposit through `createSendProposal` therefore mints
- * a plain P2ID: the note does not match the mandate (the allocator can reject the
- * intent) and the collateral has no reclaim path.
- *
- * Rather than ship that silent mismatch, earn deposits are refused for Guardian
- * accounts here, at the earliest point that has a guardian provider (before any
- * quote or intent exists), and again in the Guardian branch of
- * `generateTransaction`. Lifting this needs a P2IDE-capable proposal (or a
- * hand-built P2IDE `requestBytes` fed through `createCustomProposal`, the way the
- * Agglayer `bridged-send` path does).
- */
-export const GUARDIAN_EARN_DEPOSIT_UNSUPPORTED =
-  'Earn deposits are not available on Guardian accounts yet — the collateral note needs a reclaim height ' +
-  'that Guardian proposals cannot express. Use a standard account to deposit.';
-
 export interface OpenEarnPositionArgs {
   /** Collateral amount in `MIDEN_USDC_DECIMALS` base units. */
   amount: bigint;
@@ -362,9 +336,6 @@ export async function openEarnPosition(args: OpenEarnPositionArgs): Promise<{ tx
   }
   if (!isEvmAddress(args.evmAddress)) {
     throw new Error('Enter a valid EVM address (0x followed by 40 hex characters).');
-  }
-  if (await isGuardianAccount(args.senderPublicKey, args.deps.guardianProvider)) {
-    throw new Error(GUARDIAN_EARN_DEPOSIT_UNSUPPORTED);
   }
   const evmRecipient = args.evmAddress;
 

--- a/src/lib/epoch/index.ts
+++ b/src/lib/epoch/index.ts
@@ -17,7 +17,6 @@ export {
   buildEarnTaskDataParams,
   getEarnQuote,
   buildEarnIntent,
-  GUARDIAN_EARN_DEPOSIT_UNSUPPORTED,
   MIDEN_USDC_FAUCET,
   MIDEN_USDC_DECIMALS,
   EARN_MARKET_UID,

--- a/src/lib/miden/db/types.ts
+++ b/src/lib/miden/db/types.ts
@@ -599,10 +599,12 @@ export class BridgedSendTransaction implements ITransaction {
 }
 
 /**
- * Open an Epoch lending position. Always send-style: a recallable P2IDE note to the
- * solver's allocator account, processed by the normal send pipeline
- * (`sendTransaction`) like the Epoch `bridged-send`. The EVM lending deposit is
- * solver-fulfilled, so there is no `requestBytes` and no manual claim.
+ * Open an Epoch lending position: a recallable P2IDE note to the solver's allocator
+ * account. On non-Guardian accounts it is send-style, processed by the normal send
+ * pipeline (`sendTransaction`) like the Epoch `bridged-send`. On Guardian accounts the
+ * multisig send proposal is P2ID-only, so the P2IDE is serialized into `requestBytes`
+ * and proposed as a custom proposal (see `generateGuardianTransaction` 'earn-deposit').
+ * The EVM lending deposit is solver-fulfilled, so there is no manual claim.
  */
 export class EarnDepositTransaction implements ITransaction {
   id: string;

--- a/src/lib/miden/db/types.ts
+++ b/src/lib/miden/db/types.ts
@@ -615,6 +615,8 @@ export class EarnDepositTransaction implements ITransaction {
   noteType?: NoteType;
   transactionId?: string;
   outputNoteIds?: string[];
+  /** Guardian path: serialized P2IDE send request reused across propose/sign/retry. */
+  requestBytes?: Uint8Array;
   status: ITransactionStatus;
   initiatedAt: number;
   processingStartedAt?: number;

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -204,8 +204,7 @@ export const generateTransaction = async (
       // rows on a transient pre-submit 409; a Failed row is terminal.)
       if (
         transaction.type === 'earn-deposit' &&
-        (extractSdkErrorCode(error) === 'ApplyTransactionAfterSubmitFailed' ||
-          isGuardianCanonicalizationError(error))
+        (extractSdkErrorCode(error) === 'ApplyTransactionAfterSubmitFailed' || isGuardianCanonicalizationError(error))
       ) {
         console.warn(
           '[Guardian] earn-deposit submitted but post-submit reconcile failed — marking Failed so the awaiting caller stops waiting:',

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -198,8 +198,10 @@ export const generateTransaction = async (
       // hangs the wait promise (and `openEarnPosition`) forever. Fail the row instead
       // so the caller resolves via the error branch; the on-chain P2IDE collateral note
       // reclaims itself at its recall height. Mirrors generateTransactionsLoop's
-      // non-guardian guard; earn-deposit is excluded from REQUEUEABLE_ON_PENDING_CONFLICT
-      // so a Failed row is never re-queued into a duplicate collateral note.
+      // non-guardian guard; earn-deposit is excluded from `REQUEUEABLE_TYPES` (retry.ts)
+      // so a Failed row is never re-queued into a duplicate collateral note. (It IS a
+      // member of REQUEUEABLE_ON_PENDING_CONFLICT, but that set only requeues still-Queued
+      // rows on a transient pre-submit 409; a Failed row is terminal.)
       if (
         transaction.type === 'earn-deposit' &&
         (extractSdkErrorCode(error) === 'ApplyTransactionAfterSubmitFailed' ||
@@ -597,6 +599,18 @@ const generateGuardianTransaction = async (
           'Earn deposit is missing recallBlocks/allocator — the collateral must be a recallable P2IDE note.'
         );
       }
+      // If openEarnPosition already abandoned this deposit — its 5-min
+      // waitForTransactionCompletion timed out, or the Epoch intent was aborted — it
+      // marked extraInputs.epochStatus 'failed'. A guardian requeue can keep this row
+      // live past that wait (up to MAX_QUEUED_AGE), so bail out rather than submit a
+      // collateral note the allocator has no live intent for: that would strand the note
+      // until its recall height AND falsely mark the row 'Deposited to lending'. This
+      // throw is terminal (→ cancelTransaction below), and a Failed row is never re-picked.
+      if (earnTx.extraInputs?.epochStatus === 'failed') {
+        throw new Error(
+          'Earn deposit was already abandoned by the caller (epochStatus=failed) — refusing to submit an orphan collateral note.'
+        );
+      }
       // The P2IDE note's serial number is random, so build the request ONCE and
       // reuse the exact same bytes for BOTH `createCustomProposal` and
       // `signAndCreateTransactionRequest` below; persist them so a retry after a
@@ -604,7 +618,13 @@ const generateGuardianTransaction = async (
       if (!transaction.requestBytes) {
         const requestBytes = await withWasmClientLock(async () => {
           const midenClient = await getMidenClient();
-          const syncHeight = await midenClient.client.getSyncHeight();
+          // Force a fresh sync (like the non-Guardian earn path,
+          // MidenClientInterface.sendTransaction) so the absolute reclaim height is
+          // measured against a CURRENT chain head. A stale cached getSyncHeight() on a
+          // cold-started/degraded wallet could understate the height enough that the
+          // note's remaining reclaim window falls below the allocator's minimum and the
+          // deposit is rejected.
+          const syncHeight = (await midenClient.client.sync()).blockNum();
           const client = await WasmWebClient.createClient(MIDEN_NETWORK_ENDPOINTS.get(DEFAULT_NETWORK)!);
           try {
             const tr = await client.newSendTransactionRequest(

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -252,6 +252,19 @@ export const generateTransaction = async (
           stage: 'creating-proposal',
           nextEligibleAt: Math.floor(Date.now() / 1000) + PENDING_CONFLICT_REQUEUE_COOLDOWN_SEC
         });
+        // An earn-deposit's requestBytes freeze an ABSOLUTE reclaim height at build
+        // time (syncHeight + recallBlocks). Unlike send/swap — whose reused note stays
+        // valid indefinitely — the Epoch allocator rejects a collateral note whose
+        // REMAINING reclaim window has shrunk below its minimum, so reusing the frozen
+        // bytes across a long requeue loop (up to MAX_QUEUED_AGE) would strand the
+        // collateral at the allocator. Drop the cached request so the next cycle rebuilds
+        // the P2IDE note against a fresh sync height. Safe here: a pending-conflict 409
+        // means no proposal was registered and no note was submitted.
+        if (transaction.type === 'earn-deposit') {
+          await Repo.transactions.where({ id: transaction.id }).modify(t => {
+            t.requestBytes = undefined;
+          });
+        }
         return;
       }
       await cancelTransaction(transaction, error);

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -187,12 +187,36 @@ export const generateTransaction = async (
       // ApplyTransactionAfterSubmitFailed handler: mark Completed so the next sync
       // reconciles the note state via ConsumedExternal. (Structural ops are handled
       // above and never reach here on success.)
+      //
+      // Earn-deposit is the exception among value-moving guardian ops: its caller
+      // (`createEarnP2IDNote` via `waitForTransactionCompletion`) reads
+      // `resultBytes`/`outputNoteIds` back off the finished row. On a post-submit
+      // failure — a local apply throw OR a canonicalization race — there is NO
+      // TransactionResult to repopulate them, so marking the row Completed (as the
+      // branches below do for send/consume/swap/execute) would leave the caller to
+      // `TransactionResult.deserialize(undefined)`, which throws AFTER `cleanup()` and
+      // hangs the wait promise (and `openEarnPosition`) forever. Fail the row instead
+      // so the caller resolves via the error branch; the on-chain P2IDE collateral note
+      // reclaims itself at its recall height. Mirrors generateTransactionsLoop's
+      // non-guardian guard; earn-deposit is excluded from REQUEUEABLE_ON_PENDING_CONFLICT
+      // so a Failed row is never re-queued into a duplicate collateral note.
+      if (
+        transaction.type === 'earn-deposit' &&
+        (extractSdkErrorCode(error) === 'ApplyTransactionAfterSubmitFailed' ||
+          isGuardianCanonicalizationError(error))
+      ) {
+        console.warn(
+          '[Guardian] earn-deposit submitted but post-submit reconcile failed — marking Failed so the awaiting caller stops waiting:',
+          error
+        );
+        await cancelTransaction(transaction, error);
+        return;
+      }
       if (
         extractSdkErrorCode(error) === 'ApplyTransactionAfterSubmitFailed' &&
         (transaction.type === 'consume' ||
           transaction.type === 'send' ||
           transaction.type === 'swap' ||
-          transaction.type === 'earn-deposit' ||
           transaction.type === 'execute')
       ) {
         console.warn(
@@ -258,8 +282,10 @@ export const generateTransaction = async (
         // REMAINING reclaim window has shrunk below its minimum, so reusing the frozen
         // bytes across a long requeue loop (up to MAX_QUEUED_AGE) would strand the
         // collateral at the allocator. Drop the cached request so the next cycle rebuilds
-        // the P2IDE note against a fresh sync height. Safe here: a pending-conflict 409
-        // means no proposal was registered and no note was submitted.
+        // the P2IDE note against a fresh sync height. Safe here: no collateral note reached
+        // the chain — any proposal that a 409 from the un-retried
+        // signAndCreateTransactionRequest may have registered was already abandoned by the
+        // submit catch — so rebuilding a fresh note orphans nothing.
         if (transaction.type === 'earn-deposit') {
           await Repo.transactions.where({ id: transaction.id }).modify(t => {
             t.requestBytes = undefined;

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -618,13 +618,25 @@ const generateGuardianTransaction = async (
       if (!transaction.requestBytes) {
         const requestBytes = await withWasmClientLock(async () => {
           const midenClient = await getMidenClient();
-          // Force a fresh sync (like the non-Guardian earn path,
+          // Prefer a fresh sync (like the non-Guardian earn path,
           // MidenClientInterface.sendTransaction) so the absolute reclaim height is
-          // measured against a CURRENT chain head. A stale cached getSyncHeight() on a
-          // cold-started/degraded wallet could understate the height enough that the
-          // note's remaining reclaim window falls below the allocator's minimum and the
-          // deposit is rejected.
-          const syncHeight = (await midenClient.client.sync()).blockNum();
+          // measured against a CURRENT chain head — a stale cached height on a
+          // cold-started wallet could understate it enough that the note's remaining
+          // reclaim window falls below the allocator's minimum and the deposit is
+          // rejected. But a network sync can fail/time out, and that must NOT fail an
+          // otherwise-submittable deposit, so fall back to the last-synced height (the
+          // recall buffer absorbs mild lag). This keeps the guardian path no more
+          // network-fragile than the pre-fresh-sync behavior.
+          let syncHeight: number;
+          try {
+            syncHeight = (await midenClient.client.sync()).blockNum();
+          } catch (syncError) {
+            console.warn(
+              '[Guardian] fresh sync before earn-deposit note build failed; using last-synced height',
+              syncError
+            );
+            syncHeight = await midenClient.client.getSyncHeight();
+          }
           const client = await WasmWebClient.createClient(MIDEN_NETWORK_ENDPOINTS.get(DEFAULT_NETWORK)!);
           try {
             const tr = await client.newSendTransactionRequest(

--- a/src/lib/miden/transaction/index.ts
+++ b/src/lib/miden/transaction/index.ts
@@ -539,18 +539,60 @@ const generateGuardianTransaction = async (
       break;
     }
     case 'earn-deposit': {
-      // NOT SUPPORTED on Guardian accounts — see `GUARDIAN_EARN_DEPOSIT_UNSUPPORTED`
-      // in lib/epoch/earn.ts. The Epoch mandate advertises a P2IDE collateral note
-      // with an absolute `midenReclaimHeight`; the multisig client exposes only
-      // `createP2idProposal` (no recall height), so proposing this as a plain send
-      // would mint a P2ID that doesn't match the mandate AND leaves the collateral
-      // with no reclaim path. `openEarnPosition` refuses Guardian accounts before a
-      // row is ever queued; this is the backstop for any row that slips through
-      // (e.g. an account converted to Guardian while a deposit was queued).
-      throw new Error(
-        'Earn deposits are not available on Guardian accounts yet — the collateral note needs a reclaim ' +
-          'height that Guardian proposals cannot express.'
+      // Guardian earn deposit: the Epoch mandate requires a P2IDE collateral note
+      // with a reclaim height, which the multisig client's P2ID proposal cannot
+      // express — so route it through a custom proposal built from a P2IDE send
+      // request, exactly like the recallable `send` case (see OpenZeppelin/
+      // guardian#366). `recallBlocks` (set on the row by `openEarnPosition`) is a
+      // RELATIVE blocks-until-reclaim offset; the note's absolute reclaim height is
+      // `syncHeight + recallBlocks` at build time, the same relative→absolute
+      // conversion the non-Guardian path uses. The Epoch allocator validates the
+      // REMAINING reclaim window against its own (later) chain head — not an exact
+      // height — so the extra guardian propose/sign/submit delay is absorbed by
+      // `MIDEN_RECLAIM_BUFFER_BLOCKS` baked into `recallBlocks` (see earn-note.ts).
+      const earnTx = transaction as EarnDepositTransaction;
+      service = await getOrCreateMultisigService(transaction.accountId, guardianProvider);
+      const recallBlocks = earnTx.extraInputs?.recallBlocks;
+      if (!recallBlocks || !earnTx.secondaryAccountId) {
+        throw new Error(
+          'Earn deposit is missing recallBlocks/allocator — the collateral must be a recallable P2IDE note.'
+        );
+      }
+      // The P2IDE note's serial number is random, so build the request ONCE and
+      // reuse the exact same bytes for BOTH `createCustomProposal` and
+      // `signAndCreateTransactionRequest` below; persist them so a retry after a
+      // process restart reuses the same request (same rule as send/swap).
+      if (!transaction.requestBytes) {
+        const requestBytes = await withWasmClientLock(async () => {
+          const midenClient = await getMidenClient();
+          const syncHeight = await midenClient.client.getSyncHeight();
+          const client = await WasmWebClient.createClient(MIDEN_NETWORK_ENDPOINTS.get(DEFAULT_NETWORK)!);
+          try {
+            const tr = await client.newSendTransactionRequest(
+              accountIdStringToSdk(earnTx.accountId),
+              accountIdStringToSdk(earnTx.secondaryAccountId!),
+              accountIdStringToSdk(earnTx.faucetId),
+              // Earn collateral is always a PUBLIC P2IDE note — the Epoch allocator
+              // discovers and consumes it on-chain (createEarnP2IDNote hardcodes it).
+              NoteType.Public,
+              BigInt(earnTx.amount),
+              syncHeight + recallBlocks,
+              null
+            );
+            return tr.serialize();
+          } finally {
+            client.terminate();
+          }
+        });
+        transaction.requestBytes = requestBytes;
+        await Repo.transactions.where({ id: transaction.id }).modify(t => {
+          t.requestBytes = requestBytes;
+        });
+      }
+      proposalResult = await withGuardianConflictRetry(() =>
+        service.createCustomProposal(transaction.requestBytes!, 'earn_deposit')
       );
+      break;
     }
     case 'swap': {
       service = await getOrCreateMultisigService(transaction.accountId, guardianProvider);
@@ -808,8 +850,13 @@ const generateGuardianTransaction = async (
     case 'bridged-send':
       await completeBridgedSendTransaction(transaction as BridgedSendTransaction, result);
       break;
-    // No `earn-deposit` case: the proposal switch above throws for that type on
-    // Guardian accounts (no P2IDE proposal exists), so it can never reach here.
+    case 'earn-deposit':
+      // Same completion as the non-Guardian path: extract the committed P2IDE
+      // collateral note id and mark the row Deposited. `createEarnP2IDNote` reads
+      // `outputNoteIds[0]` off this row to hand the note back to the Epoch SDK, so
+      // routing this to the generic custom-tx completion would strand the deposit.
+      await completeEarnDepositTransaction(transaction as EarnDepositTransaction, result);
+      break;
     case 'execute':
     default:
       await completeCustomTransaction(transaction, result);

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -689,6 +689,126 @@ describe('generateTransaction — Guardian routing', () => {
     }
   });
 
+  it('Guardian earn-deposit: submit lands but local apply fails — row is marked Failed (not Completed) so the awaiting caller stops waiting', async () => {
+    // A Completed earn-deposit row without resultBytes would hang createEarnP2IDNote's
+    // waitForTransactionCompletion (TransactionResult.deserialize(undefined) throws after
+    // cleanup(), so the wait promise never settles and openEarnPosition hangs forever).
+    // A post-submit apply failure must therefore Fail the row, NOT Complete it — unlike
+    // send/consume/swap/execute, which mark Completed and let the next sync reconcile.
+    const txId = 'earn-guardian-applyfail';
+    const requestBytes = new Uint8Array([31, 32, 33]);
+    const transaction = Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: 'allocator',
+      faucetId: 'faucet',
+      noteType: 'public',
+      requestBytes: undefined,
+      extraInputs: { recallBlocks: 25 },
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const newSendTransactionRequest = jest.fn(async () => ({ serialize: () => requestBytes }));
+    mockCreateWasmWebClient.mockResolvedValue({ newSendTransactionRequest, terminate: jest.fn() });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(async () => ({ id: 'earn-applyfail-proposal', nonce: 5 })),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(async () => ({
+        serialize: () => new Uint8Array([1]),
+        authArg: () => undefined
+      })),
+      abandonCandidate: jest.fn(async () => {}),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+
+    // Submit lands on-chain but the LOCAL apply throws ApplyTransactionAfterSubmitFailed.
+    const applyErr: Error & { errorCode?: string } = new Error('apply failed');
+    applyErr.errorCode = 'ApplyTransactionAfterSubmitFailed';
+    const client = Object.assign(
+      makeClientApi(
+        makeResult(),
+        jest.fn(async () => {
+          throw applyErr;
+        })
+      ),
+      { getSyncHeight: jest.fn(async () => 100) }
+    );
+    mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // Failed, NOT Completed — a Completed row without resultBytes hangs the caller.
+    const row = txStore.find(r => r.id === txId);
+    expect(row?.status).toBe(ITransactionStatus.Failed);
+  });
+
+  it('Guardian earn-deposit: a canonicalization race after submit also marks the row Failed (not Completed)', async () => {
+    // The other arm of the same guard: a canonicalization nonce-lag error would mark
+    // any other guardian tx Completed, but for earn-deposit that Completed-without-
+    // resultBytes state hangs the caller, so it must Fail here too.
+    const txId = 'earn-guardian-canon';
+    const requestBytes = new Uint8Array([41, 42, 43]);
+    const transaction = Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: 'allocator',
+      faucetId: 'faucet',
+      noteType: 'public',
+      requestBytes: undefined,
+      extraInputs: { recallBlocks: 25 },
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const newSendTransactionRequest = jest.fn(async () => ({ serialize: () => requestBytes }));
+    mockCreateWasmWebClient.mockResolvedValue({ newSendTransactionRequest, terminate: jest.fn() });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(async () => ({ id: 'earn-canon-proposal', nonce: 6 })),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(async () => ({
+        serialize: () => new Uint8Array([1]),
+        authArg: () => undefined
+      })),
+      abandonCandidate: jest.fn(async () => {}),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+
+    const canonErr = new Error(
+      'Refusing to overwrite local state: incoming nonce 5 is not greater than local nonce 7'
+    );
+    const client = Object.assign(
+      makeClientApi(
+        makeResult(),
+        jest.fn(async () => {
+          throw canonErr;
+        })
+      ),
+      { getSyncHeight: jest.fn(async () => 100) }
+    );
+    mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    expect(txStore.find(r => r.id === txId)?.status).toBe(ITransactionStatus.Failed);
+  });
+
   it('Guardian recallable send reuses persisted request bytes after a retry', async () => {
     const txId = 'recallable-retry';
     const result = makeResult();

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -425,7 +425,9 @@ describe('generateTransaction — Guardian routing', () => {
       amount: 1000n,
       secondaryAccountId: 'allocator',
       faucetId: 'faucet',
-      noteType: 'public',
+      // Row says 'private', but earn collateral is always minted PUBLIC — the 4th-arg
+      // assertion ('Public') below only holds if the source ignores the row's noteType.
+      noteType: 'private',
       requestBytes: undefined,
       extraInputs: { recallBlocks: 25 },
       delegateTransaction: true
@@ -479,6 +481,15 @@ describe('generateTransaction — Guardian routing', () => {
     expect(multisigService.createSendProposal).not.toHaveBeenCalled();
     expect(multisigService.signAndCreateTransactionRequest).toHaveBeenCalledWith('earn-proposal', requestBytes);
     expect(txStore.find(row => row.id === txId)?.requestBytes).toBe(requestBytes);
+
+    // Completion must route to completeEarnDepositTransaction, NOT the generic custom-tx
+    // completion — otherwise the row finishes without the collateral note id that
+    // createEarnP2IDNote reads back for the Epoch handoff (stranding the deposit).
+    // 'Deposited to lending' is set only by completeEarnDepositTransaction, so it pins
+    // the routing: deleting the completion case fails this assertion.
+    const completed = txStore.find(row => row.id === txId);
+    expect(completed?.status).toBe(ITransactionStatus.Completed);
+    expect(completed?.displayMessage).toBe('Deposited to lending');
   });
 
   it('Guardian earn-deposit reuses persisted request bytes after a retry', async () => {
@@ -563,6 +574,119 @@ describe('generateTransaction — Guardian routing', () => {
     expect(mockCreateWasmWebClient).not.toHaveBeenCalled();
     expect(multisigService.createCustomProposal).not.toHaveBeenCalled();
     expect(txStore.find(row => row.id === txId)?.status).toBe(ITransactionStatus.Failed);
+  });
+
+  it('Guardian earn-deposit refuses to build a note when the allocator (secondaryAccountId) is missing', async () => {
+    const txId = 'earn-guardian-noalloc';
+    const transaction = Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: undefined, // no allocator to send the collateral to
+      faucetId: 'faucet',
+      noteType: 'public',
+      requestBytes: undefined,
+      extraInputs: { recallBlocks: 25 }, // recallBlocks present — only the allocator is missing
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      client: makeClientApi(makeResult())
+    });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // Same fail-fast as the missing-recallBlocks case — the other half of the guard.
+    expect(mockCreateWasmWebClient).not.toHaveBeenCalled();
+    expect(multisigService.createCustomProposal).not.toHaveBeenCalled();
+    expect(txStore.find(row => row.id === txId)?.status).toBe(ITransactionStatus.Failed);
+  });
+
+  it('Guardian earn-deposit: a still-pending 409 requeues AND drops the frozen requestBytes so the next cycle rebuilds a fresh reclaim height', async () => {
+    // An earn-deposit builds requestBytes (with an absolute reclaim height) BEFORE the
+    // custom proposal. If the proposal keeps hitting a transient pending-delta 409, the
+    // row is requeued — but the frozen bytes must be dropped, or a delayed re-submit
+    // would land a collateral note whose remaining reclaim window is below the Epoch
+    // allocator's minimum (stranding the collateral). Assert the drop.
+    jest.useFakeTimers();
+    try {
+      const txId = 'earn-pending-conflict';
+      const requestBytes = new Uint8Array([21, 22, 23]);
+      txStore.push({
+        id: txId,
+        type: 'earn-deposit',
+        accountId: 'guardian-acc',
+        status: ITransactionStatus.Queued,
+        secondaryAccountId: 'allocator',
+        faucetId: 'faucet',
+        amount: 1000n,
+        noteType: 'public',
+        extraInputs: { recallBlocks: 25 },
+        delegateTransaction: true,
+        initiatedAt: Math.floor(Date.now() / 1000)
+      });
+
+      const newSendTransactionRequest = jest.fn(async () => ({ serialize: () => requestBytes }));
+      mockCreateWasmWebClient.mockResolvedValue({ newSendTransactionRequest, terminate: jest.fn() });
+
+      const conflict = { status: 409, body: 'ConflictPendingDelta' };
+      const multisigService = {
+        createCustomProposal: jest.fn(async () => {
+          throw conflict;
+        }),
+        createSendProposal: jest.fn(),
+        signAndCreateTransactionRequest: jest.fn(),
+        sync: jest.fn(async () => {})
+      };
+      mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+      const client = Object.assign(makeClientApi(makeResult()), {
+        getSyncHeight: jest.fn(async () => 100)
+      });
+      mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
+
+      const pending = generateTransaction(
+        Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+          id: txId,
+          type: 'earn-deposit',
+          amount: 1000n,
+          secondaryAccountId: 'allocator',
+          faucetId: 'faucet',
+          noteType: 'public',
+          extraInputs: { recallBlocks: 25 },
+          delegateTransaction: true
+        }),
+        jest.fn(async () => new Uint8Array([2])),
+        false,
+        makeGuardianProvider(true)
+      );
+      // Fast-forward withGuardianConflictRetry's backoff so the retry budget exhausts.
+      await jest.runAllTimersAsync();
+      await pending;
+
+      const row = txStore.find(r => r.id === txId) as Record<string, unknown>;
+      // Requeued (transient lock), not terminally Failed...
+      expect(row.status).toBe(ITransactionStatus.Queued);
+      // ...and the frozen absolute-height request was dropped so the next cycle rebuilds
+      // the note against a fresh sync height (send/swap keep theirs; earn must not).
+      expect(row.requestBytes).toBeUndefined();
+      expect(multisigService.signAndCreateTransactionRequest).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('Guardian recallable send reuses persisted request bytes after a retry', async () => {

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -415,6 +415,156 @@ describe('generateTransaction — Guardian routing', () => {
     }
   );
 
+  it('Guardian earn-deposit builds a P2IDE collateral note to the allocator via a custom proposal', async () => {
+    const txId = 'earn-guardian';
+    const result = makeResult();
+    const requestBytes = new Uint8Array([11, 12, 13]);
+    const transaction = Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: 'allocator',
+      faucetId: 'faucet',
+      noteType: 'public',
+      requestBytes: undefined,
+      extraInputs: { recallBlocks: 25 },
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const newSendTransactionRequest = jest.fn(async () => ({ serialize: () => requestBytes }));
+    const terminate = jest.fn();
+    mockCreateWasmWebClient.mockResolvedValue({ newSendTransactionRequest, terminate });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(async () => ({ id: 'earn-proposal' })),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(async () => ({
+        serialize: () => new Uint8Array([1]),
+        authArg: () => undefined
+      })),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+
+    const client = Object.assign(makeClientApi(result), {
+      getSyncHeight: jest.fn(async () => 100)
+    });
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      client
+    });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // P2IDE collateral note to the allocator with an absolute reclaim height
+    // (syncHeight 100 + recallBlocks 25 = 125), proposed as a custom proposal —
+    // never a plain P2ID send proposal.
+    expect(newSendTransactionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ toString: expect.any(Function) }),
+      expect.objectContaining({ toString: expect.any(Function) }),
+      expect.objectContaining({ toString: expect.any(Function) }),
+      'Public',
+      1000n,
+      125,
+      null
+    );
+    expect(terminate).toHaveBeenCalledTimes(1);
+    expect(multisigService.createCustomProposal).toHaveBeenCalledWith(requestBytes, 'earn_deposit');
+    expect(multisigService.createSendProposal).not.toHaveBeenCalled();
+    expect(multisigService.signAndCreateTransactionRequest).toHaveBeenCalledWith('earn-proposal', requestBytes);
+    expect(txStore.find(row => row.id === txId)?.requestBytes).toBe(requestBytes);
+  });
+
+  it('Guardian earn-deposit reuses persisted request bytes after a retry', async () => {
+    const txId = 'earn-guardian-retry';
+    const result = makeResult();
+    const requestBytes = new Uint8Array([7, 8, 9]);
+    const transaction = Object.assign(new Transaction('guardian-acc', requestBytes), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: 'allocator',
+      faucetId: 'faucet',
+      noteType: 'public',
+      extraInputs: { recallBlocks: 25 },
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(async () => ({ id: 'earn-retry-proposal' })),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(async () => ({
+        serialize: () => new Uint8Array([1]),
+        authArg: () => undefined
+      })),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      client: makeClientApi(result)
+    });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // Persisted bytes are reused verbatim — no fresh P2IDE request is built.
+    expect(mockCreateWasmWebClient).not.toHaveBeenCalled();
+    expect(multisigService.createCustomProposal).toHaveBeenCalledWith(requestBytes, 'earn_deposit');
+    expect(multisigService.signAndCreateTransactionRequest).toHaveBeenCalledWith('earn-retry-proposal', requestBytes);
+  });
+
+  it('Guardian earn-deposit refuses to build a non-recallable note when recallBlocks is missing', async () => {
+    const txId = 'earn-guardian-norecall';
+    const transaction = Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: 'allocator',
+      faucetId: 'faucet',
+      noteType: 'public',
+      requestBytes: undefined,
+      extraInputs: {}, // no recallBlocks — a P2ID note would lock the collateral with no reclaim path
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      client: makeClientApi(makeResult())
+    });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // The row fails fast; no P2IDE request or proposal is built.
+    expect(mockCreateWasmWebClient).not.toHaveBeenCalled();
+    expect(multisigService.createCustomProposal).not.toHaveBeenCalled();
+    expect(txStore.find(row => row.id === txId)?.status).toBe(ITransactionStatus.Failed);
+  });
+
   it('Guardian recallable send reuses persisted request bytes after a retry', async () => {
     const txId = 'recallable-retry';
     const result = makeResult();

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -896,9 +896,7 @@ describe('generateTransaction — Guardian routing', () => {
     };
     mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
 
-    const canonErr = new Error(
-      'Refusing to overwrite local state: incoming nonce 5 is not greater than local nonce 7'
-    );
+    const canonErr = new Error('Refusing to overwrite local state: incoming nonce 5 is not greater than local nonce 7');
     const client = Object.assign(
       makeClientApi(
         makeResult(),

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -450,7 +450,7 @@ describe('generateTransaction — Guardian routing', () => {
     mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
 
     const client = Object.assign(makeClientApi(result), {
-      getSyncHeight: jest.fn(async () => 100)
+      sync: jest.fn(async () => ({ blockNum: () => 100 }))
     });
     mockGetMidenClient.mockResolvedValue({
       syncState: jest.fn(async () => {}),
@@ -616,6 +616,50 @@ describe('generateTransaction — Guardian routing', () => {
     expect(txStore.find(row => row.id === txId)?.status).toBe(ITransactionStatus.Failed);
   });
 
+  it('Guardian earn-deposit: refuses to submit once the caller abandoned the deposit (epochStatus=failed)', async () => {
+    // openEarnPosition marks epochStatus 'failed' when it gives up (its 5-min wait timed
+    // out / the Epoch intent was aborted). A guardian requeue can outlive that wait, so
+    // the loop must NOT then build+submit an orphan collateral note (no live intent) —
+    // it fails the row instead.
+    const txId = 'earn-guardian-abandoned';
+    const transaction = Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: 'allocator',
+      faucetId: 'faucet',
+      noteType: 'public',
+      requestBytes: undefined,
+      extraInputs: { recallBlocks: 25, epochStatus: 'failed' },
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+    mockGetMidenClient.mockResolvedValue({
+      syncState: jest.fn(async () => {}),
+      client: makeClientApi(makeResult())
+    });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // No note built or proposed; the row is Failed (terminal), never Completed.
+    expect(mockCreateWasmWebClient).not.toHaveBeenCalled();
+    expect(multisigService.createCustomProposal).not.toHaveBeenCalled();
+    expect(txStore.find(row => row.id === txId)?.status).toBe(ITransactionStatus.Failed);
+  });
+
   it('Guardian earn-deposit: a still-pending 409 requeues AND drops the frozen requestBytes so the next cycle rebuilds a fresh reclaim height', async () => {
     // An earn-deposit builds requestBytes (with an absolute reclaim height) BEFORE the
     // custom proposal. If the proposal keeps hitting a transient pending-delta 409, the
@@ -654,7 +698,7 @@ describe('generateTransaction — Guardian routing', () => {
       };
       mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
       const client = Object.assign(makeClientApi(makeResult()), {
-        getSyncHeight: jest.fn(async () => 100)
+        sync: jest.fn(async () => ({ blockNum: () => 100 }))
       });
       mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
 
@@ -735,7 +779,7 @@ describe('generateTransaction — Guardian routing', () => {
           throw applyErr;
         })
       ),
-      { getSyncHeight: jest.fn(async () => 100) }
+      { sync: jest.fn(async () => ({ blockNum: () => 100 })) }
     );
     mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
 
@@ -795,7 +839,7 @@ describe('generateTransaction — Guardian routing', () => {
           throw canonErr;
         })
       ),
-      { getSyncHeight: jest.fn(async () => 100) }
+      { sync: jest.fn(async () => ({ blockNum: () => 100 })) }
     );
     mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
 

--- a/src/lib/miden/transaction/transactions.guardian.test.ts
+++ b/src/lib/miden/transaction/transactions.guardian.test.ts
@@ -492,6 +492,68 @@ describe('generateTransaction — Guardian routing', () => {
     expect(completed?.displayMessage).toBe('Deposited to lending');
   });
 
+  it('Guardian earn-deposit: falls back to the last-synced height when the fresh sync fails', async () => {
+    // A transient network sync failure must NOT fail an otherwise-submittable deposit —
+    // the note build falls back to the cached getSyncHeight() (the recall buffer absorbs
+    // mild lag), keeping the guardian path no more network-fragile than before.
+    const txId = 'earn-guardian-syncfail';
+    const requestBytes = new Uint8Array([51, 52, 53]);
+    const transaction = Object.assign(new Transaction('guardian-acc', new Uint8Array()), {
+      id: txId,
+      type: 'earn-deposit',
+      amount: 1000n,
+      secondaryAccountId: 'allocator',
+      faucetId: 'faucet',
+      noteType: 'public',
+      requestBytes: undefined,
+      extraInputs: { recallBlocks: 25 },
+      delegateTransaction: true
+    });
+    txStore.push({ ...transaction, status: ITransactionStatus.Queued });
+
+    const newSendTransactionRequest = jest.fn(async () => ({ serialize: () => requestBytes }));
+    mockCreateWasmWebClient.mockResolvedValue({ newSendTransactionRequest, terminate: jest.fn() });
+
+    const multisigService = {
+      createCustomProposal: jest.fn(async () => ({ id: 'earn-syncfail-proposal' })),
+      createSendProposal: jest.fn(),
+      signAndCreateTransactionRequest: jest.fn(async () => ({
+        serialize: () => new Uint8Array([1]),
+        authArg: () => undefined
+      })),
+      sync: jest.fn(async () => {})
+    };
+    mockGetOrCreateMultisigService.mockResolvedValue(multisigService);
+
+    // Fresh sync throws; getSyncHeight (the fallback) returns 200.
+    const client = Object.assign(makeClientApi(makeResult()), {
+      sync: jest.fn(async () => {
+        throw new Error('sync timed out');
+      }),
+      getSyncHeight: jest.fn(async () => 200)
+    });
+    mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
+
+    await generateTransaction(
+      transaction,
+      jest.fn(async () => new Uint8Array([2])),
+      false,
+      makeGuardianProvider(true)
+    );
+
+    // Built with the fallback height (200 + 25 = 225) and proceeded to a custom proposal.
+    expect(newSendTransactionRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ toString: expect.any(Function) }),
+      expect.objectContaining({ toString: expect.any(Function) }),
+      expect.objectContaining({ toString: expect.any(Function) }),
+      'Public',
+      1000n,
+      225,
+      null
+    );
+    expect(multisigService.createCustomProposal).toHaveBeenCalledWith(requestBytes, 'earn_deposit');
+  });
+
   it('Guardian earn-deposit reuses persisted request bytes after a retry', async () => {
     const txId = 'earn-guardian-retry';
     const result = makeResult();
@@ -772,15 +834,12 @@ describe('generateTransaction — Guardian routing', () => {
     // Submit lands on-chain but the LOCAL apply throws ApplyTransactionAfterSubmitFailed.
     const applyErr: Error & { errorCode?: string } = new Error('apply failed');
     applyErr.errorCode = 'ApplyTransactionAfterSubmitFailed';
-    const client = Object.assign(
-      makeClientApi(
-        makeResult(),
-        jest.fn(async () => {
-          throw applyErr;
-        })
-      ),
-      { sync: jest.fn(async () => ({ blockNum: () => 100 })) }
-    );
+    const applyFn = jest.fn(async () => {
+      throw applyErr;
+    });
+    const client = Object.assign(makeClientApi(makeResult(), applyFn), {
+      sync: jest.fn(async () => ({ blockNum: () => 100 }))
+    });
     mockGetMidenClient.mockResolvedValue({ syncState: jest.fn(async () => {}), client });
 
     await generateTransaction(
@@ -790,9 +849,17 @@ describe('generateTransaction — Guardian routing', () => {
       makeGuardianProvider(true)
     );
 
-    // Failed, NOT Completed — a Completed row without resultBytes hangs the caller.
+    // The failure is specifically POST-submit — the proposal was signed and the tx
+    // submitted (apply runs only after submit lands), so the generic value-moving path
+    // would have marked it Completed. This pins the earn-deposit exception to the guard,
+    // distinguishing it from both a pre-submit early throw and the Completed fallback.
+    expect(multisigService.signAndCreateTransactionRequest).toHaveBeenCalled();
+    expect(applyFn).toHaveBeenCalled();
     const row = txStore.find(r => r.id === txId);
     expect(row?.status).toBe(ITransactionStatus.Failed);
+    // Never a Completed-branch success message.
+    expect(row?.displayMessage).not.toBe('Deposited to lending');
+    expect(row?.displayMessage).not.toBe('Sent');
   });
 
   it('Guardian earn-deposit: a canonicalization race after submit also marks the row Failed (not Completed)', async () => {

--- a/src/screens/earn-flow/EarnDepositReview.test.tsx
+++ b/src/screens/earn-flow/EarnDepositReview.test.tsx
@@ -194,16 +194,19 @@ describe('EarnDepositReview', () => {
   });
 
   describe('open position CTA', () => {
-    it('disables the CTA and explains why on a Guardian account', () => {
+    // Guardian accounts are supported: the collateral note is built as a
+    // recallable P2IDE custom proposal in `generateTransaction`, so the CTA is
+    // never gated on account type. This fails if the old guardian block returns.
+    it('lets a Guardian account open a position', async () => {
       mockAccount.type = 'guardian';
       renderReview('aave-usdc-ethereum-1', '?amount=1000');
 
       const cta = screen.getByTestId('open-position-btn');
-      expect(cta).toBeDisabled();
-      expect(screen.getByText('earnDepositGuardianUnsupported')).toBeInTheDocument();
+      expect(cta).toBeEnabled();
+      expect(screen.queryByText('earnDepositGuardianUnsupported')).not.toBeInTheDocument();
 
       fireEvent.click(cta);
-      expect(mockOpenEarnPosition).not.toHaveBeenCalled();
+      await waitFor(() => expect(mockOpenEarnPosition).toHaveBeenCalledTimes(1));
     });
 
     it('fires haptics and opens the Epoch position with the scaled amount + account owner', async () => {

--- a/src/screens/earn-flow/EarnDepositReview.tsx
+++ b/src/screens/earn-flow/EarnDepositReview.tsx
@@ -15,7 +15,6 @@ import { hapticLight } from 'lib/mobile/haptics';
 import { isMobile } from 'lib/platform';
 import { ChartContainer } from 'lib/ui/charts';
 import { navigate, useLocation } from 'lib/woozie';
-import { WalletType } from 'screens/onboarding/types';
 
 import { EarnFlowHeader } from './components';
 import { placeholderVault } from './earn-mapping';
@@ -51,14 +50,9 @@ const EarnDepositReview: FC<EarnDepositReviewProps> = ({ vaultId }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  // Earn deposits need a P2IDE collateral note with a reclaim height; Guardian
-  // proposals can only express a plain P2ID (see GUARDIAN_EARN_DEPOSIT_UNSUPPORTED).
-  // `openEarnPosition` refuses these too — this just avoids a dead-end CTA.
-  const isGuardian = account.type === WalletType.Guardian;
-
   const handleOpenPosition = async () => {
     hapticLight();
-    if (isSubmitting || isGuardian) return;
+    if (isSubmitting) return;
     if (!account.evmAddress) {
       setSubmitError(t('earnNoEvmAddress'));
       return;
@@ -100,11 +94,6 @@ const EarnDepositReview: FC<EarnDepositReviewProps> = ({ vaultId }) => {
       </div>
 
       <div className={clsx('shrink-0 pt-4 pb-6', isMobile() ? 'px-8' : 'px-6')}>
-        {isGuardian && (
-          <div className="mb-2 text-center text-sm leading-tight text-status-negative">
-            {t('earnDepositGuardianUnsupported')}
-          </div>
-        )}
         {submitError && (
           <div className="mb-2 text-center text-sm leading-tight text-status-negative">{submitError}</div>
         )}
@@ -113,7 +102,7 @@ const EarnDepositReview: FC<EarnDepositReviewProps> = ({ vaultId }) => {
           title={t('earnOpenPosition')}
           variant={ButtonVariant.Primary}
           onClick={handleOpenPosition}
-          disabled={isSubmitting || amountValue <= 0 || !vault.id || isGuardian}
+          disabled={isSubmitting || amountValue <= 0 || !vault.id}
           className="w-full max-w-none rounded-full text-base font-semibold"
         />
       </div>

--- a/src/screens/earn-flow/EarnVaultDetail.test.tsx
+++ b/src/screens/earn-flow/EarnVaultDetail.test.tsx
@@ -19,20 +19,11 @@ import EarnVaultDetail from './EarnVaultDetail';
 // props via data-* attributes so we can assert what `EarnVaultDetail` passed
 // (label / value / valueClassName), which is where the audited-branch styling
 // lives.
-// --- Wallet context: the screen reads the account only to disable the Deposit
-//     CTA on Guardian accounts (earn deposits need a P2IDE collateral note that
-//     Guardian proposals can't express). Mutated per-test to flip that branch.
-const mockAccount: { publicKey: string; type?: string } = { publicKey: 'mm1testaccount' };
-
 // i18n: the component and the shared Button/CircleButton call `useTranslation`.
 // Stub it so `t(key)` echoes the key, letting us assert on stable keys instead
 // of translated English.
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
-}));
-
-jest.mock('lib/miden/front', () => ({
-  useAccount: () => mockAccount
 }));
 
 jest.mock('./components', () => ({
@@ -176,26 +167,15 @@ const metricValue = (label: string) => {
 describe('EarnVaultDetail', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockAccount.type = undefined;
   });
 
-  it('disables the Deposit CTA and explains why on a Guardian account', () => {
-    mockAccount.type = 'guardian';
-    render(<EarnVaultDetail vaultId="v-audited" />);
-
-    const deposit = screen.getByRole('button', { name: 'earnDeposit' });
-    expect(deposit).toBeDisabled();
-    expect(screen.getByText('earnDepositGuardianUnsupported')).toBeInTheDocument();
-
-    fireEvent.click(deposit);
-    expect(navigate).not.toHaveBeenCalled();
-  });
-
-  it('leaves the Deposit CTA enabled (and unexplained) on a standard account', () => {
+  // Guardian accounts are supported: earn deposits are built as a recallable
+  // P2IDE custom proposal in `generateTransaction`, so the CTA is never gated on
+  // account type — it only disables while the vault id is still loading.
+  it('leaves the Deposit CTA enabled once the vault has loaded', () => {
     render(<EarnVaultDetail vaultId="v-audited" />);
 
     expect(screen.getByRole('button', { name: 'earnDeposit' })).not.toBeDisabled();
-    expect(screen.queryByText('earnDepositGuardianUnsupported')).not.toBeInTheDocument();
   });
 
   it('renders the audited vault: header, APY block, stats, about and chart', () => {

--- a/src/screens/earn-flow/EarnVaultDetail.tsx
+++ b/src/screens/earn-flow/EarnVaultDetail.tsx
@@ -7,11 +7,9 @@ import { Area, AreaChart, Tooltip, YAxis } from 'recharts';
 import { IconName } from 'app/icons/v2';
 import { Button, ButtonVariant } from 'components/Button';
 import { CircleButton } from 'components/CircleButton';
-import { useAccount } from 'lib/miden/front';
 import { hapticSelection } from 'lib/mobile/haptics';
 import { ChartContainer } from 'lib/ui/charts';
 import { goBack, navigate } from 'lib/woozie';
-import { WalletType } from 'screens/onboarding/types';
 
 import { MetricCard } from './components';
 import { placeholderVault } from './earn-mapping';
@@ -30,11 +28,6 @@ const EarnVaultDetail: FC<EarnVaultDetailProps> = ({ vaultId }) => {
   const { t } = useTranslation();
   const { vaults } = useEarnPositions();
   const vault = useMemo(() => vaults.find(item => item.id === vaultId) ?? placeholderVault(), [vaults, vaultId]);
-
-  // Earn deposits need a P2IDE collateral note with a reclaim height; Guardian
-  // proposals can only express a plain P2ID (see GUARDIAN_EARN_DEPOSIT_UNSUPPORTED).
-  const account = useAccount();
-  const isGuardian = account.type === WalletType.Guardian;
 
   return (
     <div className="flex h-full flex-col overflow-hidden bg-app-bg font-inter" data-testid="earn-vault-detail-page">
@@ -96,16 +89,11 @@ const EarnVaultDetail: FC<EarnVaultDetailProps> = ({ vaultId }) => {
           <VaultAbout vault={vault} />
 
           <div className="mt-auto pt-16">
-            {isGuardian && (
-              <div className="mb-3 text-center text-sm leading-tight text-status-negative">
-                {t('earnDepositGuardianUnsupported')}
-              </div>
-            )}
             <Button
               data-testid="earn-vault-deposit-btn"
               title={t('earnDeposit')}
               variant={ButtonVariant.Primary}
-              disabled={!vault.id || isGuardian}
+              disabled={!vault.id}
               onClick={() => navigate(`/earn/vaults/${vaultId}/deposit`)}
               className="h-14 max-w-none rounded-full text-lg font-bold"
             />


### PR DESCRIPTION
## What

Enables Earn (Epoch lending) deposits on **Guardian** (multisig) accounts. Previously the Deposit CTA was disabled with _"Earn deposits aren't available on Guardian accounts yet."_

## Why it was blocked

An Earn collateral note must be a recallable **P2IDE** — it carries a reclaim height that the Epoch allocator validates and that is the user's only escape hatch if the lending leg never settles. The multisig client's send proposal is **P2ID-only**, so the collateral couldn't be expressed on a Guardian account. This is the same limitation that was solved for Guardian *sends* in v1.15.17.

## How

Reuses the v1.15.17 mechanism instead of leaving the feature blocked:

- The Guardian `earn-deposit` branch of `generateTransaction` builds a P2IDE `newSendTransactionRequest` to the Epoch allocator (relative `recallBlocks` → absolute `syncHeight + recallBlocks`, the same relative→absolute conversion the non-Guardian path uses) and proposes it via `createCustomProposal(bytes, 'earn_deposit')`. The request bytes are persisted on the row so a retry after a process restart reuses identical bytes (same rule as send/swap).
- **Completion fix:** the Guardian completion switch now routes `earn-deposit` to `completeEarnDepositTransaction` (extracts the committed collateral note id that `createEarnP2IDNote` hands back to the Epoch SDK). Without this it would have fallen through to the generic custom-tx completion and stranded the deposit.
- Removed the old guard (`GUARDIAN_EARN_DEPOSIT_UNSUPPORTED`), both UI gates (`EarnVaultDetail` / `EarnDepositReview`), the now-dead i18n key, and unused imports.

## Testing

- `yarn test` — full suite (6754 tests) green. Coverage gate clears all four metrics (branches 95.13%, functions 95.09%, lines/statements 95.42%). New tests in `transactions.guardian.test.ts` cover the build-to-allocator, retry-reuse, and missing-`recallBlocks` fail-fast paths; `earn.test.ts` and both earn screen tests updated for the now-enabled path.
- `yarn lint`, `yarn lint:i18n`, `tsc --noEmit` — clean.
- **On-device (iPad, real Guardian account, testnet):** deposited 5 USDC end-to-end. Collateral built as a Miden P2IDE, Guardian co-signed and submitted on-chain (txid `0x17a9999bebf8b6b9c73d696571361d2a04a20c875edb367b6a70cb69d851798c`), completion marked "Deposited to lending", the Epoch allocator confirmed (`epochStatus: confirmed`), and the position rendered in the Earn UI (Total Deposited $0 → $4.96).
