### PR TITLE
docs: link the E2E architecture doc from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ if (isDesktop()) {
 
 ## Testing
 
+> 📐 **How the E2E harness works** — for a high-level tour of the end-to-end test lab (what each suite proves, which components are real vs. stand-ins, and how the local Ethereum is set up), see **[Inside the Miden Wallet Test Lab](playwright/e2e/docs/e2e-architecture.md)**.
+
 ```bash
 # Unit tests
 yarn test


### PR DESCRIPTION
Adds a link from the README's Testing section to the E2E harness architecture doc (`playwright/e2e/docs/e2e-architecture.md`, merged in #441/#442) so it's discoverable. Docs-only, one line.