### PR TITLE
test(e2e): deterministic guardian browser-crash recovery test + harden reopen() cold-SW readiness

### DIFF
--- a/playwright/e2e/helpers/wallet-page.ts
+++ b/playwright/e2e/helpers/wallet-page.ts
@@ -261,8 +261,16 @@ export interface ChromeWalletPageApi extends WalletPage, IdbDumpSource {
    * password if needed. Used to prove state that must be durably persisted
    * (e.g. a switched guardian endpoint) survives a fresh session, not just
    * the one that made the change.
+   *
+   * Returns whether it took the crash-recovery RELAUNCH path -- i.e. the browser
+   * was dead, so the whole persistent context was relaunched from the on-disk
+   * profile with a cold SW -- vs a normal warm page swap. A spec that used
+   * `killBrowser()` can assert the return is `true` to prove the crash path
+   * actually ran (guarding against e.g. a Playwright change that made
+   * `killBrowser()` a no-op, which would otherwise pass silently on the fast
+   * path).
    */
-  reopen(): Promise<void>;
+  reopen(): Promise<boolean>;
   /**
    * Terminate the wallet mid-flight: closes the current page and, unlike
    * `reopen()`, does NOT open a fresh one -- models a user closing the
@@ -278,6 +286,26 @@ export interface ChromeWalletPageApi extends WalletPage, IdbDumpSource {
    * closed page in the meantime.
    */
   kill(): Promise<void>;
+  /**
+   * Like `kill()`, but tears down the ENTIRE browser (its persistent context
+   * AND the service worker), not just the page -- simulating the wallet's whole
+   * Chromium process crashing mid-flight, which the CI runner does
+   * intermittently in these specs. The follow-up `reopen()` detects the dead
+   * browser and recovers by relaunching the context on the same on-disk profile,
+   * so the wallet is restored from its persisted IndexedDB state and comes back
+   * USABLE (the SW's in-memory vault key is gone, so it comes back locked and
+   * `reopen()` unlocks it). Use this over `kill()` when a spec must
+   * DETERMINISTICALLY exercise that crash-recovery relaunch path rather than rely
+   * on an incidental (~coin-flip) crash. Callers must follow up with `reopen()`.
+   *
+   * NOTE: this does NOT auto-resume an in-flight transaction. Production's
+   * cold-start handler (`runtime.onStartup` -> `failInterruptedTransactions`)
+   * deliberately FAILS interrupted rows and requires a manual Retry, and the
+   * unpacked test extension never fires `runtime.onStartup` on relaunch anyway
+   * -- so a spec must not assert that a transaction interrupted by killBrowser()
+   * resumes (see guardian-recovery-stress.spec.ts's browser-crash describe).
+   */
+  killBrowser(): Promise<void>;
   /**
    * Poll for a transaction row of `transactionType` (`ITransaction.stage` in
    * `src/lib/miden/db/types.ts`) to reach `stage` while its status is still
@@ -960,7 +988,7 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
     });
   }
 
-  async reopen(): Promise<void> {
+  async reopen(): Promise<boolean> {
     // Deliberately does NOT use chrome.runtime.reload(): that reloads the
     // whole extension bundle (tearing down and respawning the service
     // worker), and MV3 invalidates every currently-open extension page as
@@ -985,6 +1013,12 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
     if (!this.page.isClosed()) {
       await this.page.close();
     }
+
+    // Set when openFreshPage takes the crash-recovery relaunch path below. The
+    // relaunched context has a genuinely COLD service worker (it must re-load the
+    // ~14MB WASM before intercom answers), so the readiness wait needs the same
+    // reload-retry budget as the initial launch rather than a single window.
+    let relaunched = false;
 
     // context.newPage() can transiently fail on a resource-constrained CI runner
     // with a Chromium protocol error ("Target.createTarget: Failed to open a new
@@ -1011,6 +1045,7 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
           // already-onboarded wallet exactly as for a normal page swap.
           if (context.browser()?.isConnected() === false) {
             if (this.relaunch) {
+              relaunched = true;
               return await this.relaunch();
             }
             throw new Error(
@@ -1026,22 +1061,40 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
     };
     const freshPage = await openFreshPage();
     this.currentPage = freshPage;
-    await this.page.goto(this.fullpageUrl, { waitUntil: 'domcontentloaded' });
 
     const explore = this.page.getByTestId('explore-page');
     const unlock = this.page.getByTestId('unlock-password');
 
-    // The SW is still alive across this swap, so the wallet is normally
-    // still unlocked -- but give this the same headroom as a cold start in
-    // case the SW happens to be busy (e.g. mid re-sync) when the fresh page
-    // reconnects over intercom.
-    await explore.or(unlock).first().waitFor({ timeout: 90_000 });
+    // Wait for the reopened, already-onboarded wallet to settle on either the
+    // Explore surface (normal case, still unlocked) or the unlock screen.
+    //
+    // On a normal page swap the service worker stays warm, so ONE 90s window is
+    // ample. On the crash-recovery relaunch path the SW is COLD and must re-load
+    // the ~14MB WASM before intercom answers -- which can outlast a single window
+    // under CI load. So mirror the initial launch (launchWalletInstance): give
+    // the relaunch case up to 3 windows, re-navigating between them so a cold
+    // init that misses one window gets a fresh retry instead of failing reopen().
+    const readinessAttempts = relaunched ? 3 : 1;
+    for (let attempt = 1; attempt <= readinessAttempts; attempt++) {
+      await this.page.goto(this.fullpageUrl, { waitUntil: 'domcontentloaded' });
+      try {
+        await explore.or(unlock).first().waitFor({ timeout: 90_000 });
+        break;
+      } catch (err) {
+        if (attempt === readinessAttempts) throw err;
+        // Cold SW still parsing WASM -- let React mount what it can, then the
+        // next iteration re-navigates for a fresh intercom retry window.
+        await this.page.waitForSelector('#root > *', { timeout: 15_000 }).catch(() => {});
+      }
+    }
 
     if (await unlock.isVisible().catch(() => false)) {
       await this.unlockWallet();
     } else {
       await explore.waitFor({ timeout: 15_000 });
     }
+
+    return relaunched;
   }
 
   async kill(): Promise<void> {
@@ -1052,6 +1105,19 @@ export class ChromeWalletPage implements ChromeWalletPageApi {
     // teardown (e.g. from a crash) throwing here shouldn't fail the "kill"
     // step, only the "did the wallet recover" step that follows it.
     await this.page.close().catch(() => {});
+  }
+
+  async killBrowser(): Promise<void> {
+    // Tear down the ENTIRE browser (persistent context + service worker), not
+    // just the page -- a DETERMINISTIC stand-in for the intermittent Chromium
+    // process crash the CI runner produces mid-rotation. `context.browser()` is
+    // the Browser backing this wallet's persistent context; closing it drops the
+    // context too, so the following reopen() sees
+    // `context.browser()?.isConnected() === false` and takes its crash-recovery
+    // path (relaunch from the on-disk profile). Swallow errors: the browser may
+    // already be gone (e.g. it genuinely crashed first).
+    const browser = this.page.context().browser();
+    await browser?.close().catch(() => {});
   }
 
   async waitForStage(

--- a/playwright/e2e/tests/guardian-recovery-stress.spec.ts
+++ b/playwright/e2e/tests/guardian-recovery-stress.spec.ts
@@ -535,3 +535,88 @@ test.describe('Guardian recovery stress - pending-delta conflict during rotation
     );
   });
 });
+
+/**
+ * killBrowser() harness capability + reopen()'s crash-recovery relaunch,
+ * verified DETERMINISTICALLY. Where an incidental Chromium crash mid-test is a
+ * coin flip, killBrowser() tears the whole browser down (persistent context AND
+ * service worker) every run, so reopen()'s relaunch path -- and in particular
+ * its COLD-service-worker readiness wait (the relaunched SW must re-load the
+ * ~14MB WASM) -- is exercised on every run. No other spec covers that path
+ * deterministically.
+ *
+ * SCOPE, deliberately narrow: this asserts only the HARNESS-level guarantee --
+ * after the wallet's entire browser dies, reopen() brings it back USABLE with
+ * its account intact (read from the on-disk IndexedDB profile). It does NOT
+ * assert that an in-flight transaction RESUMES, because neither the product nor
+ * the harness makes that a sound claim:
+ *   - Production's cold-start handler (`runtime.onStartup` ->
+ *     `failInterruptedTransactions`, src/background.ts / transaction/cancel.ts)
+ *     deliberately FAILS every in-flight row and requires a manual Retry -- it
+ *     does NOT auto-resume (a resubmit could trip the node's nullifier check).
+ *   - The unpacked test extension never fires `runtime.onStartup` on a relaunch
+ *     anyway (Chrome treats `--load-extension` as a fresh install each launch,
+ *     firing `runtime.onInstalled` instead), so the harness cannot reproduce
+ *     that production behaviour here.
+ * A faithful "crash mid-rotation -> rotation Failed -> Retry completes" test is
+ * a documented follow-up (it needs a test-gated hook to fire the onStartup
+ * sweep). This test stays honest about what it can prove.
+ */
+test.describe('Guardian recovery stress - wallet survives a full browser crash', () => {
+  test('killBrowser() then reopen() relaunches from the on-disk profile to a usable wallet, account intact', async ({
+    walletA,
+    steps
+  }) => {
+    // Create + whole-browser relaunch + cold-SW re-init; no rotation/proof here,
+    // so 300s is ample.
+    test.setTimeout(300_000);
+
+    let address = '';
+
+    await steps.step(
+      'create_guardian_wallet_on_a',
+      async () => {
+        const created = await walletA.createGuardianWallet(A);
+        address = created.address;
+      },
+      { screenshotWallets: [{ target: walletA.page, label: 'A' }] }
+    );
+
+    // Kill the WHOLE browser (context + SW), not just the page -- the
+    // deterministic stand-in for the intermittent Chromium crash. NOT wrapped in
+    // a step: the post-step screenshot would target the page killBrowser() just
+    // destroyed.
+    await walletA.killBrowser();
+
+    await steps.step(
+      'reopen_relaunches_to_usable_wallet',
+      async () => {
+        // reopen() finds the browser dead (context.browser() disconnected) and
+        // relaunches the persistent context on the same userDataDir; its cold-SW
+        // readiness wait must bring the wallet back to a usable surface (Explore,
+        // or unlock -> unlocked).
+        const relaunched = await walletA.reopen();
+        // Tripwire: prove killBrowser() actually killed the browser so reopen()
+        // took the crash-recovery RELAUNCH path, not the warm fast path. Without
+        // this, a killBrowser() that regressed to a no-op (e.g. a Playwright
+        // change making context.browser() null for persistent contexts) would
+        // leave the wallet warm and this test would still pass while covering
+        // none of the relaunch / cold-SW readiness code it exists to exercise.
+        expect(
+          relaunched,
+          'killBrowser() must have forced reopen into its crash-recovery relaunch path -- if false, the browser ' +
+            'did not actually die and this test is covering nothing'
+        ).toBe(true);
+
+        // The account persisted on disk (IndexedDB) survives the whole-browser
+        // crash + relaunch -- same account id read back afterwards.
+        const addressAfter = await walletA.getAccountAddress();
+        expect(
+          addressAfter,
+          'the guardian account must survive a whole-browser crash + relaunch, read back from the on-disk profile'
+        ).toBe(address);
+      },
+      { screenshotWallets: [{ target: walletA.page, label: 'A' }] }
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #450 (the crash-resilient `reopen()` that recovers the guardian recovery specs from an intermittent, non-OOM Chromium crash by relaunching the persistent context from the on-disk profile). That fix shipped but its recovery path had never actually been exercised on CI — both green runs happened to not crash. This PR deterministically verifies it and hardens it.

## What this adds

- **`killBrowser()` harness method** — tears down the whole browser (persistent context + service worker), not just the page, as a **deterministic** stand-in for the intermittent Chromium crash (where an incidental one is a coin flip). Verified locally against `playwright-core@1.61.0`: `context.browser()` is non-null for a persistent context, `.close()` flips `isConnected()` to false, so `reopen()` genuinely takes its relaunch branch.
- **Harden `reopen()`'s post-relaunch readiness** — the relaunched context has a **cold** SW that must re-load the ~14MB WASM before intercom answers. The old readiness wait was a single 90s window; the initial launch budgets 3×90s *with reloads* for exactly this. `reopen()` now does the same **only on the relaunch path** (the fast warm-swap path is byte-for-byte unchanged). `reopen()` returns whether it relaunched.
- **One honest deterministic test** — `killBrowser()` → `reopen()` → assert the wallet recovers to a usable state with its account intact (read back from the on-disk IndexedDB profile), plus a **tripwire** asserting `reopen()` actually took the relaunch path (so the test can't silently stop covering the crash path).

## What it deliberately does NOT claim

An earlier draft of this test asserted the interrupted rotation **resumes to completion** after a crash. An adversarial review caught that this is the **opposite** of production behavior and confirmed it against `main`:

- Production's cold-start handler (`runtime.onStartup` → `failInterruptedTransactions`, `src/background.ts` / `transaction/cancel.ts`) deliberately **fails** every in-flight row and requires a manual **Retry** — resubmitting a tx that already landed on-chain would trip the node's nullifier check.
- The unpacked test extension (`--load-extension`) never fires `runtime.onStartup` on relaunch (Chrome fires `runtime.onInstalled` instead), so the harness can't reproduce that production path anyway.

So the test asserts only the harness-level guarantee (browser dies → wallet comes back usable), not transaction resume. Production's crash behavior is **fail + retry** — escapable, not stuck.

## Follow-up (not in this PR)

A faithful "crash mid-rotation → rotation Failed → Retry completes" test needs a `MIDEN_E2E_TEST`-gated hook to fire the `onStartup` sweep in the harness. Separately worth investigating: the on-chain-committed-but-guardian-not-registered window (does Retry/sync fully re-register the new hot key with the guardian, or can it 401 — a real "stuck guardian" risk on a security-sensitive path).

Harness-only change (`playwright/e2e/**`); no wallet source or user-facing behavior changes.
