### PR TITLE
fix(e2e): run guardian fault/stress specs against the live guardians, not just localhost

### DIFF
--- a/playwright/e2e/fixtures/two-wallets.ts
+++ b/playwright/e2e/fixtures/two-wallets.ts
@@ -7,7 +7,7 @@ import { getEnvironmentConfig } from '../config/environments';
 import { attachConsoleCapture } from '../harness/browser-capture';
 import { CLIRunner } from '../harness/cli-runner';
 import { buildFailureReport, saveFailureReport } from '../harness/failure-report';
-import { installGuardianFaults, type GuardianFaultPolicy } from '../harness/guardian-fault';
+import { installGuardianFaults, type GuardianFaultPolicy, type GuardianOrigins } from '../harness/guardian-fault';
 import {
   SW_FETCH_LOG_PREFIX,
   attachNetworkCapture,
@@ -45,6 +45,15 @@ type TwoWalletFixtures = {
 };
 
 // ── Constants ───────────────────────────────────────────────────────────────
+
+// The guardian operator origins fault injection keys on, for the active
+// E2E_NETWORK: local containers on localhost, the real operators on
+// devnet/testnet. Read at install time so faults match whichever guardians
+// the wallet actually talks to on this network.
+const guardianOrigins = (): GuardianOrigins => {
+  const cfg = getEnvironmentConfig();
+  return { a: cfg.guardianUrl, b: cfg.guardianUrlB };
+};
 
 const ROOT_DIR = path.resolve(__dirname, '../../..');
 const DEFAULT_EXTENSION_PATH = path.join(ROOT_DIR, 'dist', 'chrome_unpacked');
@@ -180,7 +189,7 @@ async function relaunchContext(userDataDir: string, extensionPath: string) {
   for (const p of context.pages()) {
     if (p !== page) await p.close().catch(() => {});
   }
-  const faults = installGuardianFaults(context);
+  const faults = installGuardianFaults(context, guardianOrigins());
   return { context, page, faults };
 }
 
@@ -390,7 +399,7 @@ async function launchWalletInstance(label: 'A' | 'B', extensionPath: string, tim
   // GuardianFaultPolicy the spec arms via the wallet page object below.
   // `let`: relaunch swaps in the new context's faults so armGuardianFault()/
   // clearFaults() (captured by reference below) keep targeting the live context.
-  let faults = installGuardianFaults(context);
+  let faults = installGuardianFaults(context, guardianOrigins());
 
   // Passed to ChromeWalletPage.reopen(): when the browser PROCESS has died (not
   // just the page), relaunch a fresh context on this same userDataDir and swap

--- a/playwright/e2e/harness/guardian-fault.ts
+++ b/playwright/e2e/harness/guardian-fault.ts
@@ -97,10 +97,35 @@ export interface GuardianRouteLike {
 
 const GUARDIAN_FAULT_PATHS: readonly GuardianFaultPath[] = ['pubkey', 'configure', 'delta'];
 
-/** Guardian A listens on :3000, guardian B on :3001 (see local-stack/docker-compose.local.yml). */
-export function targetOf(url: string): GuardianFaultTarget | null {
-  if (url.startsWith('http://localhost:3000/')) return 'A';
-  if (url.startsWith('http://localhost:3001/')) return 'B';
+/**
+ * The two guardian operator origins for the active environment. `a` is the
+ * wallet's own operator (`guardianUrl`); `b` is the distinct second operator
+ * used by the switch tests (`guardianUrlB`, absent on single-operator networks
+ * like devnet). On the localhost stack these are the two containers
+ * (:3000 / :3001); on devnet/testnet they are the real operator origins
+ * (e.g. guardian.openzeppelin.com / guardian-testnet.kodax.com). Fault
+ * matching is keyed on these so the specs exercise the real guardians on
+ * live networks, not just the local containers.
+ */
+export interface GuardianOrigins {
+  a: string;
+  b?: string;
+}
+
+/** The local guardian containers (see local-stack/docker-compose.local.yml). */
+export const LOCAL_GUARDIAN_ORIGINS: GuardianOrigins = {
+  a: 'http://localhost:3000',
+  b: 'http://localhost:3001'
+};
+
+const matchesOrigin = (url: string, origin: string): boolean =>
+  url.startsWith(origin.endsWith('/') ? origin : `${origin}/`);
+
+/** Which guardian operator a request targets, matched by origin against the
+ *  active environment's operators. */
+export function targetOf(url: string, origins: GuardianOrigins): GuardianFaultTarget | null {
+  if (matchesOrigin(url, origins.a)) return 'A';
+  if (origins.b && matchesOrigin(url, origins.b)) return 'B';
   return null;
 }
 
@@ -129,9 +154,10 @@ export type GuardianFaultAction =
 export function decideGuardianFault(
   url: string,
   policy: GuardianFaultPolicy | null,
-  hits: number
+  hits: number,
+  origins: GuardianOrigins
 ): { action: GuardianFaultAction; hits: number } {
-  const target = targetOf(url);
+  const target = targetOf(url, origins);
   if (!policy || !target) return { action: { kind: 'continue' }, hits };
   if (policy.target && policy.target !== target) return { action: { kind: 'continue' }, hits };
   if (pathOf(url) !== policy.path) return { action: { kind: 'continue' }, hits };
@@ -204,13 +230,13 @@ export async function applyGuardianFaultAction(route: GuardianRouteLike, action:
  * policy can be armed at a time -- `arm()` replaces it and resets the
  * `failFirstN` hit counter.
  */
-export function installGuardianFaults(context: BrowserContext): GuardianFaultControls {
+export function installGuardianFaults(context: BrowserContext, origins: GuardianOrigins): GuardianFaultControls {
   let policy: GuardianFaultPolicy | null = null;
   let hits = 0;
 
   context.route('**/*', async (route: Route) => {
     const url = route.request().url();
-    const decision = decideGuardianFault(url, policy, hits);
+    const decision = decideGuardianFault(url, policy, hits, origins);
     hits = decision.hits;
     await applyGuardianFaultAction(route, decision.action);
   });

--- a/playwright/e2e/tests/guardian-fault-policy.spec.ts
+++ b/playwright/e2e/tests/guardian-fault-policy.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  LOCAL_GUARDIAN_ORIGINS,
   applyGuardianFaultAction,
   decideGuardianFault,
   pathOf,
@@ -21,14 +22,14 @@ import {
 
 test.describe('targetOf', () => {
   test('matches guardian A (port 3000) and B (port 3001) by origin', () => {
-    expect(targetOf('http://localhost:3000/pubkey?scheme=ecdsa')).toBe('A');
-    expect(targetOf('http://localhost:3001/pubkey?scheme=ecdsa')).toBe('B');
+    expect(targetOf('http://localhost:3000/pubkey?scheme=ecdsa', LOCAL_GUARDIAN_ORIGINS)).toBe('A');
+    expect(targetOf('http://localhost:3001/pubkey?scheme=ecdsa', LOCAL_GUARDIAN_ORIGINS)).toBe('B');
   });
 
   test('does not match unrelated origins (node RPC, prover, note-transport)', () => {
-    expect(targetOf('http://localhost:57291/rpc')).toBeNull();
-    expect(targetOf('http://localhost:50052/prove')).toBeNull();
-    expect(targetOf('http://localhost:57292/notes')).toBeNull();
+    expect(targetOf('http://localhost:57291/rpc', LOCAL_GUARDIAN_ORIGINS)).toBeNull();
+    expect(targetOf('http://localhost:50052/prove', LOCAL_GUARDIAN_ORIGINS)).toBeNull();
+    expect(targetOf('http://localhost:57292/notes', LOCAL_GUARDIAN_ORIGINS)).toBeNull();
   });
 });
 
@@ -63,55 +64,55 @@ const DELTA_A = 'http://localhost:3000/delta?account_id=abc';
 
 test.describe('decideGuardianFault', () => {
   test('passes through when no policy is armed', () => {
-    const result = decideGuardianFault(PUBKEY_B, null, 0);
+    const result = decideGuardianFault(PUBKEY_B, null, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'continue' }, hits: 0 });
   });
 
   test('passes through requests to an unrelated origin even with a policy armed', () => {
     const policy: GuardianFaultPolicy = { path: 'pubkey', mode: 'status500' };
-    const result = decideGuardianFault('http://localhost:57291/rpc', policy, 0);
+    const result = decideGuardianFault('http://localhost:57291/rpc', policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'continue' }, hits: 0 });
   });
 
   test('passes through when target does not match', () => {
     const policy: GuardianFaultPolicy = { target: 'A', path: 'pubkey', mode: 'status500' };
-    const result = decideGuardianFault(PUBKEY_B, policy, 0);
+    const result = decideGuardianFault(PUBKEY_B, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'continue' }, hits: 0 });
   });
 
   test('passes through when path does not match', () => {
     const policy: GuardianFaultPolicy = { path: 'configure', mode: 'status500' };
-    const result = decideGuardianFault(PUBKEY_A, policy, 0);
+    const result = decideGuardianFault(PUBKEY_A, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'continue' }, hits: 0 });
   });
 
   test('matches on path alone when no target is specified', () => {
     const policy: GuardianFaultPolicy = { path: 'pubkey', mode: 'status500' };
-    expect(decideGuardianFault(PUBKEY_A, policy, 0).action).toEqual({ kind: 'fulfill500' });
-    expect(decideGuardianFault(PUBKEY_B, policy, 0).action).toEqual({ kind: 'fulfill500' });
+    expect(decideGuardianFault(PUBKEY_A, policy, 0, LOCAL_GUARDIAN_ORIGINS).action).toEqual({ kind: 'fulfill500' });
+    expect(decideGuardianFault(PUBKEY_B, policy, 0, LOCAL_GUARDIAN_ORIGINS).action).toEqual({ kind: 'fulfill500' });
   });
 
   test('status500 mode fulfills 500 and increments hits', () => {
     const policy: GuardianFaultPolicy = { target: 'B', path: 'pubkey', mode: 'status500' };
-    const result = decideGuardianFault(PUBKEY_B, policy, 0);
+    const result = decideGuardianFault(PUBKEY_B, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'fulfill500' }, hits: 1 });
   });
 
   test('abort mode aborts and increments hits', () => {
     const policy: GuardianFaultPolicy = { target: 'B', path: 'pubkey', mode: 'abort' };
-    const result = decideGuardianFault(PUBKEY_B, policy, 0);
+    const result = decideGuardianFault(PUBKEY_B, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'abort' }, hits: 1 });
   });
 
   test('delay mode defaults to 3000ms and increments hits', () => {
     const policy: GuardianFaultPolicy = { target: 'A', path: 'delta', mode: 'delay' };
-    const result = decideGuardianFault(DELTA_A, policy, 0);
+    const result = decideGuardianFault(DELTA_A, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'delay', delayMs: 3000 }, hits: 1 });
   });
 
   test('delay mode honors a custom delayMs', () => {
     const policy: GuardianFaultPolicy = { target: 'A', path: 'delta', mode: 'delay', delayMs: 500 };
-    const result = decideGuardianFault(DELTA_A, policy, 0);
+    const result = decideGuardianFault(DELTA_A, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'delay', delayMs: 500 }, hits: 1 });
   });
 
@@ -119,38 +120,38 @@ test.describe('decideGuardianFault', () => {
     const policy: GuardianFaultPolicy = { target: 'B', path: 'pubkey', mode: 'failFirstN', count: 2 };
     let hits = 0;
 
-    const first = decideGuardianFault(PUBKEY_B, policy, hits);
+    const first = decideGuardianFault(PUBKEY_B, policy, hits, LOCAL_GUARDIAN_ORIGINS);
     expect(first.action).toEqual({ kind: 'fulfill500' });
     hits = first.hits;
     expect(hits).toBe(1);
 
-    const second = decideGuardianFault(PUBKEY_B, policy, hits);
+    const second = decideGuardianFault(PUBKEY_B, policy, hits, LOCAL_GUARDIAN_ORIGINS);
     expect(second.action).toEqual({ kind: 'fulfill500' });
     hits = second.hits;
     expect(hits).toBe(2);
 
     // Third matching request: count (2) already reached -> passes through, and
     // the hit counter does not keep climbing past what was actually armed.
-    const third = decideGuardianFault(PUBKEY_B, policy, hits);
+    const third = decideGuardianFault(PUBKEY_B, policy, hits, LOCAL_GUARDIAN_ORIGINS);
     expect(third.action).toEqual({ kind: 'continue' });
     expect(third.hits).toBe(2);
 
-    const fourth = decideGuardianFault(PUBKEY_B, policy, third.hits);
+    const fourth = decideGuardianFault(PUBKEY_B, policy, third.hits, LOCAL_GUARDIAN_ORIGINS);
     expect(fourth.action).toEqual({ kind: 'continue' });
     expect(fourth.hits).toBe(2);
   });
 
   test('failFirstN defaults count to 1 when omitted', () => {
     const policy: GuardianFaultPolicy = { target: 'B', path: 'pubkey', mode: 'failFirstN' };
-    const first = decideGuardianFault(PUBKEY_B, policy, 0);
+    const first = decideGuardianFault(PUBKEY_B, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(first.action).toEqual({ kind: 'fulfill500' });
-    const second = decideGuardianFault(PUBKEY_B, policy, first.hits);
+    const second = decideGuardianFault(PUBKEY_B, policy, first.hits, LOCAL_GUARDIAN_ORIGINS);
     expect(second.action).toEqual({ kind: 'continue' });
   });
 
   test('conflictPendingDelta fulfills a 409 (not a 500) and increments hits', () => {
     const policy: GuardianFaultPolicy = { target: 'A', path: 'delta', mode: 'conflictPendingDelta' };
-    const result = decideGuardianFault(DELTA_A, policy, 0);
+    const result = decideGuardianFault(DELTA_A, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(result).toEqual({ action: { kind: 'fulfillConflictPendingDelta' }, hits: 1 });
   });
 
@@ -158,12 +159,12 @@ test.describe('decideGuardianFault', () => {
     const policy: GuardianFaultPolicy = { target: 'A', path: 'delta', mode: 'conflictPendingDelta', count: 2 };
     let hits = 0;
 
-    const first = decideGuardianFault(DELTA_A, policy, hits);
+    const first = decideGuardianFault(DELTA_A, policy, hits, LOCAL_GUARDIAN_ORIGINS);
     expect(first.action).toEqual({ kind: 'fulfillConflictPendingDelta' });
     hits = first.hits;
     expect(hits).toBe(1);
 
-    const second = decideGuardianFault(DELTA_A, policy, hits);
+    const second = decideGuardianFault(DELTA_A, policy, hits, LOCAL_GUARDIAN_ORIGINS);
     expect(second.action).toEqual({ kind: 'fulfillConflictPendingDelta' });
     hits = second.hits;
     expect(hits).toBe(2);
@@ -171,16 +172,16 @@ test.describe('decideGuardianFault', () => {
     // Third matching request: count (2) already reached -> passes through, same
     // self-clearing shape as failFirstN above (a real guardian conflict is
     // transient and must eventually let the retried request through).
-    const third = decideGuardianFault(DELTA_A, policy, hits);
+    const third = decideGuardianFault(DELTA_A, policy, hits, LOCAL_GUARDIAN_ORIGINS);
     expect(third.action).toEqual({ kind: 'continue' });
     expect(third.hits).toBe(2);
   });
 
   test('conflictPendingDelta defaults count to 1 when omitted', () => {
     const policy: GuardianFaultPolicy = { target: 'A', path: 'delta', mode: 'conflictPendingDelta' };
-    const first = decideGuardianFault(DELTA_A, policy, 0);
+    const first = decideGuardianFault(DELTA_A, policy, 0, LOCAL_GUARDIAN_ORIGINS);
     expect(first.action).toEqual({ kind: 'fulfillConflictPendingDelta' });
-    const second = decideGuardianFault(DELTA_A, policy, first.hits);
+    const second = decideGuardianFault(DELTA_A, policy, first.hits, LOCAL_GUARDIAN_ORIGINS);
     expect(second.action).toEqual({ kind: 'continue' });
   });
 });

--- a/playwright/e2e/tests/guardian-recovery-stress.spec.ts
+++ b/playwright/e2e/tests/guardian-recovery-stress.spec.ts
@@ -1,6 +1,12 @@
+import { getEnvironmentConfig } from '../config/environments';
 import { expect, test } from '../fixtures/two-wallets';
 
-const A = 'http://localhost:3000';
+// The wallet's guardian operator for the active network: the local container on
+// localhost, the real operator (e.g. guardian.openzeppelin.com) on
+// devnet/testnet. Fault injection keys on this origin (see harness/guardian-
+// fault.ts), so the spec exercises whichever guardian the wallet actually talks
+// to — not just the local container.
+const A = getEnvironmentConfig().guardianUrl;
 
 /**
  * Guardian commitment (the on-chain `GUARDIAN_SLOT_NAMES.PUBLIC_KEY` value)

--- a/playwright/e2e/tests/guardian-switch-stress.spec.ts
+++ b/playwright/e2e/tests/guardian-switch-stress.spec.ts
@@ -1,7 +1,17 @@
+import { getEnvironmentConfig } from '../config/environments';
 import { expect, test } from '../fixtures/two-wallets';
 
-const A = 'http://localhost:3000';
-const B = 'http://localhost:3001';
+// Switch-stress needs TWO distinct guardian operators: A the wallet's own,
+// B the one it switches to. Local containers on localhost; the real operators
+// on testnet (OpenZeppelin A -> Koda B). Fault injection keys on these origins
+// (harness/guardian-fault.ts), so the spec exercises whichever guardians the
+// wallet actually talks to on this network.
+const envConfig = getEnvironmentConfig();
+const A = envConfig.guardianUrl;
+if (!envConfig.guardianUrlB) {
+  throw new Error(`E2E_NETWORK=${envConfig.name} has no second guardian (guardianUrlB) configured for switch tests`);
+}
+const B = envConfig.guardianUrlB;
 
 /**
  * Guardian commitment (the on-chain `GUARDIAN_SLOT_NAMES.PUBLIC_KEY` value)


### PR DESCRIPTION
## Problem

`E2E Blockchain` → **Chrome Guardian E2E (testnet)** has been failing on every push to main at `guardian-recovery-stress.spec.ts:77` with `TypeError: fetch failed`.

Root cause: the guardian **stress** specs hardcoded `http://localhost:3000` / `:3001`, and the fault matcher `targetOf` only recognized those localhost origins. On devnet/testnet the wallet talks to the **real** operators (`guardian.openzeppelin.com` / `guardian-testnet.kodax.com`), so:
- the spec's `guardianCommitment(A)` fetched a non-existent `localhost:3000` → connection refused → `fetch failed`, and
- even if it hadn't, the fault injection (`context.route` + `targetOf`) never matched the real guardian's requests — meaning these specs gave **zero fault-resilience coverage on live networks**.

This is a real coverage gap, not a flake. It is **not** fixed by disabling/skipping the specs.

## Fix — make the guardian origins environment-aware so the specs actually run against the live guardians

- `targetOf` / `decideGuardianFault` / `installGuardianFaults` now take the active env's guardian origins (`GuardianOrigins { a, b }`); the two-wallets fixture derives them from `getEnvironmentConfig()` (`guardianUrl` → A, `guardianUrlB` → B).
- `guardian-recovery-stress` / `guardian-switch-stress` use the env guardian URLs instead of hardcoded localhost (switch-stress keeps the two-operator precondition guard that `guardian-switch` already uses).
- Unit tests thread the exported `LOCAL_GUARDIAN_ORIGINS` — behavior unchanged.

On **localhost** the origins resolve to the two local containers exactly as before, so the localhost/PR `guardian-lifecycle` suite is unaffected. On **testnet** the fault/stress specs now exercise the real guardians.

## Verification

`tsc` clean; unit-test logic unchanged. Verified against the live testnet guardian via a `workflow_dispatch` of `e2e-blockchain` (network=testnet) on this branch — run linked below.

## Note (separate issue)

Devnet has only one guardian operator (the others are testnet-only), so the two-operator **switch** specs still can't run there. That's a distinct infra limitation (needs a second devnet operator, or the switch specs scoped to two-operator networks) — flagged for a decision, not addressed here.