### PR TITLE
fix(mobile): stop Android keyboard double-inset; bump to 1.15.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.19 (2026-08-05)
+
+### Fixes
+
+- [FIX][mobile] **Android: opening the keyboard no longer collapses the screen into a thin strip under the toolbar with a large empty gap above the keyboard.** On Android the app window is `adjustResize`, so the system already resizes the WebView to sit above the soft keyboard. The mobile keyboard-inset helper was *also* adding a `--keyboard-height` bottom padding — needed only on iOS, where the WebView overlays the keyboard instead of resizing — which double-counted the keyboard height, so screens like the Send address/amount entry shrank to a band at the top with a blank void beneath. The `--keyboard-height` compensation is now iOS-only, and Android's `adjustResize` is pinned in `AndroidManifest.xml` so the native resize is deterministic.
+
 ## 1.15.18 (2026-08-05)
 
 ### Fixes

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.miden.wallet"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11517001
-        versionName "1.15.17"
+        versionCode 11519001
+        versionName "1.15.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
 
             <intent-filter>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miden-wallet",
-  "version": "1.15.18",
+  "version": "1.15.19",
   "private": true,
   "engines": {
     "node": ">=22.0.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bread Wallet by Miden",
-  "version": "1.15.18",
+  "version": "1.15.19",
 
   "icons": {
     "16": "misc/logo-white-bg-16.png",

--- a/src/lib/mobile/keyboard-inset.test.ts
+++ b/src/lib/mobile/keyboard-inset.test.ts
@@ -3,7 +3,7 @@
  */
 import { Keyboard } from '@capacitor/keyboard';
 
-import { isMobile } from 'lib/platform';
+import { isIOS, isMobile } from 'lib/platform';
 
 import { initKeyboardInset } from './keyboard-inset';
 
@@ -15,10 +15,12 @@ jest.mock('@capacitor/keyboard', () => ({
 }));
 
 jest.mock('lib/platform', () => ({
-  isMobile: jest.fn()
+  isMobile: jest.fn(),
+  isIOS: jest.fn()
 }));
 
 const isMobileMock = isMobile as jest.Mock;
+const isIOSMock = isIOS as jest.Mock;
 const addListenerMock = Keyboard.addListener as jest.Mock;
 const setAccessoryBarVisibleMock = Keyboard.setAccessoryBarVisible as jest.Mock;
 
@@ -29,6 +31,9 @@ describe('keyboard-inset', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    // Default to iOS, where the --keyboard-height compensation is active. The
+    // Android path (native adjustResize; no compensation) is covered explicitly.
+    isIOSMock.mockReturnValue(true);
     listeners = {};
     addListenerMock.mockImplementation((event: string, cb: (info?: { keyboardHeight?: number }) => void) => {
       listeners[event] = cb;
@@ -60,6 +65,36 @@ describe('keyboard-inset', () => {
 
     listeners['keyboardWillHide']!();
     expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('0px');
+  });
+
+  it('does NOT register the keyboard-height listeners on Android (native adjustResize handles it)', async () => {
+    isMobileMock.mockReturnValue(true);
+    isIOSMock.mockReturnValue(false);
+
+    await initKeyboardInset();
+
+    // On Android the window is adjustResize, so the system already lifts the
+    // layout above the keyboard. Setting --keyboard-height too would double-count
+    // it, collapsing the layout with a void above the keyboard.
+    expect(addListenerMock).not.toHaveBeenCalledWith('keyboardWillShow', expect.any(Function));
+    expect(addListenerMock).not.toHaveBeenCalledWith('keyboardWillHide', expect.any(Function));
+    expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('');
+  });
+
+  it('still nudges the focused input into view on Android', async () => {
+    isMobileMock.mockReturnValue(true);
+    isIOSMock.mockReturnValue(false);
+
+    await initKeyboardInset();
+
+    const input = document.createElement('input');
+    input.scrollIntoView = jest.fn();
+    document.body.appendChild(input);
+
+    input.focus();
+    jest.advanceTimersByTime(300);
+
+    expect(input.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
   });
 
   it('treats a missing keyboardHeight as 0', async () => {

--- a/src/lib/mobile/keyboard-inset.ts
+++ b/src/lib/mobile/keyboard-inset.ts
@@ -1,18 +1,27 @@
 import { Keyboard } from '@capacitor/keyboard';
 
-import { isMobile } from 'lib/platform';
+import { isIOS, isMobile } from 'lib/platform';
 
 /**
  * Keyboard inset for mobile.
  *
- * Capacitor's Keyboard resize mode is 'none' (capacitor.config.ts), so the
- * soft keyboard overlays the WebView and hides bottom-of-layout inputs/CTAs.
- * This module mirrors the keyboard height into the `--keyboard-height` CSS
- * var on <html>; mobile.html's body padding-bottom consumes it via
- * `max(16px, env(safe-area-inset-bottom), var(--keyboard-height, 0px))`, so
- * the full-height layout shrinks and bottom-pinned content rides above the
- * keyboard. `keyboardWillShow` fires before the native slide with the final
- * height, letting the CSS transition on body padding run in sync with it.
+ * iOS ONLY. Capacitor's Keyboard resize mode is 'none' (capacitor.config.ts),
+ * but that only overlays the keyboard on iOS: the WKWebView keeps its full
+ * height, so the soft keyboard hides bottom-of-layout inputs/CTAs. This module
+ * mirrors the keyboard height into the `--keyboard-height` CSS var on <html>;
+ * mobile.html's body padding-bottom consumes it via
+ * `max(16px, env(safe-area-inset-bottom), var(--keyboard-height, 0px))`, so the
+ * full-height layout shrinks and bottom-pinned content rides above the keyboard.
+ * `keyboardWillShow` fires before the native slide with the final height,
+ * letting the CSS transition on body padding run in sync with it.
+ *
+ * Android is DELIBERATELY excluded from this compensation: `resize: 'none'` is
+ * only a JS-layer setting there — the native window stays ADJUST_RESIZE
+ * (see AndroidManifest's MainActivity), so the system already resizes the
+ * WebView to sit above the keyboard. Adding the CSS inset on top of that
+ * double-counts the keyboard height: the layout collapses into a thin strip at
+ * the top with an empty gap above the keyboard. So `--keyboard-height` is left
+ * at 0 on Android and the native resize does the work.
  */
 export async function initKeyboardInset(): Promise<void> {
   if (!isMobile()) return;
@@ -29,17 +38,21 @@ export async function initKeyboardInset(): Promise<void> {
     // non-iPhone platform or no native implementation — leave the bar as-is
   }
 
-  try {
-    await Keyboard.addListener('keyboardWillShow', info => {
-      root.style.setProperty('--keyboard-height', `${info.keyboardHeight || 0}px`);
-    });
+  // iOS only — on Android the native ADJUST_RESIZE already lifts the layout
+  // above the keyboard, so mirroring the height here would double-count it.
+  if (isIOS()) {
+    try {
+      await Keyboard.addListener('keyboardWillShow', info => {
+        root.style.setProperty('--keyboard-height', `${info.keyboardHeight || 0}px`);
+      });
 
-    await Keyboard.addListener('keyboardWillHide', () => {
-      root.style.setProperty('--keyboard-height', '0px');
-    });
-  } catch {
-    // Keyboard plugin has no web implementation — run without insets rather
-    // than failing mobile app init.
+      await Keyboard.addListener('keyboardWillHide', () => {
+        root.style.setProperty('--keyboard-height', '0px');
+      });
+    } catch {
+      // Keyboard plugin has no web implementation — run without insets rather
+      // than failing mobile app init.
+    }
   }
 
   // Mid-layout inputs can still sit below the fold after the layout shrinks;


### PR DESCRIPTION
Closes https://github.com/0xMiden/wallet/issues/496

## The bug (Android only)

Opening the soft keyboard collapsed the screen into a thin band under the toolbar with a large empty **void** above the keyboard (e.g. the Send address/amount entry). The keyboard height was being subtracted **twice**:

1. **Native:** the Android app window is `ADJUST_RESIZE` (confirmed via `dumpsys`), so the system already resizes the WebView to sit above the keyboard — `innerHeight` 721 → 466.
2. **CSS (the bug):** `keyboard-inset.ts` gated only on `isMobile()`, so it *also* ran on Android and added `--keyboard-height: 299px` → `body { padding-bottom: 299px }` on top of the native resize.

Result: `#root` collapsed to ~168px; the 299px padding showed as the void. That CSS compensation is correct on **iOS** (where `resize:'none'` genuinely overlays — WKWebView doesn't resize) but double-counts on Android.

## Fix

- `src/lib/mobile/keyboard-inset.ts` — apply the `--keyboard-height` compensation on **iOS only** (`isIOS()`); Android relies on native `adjustResize`. iOS code path unchanged.
- `android/app/src/main/AndroidManifest.xml` — pin `android:windowSoftInputMode="adjustResize"` on `MainActivity` so the native resize the fix depends on is deterministic.
- Tests updated: iOS path unchanged; new coverage asserts Android does **not** register the `--keyboard-height` listeners (no double-count) and still nudges the focused input into view.

## Verified on-device

Reproduced and confirmed fixed on a real OnePlus 8T (Android 14) via Chrome DevTools + screenshots: with the fix, `--keyboard-height` stays unset, `padding-bottom` back to 16px, `#root` fills the resized viewport (168 → 451px), and the void is gone.

## Version bump → 1.15.19

Ships the fix as **1.15.19**: `package.json`, `public/manifest.json`, and `android/app/build.gradle` (`versionCode 11519001`, `versionName 1.15.19`), plus the CHANGELOG entry.

**Note:** iOS 1.15.18 is *not* affected by this bug (iOS overlays; the CSS is correct there).