### PR TITLE
fix(private-send): relay note before waiting for commit so the block hint stays below the commitment block

### DIFF
--- a/.github/workflows/pr-e2e-local.yml
+++ b/.github/workflows/pr-e2e-local.yml
@@ -8,7 +8,25 @@ permissions:
   contents: read
 jobs:
   chrome-local:
-    name: local-e2e (chrome)
+    # Run the core suite under BOTH block cadences: the miden-node default (3s
+    # block / 1s batch, realistic timing) and fast 500ms blocks. Fast blocks
+    # guarantee a block lands in the wallet's commit->relay window, making
+    # send-private a deterministic guard for the private-note block-hint overshoot
+    # (web-sdk#262 / wallet#502). The fast leg is scoped to that one timing-critical
+    # spec to stay quick and stable; the default leg keeps full-suite coverage.
+    # The default leg's name stays exactly "local-e2e (chrome)" so any required-check
+    # mapping is unaffected.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name_suffix: ""
+            block_interval: ""
+            specs: ""
+          - name_suffix: " [fast blocks]"
+            block_interval: "500ms"
+            specs: "playwright/e2e/tests/send-private.spec.ts"
+    name: local-e2e (chrome)${{ matrix.name_suffix }}
     runs-on: ubuntu-latest
     # Cold-cache runs compile miden-client-cli (~8m) + note-transport (~5m);
     # warm-cache runs are ~20m. 45m gives the cold run headroom to seed the cache.
@@ -16,6 +34,10 @@ jobs:
     env:
       E2E_NETWORK: localhost
       MIDEN_NTX_AUTH: e2e-ntx-secret
+      # Empty on the default leg -> docker-compose ${VAR:-<default>} falls back to
+      # the miden-node defaults; "500ms" on the fast leg.
+      MIDEN_NODE_BLOCK_INTERVAL: ${{ matrix.block_interval }}
+      MIDEN_NODE_BATCH_INTERVAL: ${{ matrix.block_interval }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -86,7 +108,9 @@ jobs:
         # E2E): a small margin for a rare balance->send-UI sync hiccup on a loaded
         # runner. Deliberately NOT 2 -- kept at 1 so a genuine regression still fails
         # the (to-be-required) gate rather than passing on a lucky third attempt.
-        run: xvfb-run -a yarn test:e2e:blockchain:run --retries=1
+        # matrix.specs is empty for the default-timing leg (full core suite) and
+        # scoped to send-private for the fast-blocks leg.
+        run: xvfb-run -a yarn test:e2e:blockchain:run --retries=1 ${{ matrix.specs }}
       # Guardian (`guardian-*.spec.ts`) coverage lives in its own workflow,
       # pr-e2e-guardian-lifecycle.yml, which brings up BOTH guardians (A :3000 +
       # B :3001, `guardian-switch` compose profile) and runs the full suite via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.20 (TBD)
+
+### Fixes
+
+- [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.
+
 ## 1.15.19 (2026-08-05)
 
 ### Fixes

--- a/playwright/e2e/local-stack/docker-compose.local.yml
+++ b/playwright/e2e/local-stack/docker-compose.local.yml
@@ -169,14 +169,16 @@ services:
       - --validator.url=http://validator:50101
       - --ntx-builder.url=http://ntx-builder:50301
       - --rpc.network-tx-auth-header-value=${MIDEN_NTX_AUTH:-e2e-ntx-secret}
-      # Fast blocks: the block producer ticks empty blocks on a timer (default
-      # --block.interval=3s). At 3s vs the wallet's 2s localhost sync poll, a block
-      # lands in the commit->relay window only sometimes, so the private-note
-      # block-hint overshoot (web-sdk#262 / wallet#502) reproduces only flakily.
-      # 500ms guarantees a block lands in that window, making send-private a
-      # deterministic guard for the overshoot.
-      - --batch.interval=500ms
-      - --block.interval=500ms
+      # Block cadence is parameterized so CI exercises BOTH realistic timing and
+      # fast blocks. The block producer ticks empty blocks on this timer; unset, it
+      # defaults to the miden-node defaults (3s block / 1s batch) for normal-timing
+      # coverage. At 3s vs the wallet's 2s localhost sync poll a block lands in the
+      # commit->relay window only sometimes, so the private-note block-hint overshoot
+      # (web-sdk#262 / wallet#502) reproduces only flakily. Setting
+      # MIDEN_NODE_BLOCK_INTERVAL=500ms guarantees a block in that window, making
+      # send-private a deterministic guard for the overshoot.
+      - --batch.interval=${MIDEN_NODE_BATCH_INTERVAL:-1s}
+      - --block.interval=${MIDEN_NODE_BLOCK_INTERVAL:-3s}
     ports:
       - "127.0.0.1:57291:57291"
     # No custom healthcheck: the miden-node image ships its own HEALTHCHECK

--- a/playwright/e2e/local-stack/docker-compose.local.yml
+++ b/playwright/e2e/local-stack/docker-compose.local.yml
@@ -169,6 +169,14 @@ services:
       - --validator.url=http://validator:50101
       - --ntx-builder.url=http://ntx-builder:50301
       - --rpc.network-tx-auth-header-value=${MIDEN_NTX_AUTH:-e2e-ntx-secret}
+      # Fast blocks: the block producer ticks empty blocks on a timer (default
+      # --block.interval=3s). At 3s vs the wallet's 2s localhost sync poll, a block
+      # lands in the commit->relay window only sometimes, so the private-note
+      # block-hint overshoot (web-sdk#262 / wallet#502) reproduces only flakily.
+      # 500ms guarantees a block lands in that window, making send-private a
+      # deterministic guard for the overshoot.
+      - --batch.interval=500ms
+      - --block.interval=500ms
     ports:
       - "127.0.0.1:57291:57291"
     # No custom healthcheck: the miden-node image ships its own HEALTHCHECK

--- a/src/lib/miden/transaction/complete.ts
+++ b/src/lib/miden/transaction/complete.ts
@@ -69,8 +69,16 @@ export const completeCustomTransaction = async (transaction: ITransaction, resul
         const midenClient = await getMidenClient();
 
         try {
-          await midenClient.waitForTransactionCommit(executedTx.id().toHex());
+          // Relay to the transport layer BEFORE waiting for commit. The block hint
+          // sendPrivateNote attaches is the client's current sync height, and the
+          // recipient scans FORWARD from it for the note's on-chain commitment.
+          // Waiting for commit first advances sync height to/past the commitment
+          // block, so on fast chains the hint overshoots the commitment and the
+          // recipient never finds the note (silent non-delivery). Relaying first
+          // keeps the hint below the commitment; the commit wait still gates the
+          // Completed status below.
           await midenClient.sendPrivateNote(fullNote, transaction.secondaryAccountId!);
+          await midenClient.waitForTransactionCommit(executedTx.id().toHex());
         } catch (error) {
           console.error('Failed to send private note through the transport layer', {
             txId: transaction.id,
@@ -438,9 +446,11 @@ export const completeSendTransaction = async (tx: SendTransaction, result: Trans
     try {
       await withWasmClientLock(async () => {
         const midenClient = await getMidenClient();
-        await midenClient.waitForTransactionCommit(executedTx.id().toHex());
         await setTransactionStage(tx.id, 'delivering');
         try {
+          // Relay BEFORE waiting for commit — same reason as completeCustomTransaction:
+          // the sync-height block hint must stay below the note's commitment block, or
+          // the recipient scans past it and never receives.
           await midenClient.sendPrivateNote(note, tx.secondaryAccountId);
         } catch (error) {
           console.warn('Private-note transport failed; SDK outbox will retry on next sync', {
@@ -450,6 +460,7 @@ export const completeSendTransaction = async (tx: SendTransaction, result: Trans
             error
           });
         }
+        await midenClient.waitForTransactionCommit(executedTx.id().toHex());
       });
     } catch (error) {
       // Lock acquisition or pre-transport step (e.g. waitForTransactionCommit)


### PR DESCRIPTION
## Problem

Private-note delivery over the note-transport layer can silently fail: the recipient never receives the note.

In `completeCustomTransaction` (and the guardian/delivering path), the wallet relays the note **after** `waitForTransactionCommit`:

```ts
await midenClient.waitForTransactionCommit(...);   // sync height advances to/past the note's commitment block C
await midenClient.sendPrivateNote(fullNote, ...);  // relays block hint = get_sync_height()  → ≥ C
```

`sendPrivate` takes no hint parameter, so the SDK always relays the client's **current sync height** as the note's `after_block_num`. The recipient imports the note as an `ExpectedNote` and scans **forward** from that hint for the on-chain commitment. Because we wait for commit first, the hint is at or above the commitment block `C` — so on any chain that produces a block between commit and relay, `hint > C`, the recipient scans past the commitment and **never finds the note**.

This is latent on testnet (slow blocks → sync height stays ≈ `C` at relay), which is why it hasn't surfaced. It reproduces deterministically on a fast devnet.

## Fix

Relay **before** waiting for commit — the SDK's documented "prompt relay" flow — so the hint is captured while sync height is still below `C`. The recipient then scans forward from below the commitment and picks it up when it lands. The commit wait stays (after the relay) so `Completed` status is still gated on on-chain confirmation.

Applied at both private-relay sites in `complete.ts`.

## Verification

Reproduced and fixed on a fast custom devnet via the blockchain e2e harness:
- Before: `send-private` timed out at 5m every run (wallet B balance stayed 0).
- After: `send-private` passes in ~1.4m (B receives); `send-public` still passes (no regression).

## Follow-up (SDK)

The more robust fix belongs in the SDK: `send_private_note` should relay the note's **actual commitment block** (from its inclusion proof) as the hint rather than the sync height — exactly what the `miden-client` CLI's `notes --send` already does. That would let the wallet keep waiting for commit before relaying. Filing separately.