### PR TITLE
Fix inaccurate build-all command description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ yarn dev
 # Production build
 yarn build:chrome    # Chrome
 yarn build:firefox   # Firefox
-yarn build-all       # All browsers
+yarn build-all       # All build targets (browser, mobile, desktop)
 ```
 
 Load the unpacked extension from `dist/chrome_unpacked/` in Chrome's extension settings.


### PR DESCRIPTION
Updated the README comment for the build-all command to match its actual behavior.

The build-all script runs all build:* targets from package.json, including browser, mobile, and desktop builds. The previous comment only mentioned browsers, which was misleading.