### PR TITLE
fix(private-send): adopt web-sdk#263 sendPrivateOutput (expected-height hint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.
+- [FIX][all] **Private-note delivery no longer silently fails on fast chains.** A private note's transport "block hint" — the block the recipient scans forward from for the note's on-chain commitment — was the client's current sync height, which could already sit past the commitment once the wallet had synced past the note, so the recipient scanned past it and never found the note. The wallet now relays via the SDK's `sendPrivateOutput`, which derives the hint from the note's expected height (the chain tip when its transaction was submitted), so delivery is correct regardless of sync height. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet. Requires web-sdk#263.
 
 ## 1.15.19 (2026-08-05)
 

--- a/src/lib/miden/sdk/miden-client-interface.ts
+++ b/src/lib/miden/sdk/miden-client-interface.ts
@@ -472,7 +472,12 @@ export class MidenClientInterface {
   }
 
   async sendPrivateNote(note: Note, to: string): Promise<void> {
-    await this.client.notes.sendPrivate({ note, to });
+    // Relay via the output-note convenience: the SDK derives the recipient's
+    // scan-start block from the note's expected height (the chain tip when its
+    // transaction was submitted), so delivery is correct regardless of this
+    // client's current sync height (web-sdk#263). The note is one of our own
+    // committed output notes, so it exists in the store by relay time.
+    await this.client.notes.sendPrivateOutput({ noteId: note.id().toString(), to });
   }
 
   async getConsumableNotes(accountId: string): Promise<InputNoteRecord[]> {

--- a/src/lib/miden/transaction/complete.ts
+++ b/src/lib/miden/transaction/complete.ts
@@ -69,14 +69,12 @@ export const completeCustomTransaction = async (transaction: ITransaction, resul
         const midenClient = await getMidenClient();
 
         try {
-          // Relay to the transport layer BEFORE waiting for commit. The block hint
-          // sendPrivateNote attaches is the client's current sync height, and the
-          // recipient scans FORWARD from it for the note's on-chain commitment.
-          // Waiting for commit first advances sync height to/past the commitment
-          // block, so on fast chains the hint overshoots the commitment and the
-          // recipient never finds the note (silent non-delivery). Relaying first
-          // keeps the hint below the commitment; the commit wait still gates the
-          // Completed status below.
+          // Relay to the transport layer. The SDK derives the recipient's
+          // scan-start block from the note's expected height (web-sdk#263), so the
+          // recipient — which scans FORWARD from that block for the note's on-chain
+          // commitment — receives it regardless of this client's sync height or of
+          // whether we relay before or after commit. The commit wait below still
+          // gates the Completed status.
           await midenClient.sendPrivateNote(fullNote, transaction.secondaryAccountId!);
           await midenClient.waitForTransactionCommit(executedTx.id().toHex());
         } catch (error) {
@@ -448,9 +446,9 @@ export const completeSendTransaction = async (tx: SendTransaction, result: Trans
         const midenClient = await getMidenClient();
         await setTransactionStage(tx.id, 'delivering');
         try {
-          // Relay BEFORE waiting for commit — same reason as completeCustomTransaction:
-          // the sync-height block hint must stay below the note's commitment block, or
-          // the recipient scans past it and never receives.
+          // Relay to the transport layer — see completeCustomTransaction: the SDK
+          // derives the block hint from the note's expected height (web-sdk#263), so
+          // delivery is independent of this client's sync height and relay timing.
           await midenClient.sendPrivateNote(note, tx.secondaryAccountId);
         } catch (error) {
           console.warn('Private-note transport failed; SDK outbox will retry on next sync', {


### PR DESCRIPTION
## Summary

Adopt the SDK's `sendPrivateOutput` (web-sdk#263) for private-note delivery. The SDK now derives the recipient's transport block hint from the note's **expected height** (the chain tip when its transaction was submitted), so delivery is correct regardless of this client's sync height or relay timing.

This is the proper SDK-level fix behind the wallet workaround merged in #502 (which relayed before the commit wait to keep a sync-height hint below the commitment). With the hint derived from expected height, timing no longer matters; the wallet just calls the new convenience.

## Changes

- `miden-client-interface.ts`: `notes.sendPrivate({ note, to })` → `notes.sendPrivateOutput({ noteId, to })`.
- `complete.ts`: refreshed the two relay-site comments — the sync-height rationale no longer applies (the relay-before-commit ordering from #502 is retained but is now redundant for correctness).
- `CHANGELOG.md`: 1.15.20 entry updated to describe the expected-height fix.

## Verification

The SDK side is covered by web-sdk#263's cross-client regression test (relays via `sendPrivateOutput` after syncing past the note's commitment; fails if the hint regresses to sync height). This PR's CI builds the wallet against #263 via the marker below and runs the local blockchain e2e (including the 500ms fast-block `send-private` leg added in #502).

Web SDK PR: #263
