### PR TITLE
docs: add shared wallet frontend skill

### DIFF
--- a/.agents/skills/miden-wallet-frontend
+++ b/.agents/skills/miden-wallet-frontend
@@ -1,0 +1,1 @@
+../../skills/miden-wallet-frontend

--- a/.claude/skills/miden-wallet-frontend
+++ b/.claude/skills/miden-wallet-frontend
@@ -1,0 +1,1 @@
+../../skills/miden-wallet-frontend

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,10 @@ sdk-debug/
 
 # superpowers SDD scratch (progress ledger, etc.)
 .superpowers/
+
+# Track the shared frontend skill for Claude while keeping all other
+# machine-local Claude runtime state out of the repository.
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/miden-wallet-frontend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ The extension manifest version comes from `package.json`, NOT `public/manifest.j
 - **Background auto-ops**: use `startBackgroundTransactionProcessing` (polls 5s × 5min, no modal), not `openLoadingFullPage`.
 - **Sanitized frontend state**: the frontend receives state via `toFront()`; vault/keys stay backend-only.
 
+## Frontend UI, CSS, and Motion
+
+Read `skills/miden-wallet-frontend/SKILL.md` before implementing or reviewing wallet UI, CSS, motion, layout, or interaction changes. Reuse existing wallet components and semantic theme tokens before adding primitives or literal styles. Keep component-specific animation out of `src/main.css`; route nontrivial motion through Framer Motion and the reduced-motion-aware spring helpers. Interactive UI must use accessible semantics, appropriate haptics, localization, and platform isolation, then be verified on every affected surface.
+
 ## Adding a Wallet Action
 
 1. Message type in `src/lib/shared/types.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.15.20 (TBD)
 
+### Changes
+
+- [CHANGE][all] **Frontend implementation guidance is now shared across supported coding agents.** The repository now carries one vendor-neutral Miden Wallet frontend skill for component reuse, semantic styling, motion, accessibility, haptics, and cross-platform verification, with matching concise rules in the repository instructions.
+
 ### Fixes
 
 - [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ Wrap platform-specific fixes with `isIOS()`/`isAndroid()`/`isMobile()` from `lib
 ### Haptics on tappable components
 Add `hapticLight()` (taps), `hapticMedium()` (toggles), `hapticSelection()` (tabs) from `lib/mobile/haptics`. Auto-checks `isMobile()` and user setting.
 
+## Frontend UI, CSS, and Motion
+
+Read `skills/miden-wallet-frontend/SKILL.md` before implementing or reviewing wallet UI, CSS, motion, layout, or interaction changes. Reuse existing wallet components and semantic theme tokens before adding primitives or literal styles. Keep component-specific animation out of `src/main.css`; route nontrivial motion through Framer Motion and the reduced-motion-aware spring helpers. Interactive UI must use accessible semantics, appropriate haptics, localization, and platform isolation, then be verified on every affected surface.
+
 ### Mobile file downloads
 `<a download>` does nothing in WebView. Use `Filesystem.writeFile` + `Share.share` from `@capacitor/{filesystem,share}` when `isMobile()`.
 

--- a/skills/miden-wallet-frontend/SKILL.md
+++ b/skills/miden-wallet-frontend/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: miden-wallet-frontend
+description: Use when building, styling, animating, or reviewing React UI in Miden Wallet, including components, Tailwind or CSS, Framer Motion, mobile interactions, theme behavior, accessibility, or cross-platform layout.
+---
+
+# Miden Wallet Frontend
+
+## Overview
+
+Build wallet UI by extending the established system instead of copying legacy or one-off patterns. Preserve a consistent feel across extension, mobile, and desktop while keeping motion accessible and CSS scoped.
+
+## Workflow
+
+1. Read the relevant reference before editing. Search the nearby feature first, then reuse the designated component layer.
+2. Choose the smallest styling and motion mechanism that fits the behavior.
+3. Implement semantics, localization, haptics, theme behavior, and platform constraints with the UI.
+4. Verify the affected states and platforms before declaring the change ready.
+
+## Quick Decisions
+
+| Need | Use |
+| --- | --- |
+| Existing wallet control or display | Current feature, then `src/components/ui` |
+| Primary wallet CTA | `src/components/Button` |
+| Drawer, dialog, or compact generic primitive | Existing `src/lib/ui` convention |
+| New style | Tailwind + `cn()` + semantic token |
+| Component state, layout, gesture, or enter/exit motion | Framer Motion + reduced-motion-aware springs |
+| Simple status effect | Tailwind or `tw-animate-css` utility |
+| Root, platform, library, or cross-tree style | `src/main.css` |
+
+## Required Rules
+
+- Do not extend `src/app/atoms` for new UI; it is maintenance-only.
+- Use semantic theme tokens. Existing hardcoded colors and redundant `dark:` variants are not precedent.
+- Do not add component-specific classes or keyframes to `src/main.css`.
+- Use `useMotion`, `useSprings`, or `resolveTransition` with `lib/animation/springs`; do not inline spring physics.
+- Use native interactive elements where possible. Otherwise provide keyboard activation, visible focus, and an accessible name.
+- Localize user-facing text, use v2 icons, and add the established mobile haptic for meaningful interaction.
+- Isolate platform behavior through `lib/platform`; preserve mobile safe areas and native navbar ownership.
+
+## References
+
+- [Components and styling](references/components-and-styling.md)
+- [Motion and interaction](references/motion-and-interaction.md)
+- [Platform, accessibility, and verification](references/platform-accessibility-verification.md)
+
+## Common Mistakes
+
+- Adding a one-off keyframe to global CSS because it is quick.
+- Using a raw `div` as a button when a native button works.
+- Adding `dark:` to a token that already auto-flips.
+- Copying legacy atoms, literal colors, or inline spring values into new UI.
+- Treating mobile as a CSS breakpoint rather than a platform with safe-area, native-nav, and haptic behavior.

--- a/skills/miden-wallet-frontend/references/components-and-styling.md
+++ b/skills/miden-wallet-frontend/references/components-and-styling.md
@@ -1,0 +1,27 @@
+# Components and Styling
+
+## Component Selection
+
+Search the active feature before creating a primitive. Then follow this order:
+
+1. Reuse the local feature component when it represents the same product behavior.
+2. Use `src/components/ui` for wallet design-system surfaces such as cards, rows, navigation, prompt, asset, and balance UI.
+3. Use `src/components/Button` for the wallet's full-width primary, secondary, and ghost CTAs.
+4. Use `src/lib/ui` only where the local convention already uses its Radix, Vaul, or shadcn-style primitive.
+5. Maintain `src/app/atoms` only when changing an existing legacy flow; do not make it the home for new UI.
+
+Use the v2 icon registry in `src/app/icons/v2` rather than adding inline SVG for a standard wallet icon.
+
+## Styling
+
+Use Tailwind classes and `cn()` from `lib/ui/util` for conditional composition. Use a CSS module only when component-scoped CSS is genuinely necessary for selectors or behavior that Tailwind cannot express; do not add one for ordinary layout or color work.
+
+Use semantic tokens from `tailwind.config.ts` and `src/main.css`: `text-text-primary-token`, `text-text-secondary-token`, `bg-surface-input`, `bg-surface-interactive`, `bg-accent-primary`, status colors, rules, and token radii. `text-black`, `bg-white`, `bg-gray-25/50/100`, and `text-heading-gray` already resolve through theme variables; do not add `dark:` variants to them.
+
+Fixed palettes (`grey.*`, `pure-white`, `pure-black`) and SVG `fill` values need explicit theme treatment. Prefer `currentColor` for icons. Existing literal colors are migration debt, not a template for new code.
+
+## Global CSS Boundary
+
+`src/main.css` owns Tailwind imports, font and theme variables, root surfaces, browser or library overrides, safe-area behavior, and selectors that coordinate separate React trees. It may hold a global animation only when React cannot own the element or behavior is inherently root/platform scoped.
+
+Component-owned visual behavior belongs with the component. Do not add a named global class or `@keyframes` there for a card, prompt, row, button, or local state transition.

--- a/skills/miden-wallet-frontend/references/motion-and-interaction.md
+++ b/skills/miden-wallet-frontend/references/motion-and-interaction.md
@@ -1,0 +1,41 @@
+# Motion and Interaction
+
+## Motion Selection
+
+| Behavior | Implementation |
+| --- | --- |
+| Enter, exit, state swap, layout, shared element, drag, tap | Framer Motion |
+| Spring feel | `lib/animation/springs` through `useMotion`, `useSprings`, or `resolveTransition` |
+| Loader spin, pulse, or a simple utility effect | Tailwind or `tw-animate-css` |
+| Root, library, or cross-tree transition | `src/main.css`, with reduced-motion behavior |
+
+Use the spring name that matches the interaction: `snappy` for button/chrome feedback, `standard` for screens, `sheetPresent` for sheets, `morph` for shared-element movement, and `dragRelease` for a post-drag rebound. Do not invent per-component stiffness and damping values.
+
+```tsx
+import { motion } from 'framer-motion';
+
+import { springs, useMotion } from 'lib/animation';
+
+const transition = useMotion(springs.standard);
+
+return <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={transition} />;
+```
+
+For event-handler animation controls, read `useReducedMotion()` at component scope and pass the result to `resolveTransition`. Repeating or decorative motion must become instant, static, or otherwise non-disruptive when reduced motion is enabled.
+
+## PR #504 Pattern
+
+An indeterminate progress runner, icon flip, and hero state pop are all owned by `PromptCard`. Implement those as component motion rather than appending their keyframes and classes to `src/main.css`. A basic existing `animate-spin` loader remains appropriate because it is a simple status utility.
+
+## Interaction Requirements
+
+Use a native `button` for an action and an `a` for navigation whenever possible. Icon-only controls need an accessible name. Status or asynchronous completion needs the right `role` or live-region behavior. Keyboard users must receive the same action with Enter and Space when a custom control is unavoidable.
+
+Mobile feedback follows intent:
+
+- `hapticLight()` for ordinary taps.
+- `hapticMedium()` for toggles or committed selections.
+- `hapticSelection()` for tabs and pickers.
+- Success, warning, error, and drag helpers for those outcomes.
+
+Do not add haptics to passive state changes or duplicate feedback already owned by a shared component.

--- a/skills/miden-wallet-frontend/references/platform-accessibility-verification.md
+++ b/skills/miden-wallet-frontend/references/platform-accessibility-verification.md
@@ -1,0 +1,27 @@
+# Platform, Accessibility, and Verification
+
+## Platform Constraints
+
+The wallet serves extension, Capacitor iOS/Android, and Tauri desktop. Use `lib/platform` to isolate platform behavior; a mobile fix must not leak into extension or desktop.
+
+Mobile uses `100%` and safe-area padding owned by `public/mobile.html`; do not introduce `100dvh` sizing. The mobile bottom navbar is a native overlay, not a React component to recreate. Preserve the existing fixed popup, full-page, side-panel, and desktop sizing patterns before reaching for responsive breakpoints.
+
+## Accessibility and Content
+
+- Use native semantics, visible focus, keyboard access, and accessible names.
+- Keep contrast theme-safe through semantic tokens.
+- Localize every user-facing string with `t()` or `<T />`; add English source keys to `public/_locales/en/en.json` and run `yarn lint:i18n` when copy changes.
+- Use `aria-live`, `role="status"`, or `role="alert"` when asynchronous state needs announcement.
+
+## Verification Matrix
+
+| Change | Verify |
+| --- | --- |
+| Any TypeScript UI behavior | Targeted Jest/RTL, `yarn ts`, and `yarn lint` |
+| User-facing copy | `yarn lint:i18n` |
+| Visual styling | Light and dark theme inspection |
+| Nontrivial motion | Normal and reduced-motion paths |
+| Mobile or shared layout | iPhone 17 simulator screenshot and affected extension/desktop surface |
+| New interaction | Keyboard behavior, focus, haptics, and loading/error/success states |
+
+Use test mocks for Framer Motion where established by nearby tests, but assert behavior rather than implementation details. Keep tests colocated with the changed component.


### PR DESCRIPTION
## Summary

Adds one vendor-neutral Miden Wallet frontend skill and exposes it to both Claude and Codex through project-local links. The skill codifies component reuse, semantic styling, motion, accessibility, haptics, platform constraints, and verification.

The repository instructions now carry the same concise frontend baseline, while the detailed guidance remains in the shared skill.

## Validation

- `quick_validate.py` passes for `skills/miden-wallet-frontend`.
- Both `.agents/skills/miden-wallet-frontend` and `.claude/skills/miden-wallet-frontend` resolve to the canonical skill directory.
- `git diff --check` and post-commit `git show --check` pass.
- Checked the PR #504 animation case, component selection, global CSS boundary, reduced-motion, haptic, and mobile-verification guidance.

## Test plan

- [x] Validate skill frontmatter and structure
- [x] Verify shared Claude and Codex skill links
- [x] Verify no vendor-specific metadata is present in the canonical skill
- [x] Review staged and committed diffs for whitespace errors

## Out of scope

- Runtime UI changes or frontend-debt cleanup
- Dependency or lockfile changes
- Changes or comments on PR #504