### PR TITLE
fix(transaction): treat limit as a page size in getCompletedTransactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.15.20 (TBD)
+- Fixed transaction history "load more" returning no results past the first page (#PR).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## 1.15.20 (TBD)
-- Fixed transaction history "load more" returning no results past the first page (#PR).
 
 ### Fixes
 
+- [FIX][all] **Transaction history "load more" now returns the next page instead of nothing.** `getCompletedTransactions` paginated with `transactions.slice(offset, limit)`, but `Array.prototype.slice` reads its second argument as an end index, not a page size. The only caller passes `offset = HISTORY_PAGE_SIZE * page` and `limit = HISTORY_PAGE_SIZE`, so every page after the first resolved to `slice(n, n)` — an empty range — leaving "load more" silently dead while the initial load (both args undefined) pulled the entire history at once. The slice now ends at `offset + limit`, and the undefined case still returns everything.
 - [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.
 
 ## 1.15.19 (2026-08-05)

--- a/src/lib/miden/transaction/get.ts
+++ b/src/lib/miden/transaction/get.ts
@@ -75,7 +75,11 @@ export const getCompletedTransactions = async (
   if (tokenId) {
     transactions = transactions.filter(tx => matchesTokenId(tx, tokenId));
   }
-  return transactions.slice(offset, limit);
+  // `Array.prototype.slice` takes (start, end), not (start, count). Passing
+  // `limit` as the second argument makes any page past the first resolve to
+  // an empty range.
+  const start = offset ?? 0;
+  return transactions.slice(start, limit === undefined ? undefined : start + limit);
 };
 
 export const getTransactionById = async (id: string) => {


### PR DESCRIPTION
## What

`getCompletedTransactions` paginates with `transactions.slice(offset, limit)`, but `Array.prototype.slice` treats its second argument as an **end index**, not a count.

## User impact

`History.tsx` passes `offset = HISTORY_PAGE_SIZE * page` and `limit = HISTORY_PAGE_SIZE` (`HISTORY_PAGE_SIZE = 1000`, `app/defaults.tsx`). For any page past the first this becomes `slice(1000, 1000)` → `[]`, so:

- "Load more" never returns rows and `hasMore` immediately flips to `false`
- The initial load (`offset`/`limit` undefined) pulls the entire history in one go

Users with more than one page of activity can't reach their older transactions.

## Change

Compute the end index as `offset + limit`, preserving the existing "return everything" behaviour when `limit` is `undefined`.

## Testing

I wasn't able to run the suite locally, so this is verified by reading the code path rather than by execution:

- `History.tsx:102-104` passes `offset = HISTORY_PAGE_SIZE * page` and `limit = HISTORY_PAGE_SIZE`
- `app/defaults.tsx:5` sets `HISTORY_PAGE_SIZE = 1000`
- So page 1 calls `slice(1000, 1000)`, which is `[]` for any input array
- With the change it becomes `slice(1000, 2000)`

Happy to add a unit test if you'd prefer one with the fix.