### PR TITLE
fix(dapp-browser): scope injected postMessage to the page origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- [FIX][mobile] **The injected dApp bridge no longer broadcasts wallet request payloads to every listener on the page.** `sendToNative`'s non-Capacitor fallback posted the request with `targetOrigin: '*'`. That script is injected into arbitrary third-party dApp pages, so any listener there — including cross-origin iframes — could read the request type and payload. The target origin is now scoped to `window.location.origin`, matching the existing pattern in `lib/adapter/client.ts` and the guard in `contentScript.ts`. The intended listener is on the same page, so behaviour is unchanged.
 - [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.
 
 ## 1.15.19 (2026-08-05)

--- a/src/lib/dapp-browser/injection-script.ts
+++ b/src/lib/dapp-browser/injection-script.ts
@@ -73,8 +73,11 @@ export const INJECTION_SCRIPT = `
       return;
     }
 
-    // Fallback for testing in regular browser
-    window.postMessage({ __midenNative: true, ...message }, '*');
+// Fallback for testing in regular browser. Scope the target origin: this
+  // script is injected into arbitrary third-party dApp pages, and '*' would
+  // expose wallet request payloads to every listener on the page (including
+  // cross-origin iframes). Mirrors lib/adapter/client.ts.
+  window.postMessage({ __midenNative: true, ...message }, window.location.origin);
   }
 
   // Make request to wallet


### PR DESCRIPTION
## What

`sendToNative` in the injected dApp-browser script falls back to `window.postMessage(..., '*')` when the Capacitor `mobileApp` bridge isn't present.

## User impact

This script is injected into arbitrary third-party dApp pages. A wildcard target origin means every message listener on that page — including cross-origin iframes the dApp embeds — receives the wallet request type and payload. The comment directly above (lines 69–71) already states the payload must not be exposed on the dApp page, so the wildcard broadcast works against that intent.

## Change

Target `window.location.origin` instead of `'*'`. The intended listener lives on the same page, so nothing functional changes.

This aligns the file with the patterns already used elsewhere in the repo:

- `src/lib/adapter/client.ts:309` posts to `window.location.origin`
- `src/contentScript.ts:106-108` rejects a missing or `'*'` target origin

## Testing

I wasn't able to run the suite locally, so this is reasoned from the source rather than executed:

- The changed line is the non-Capacitor fallback, reached only when `window.mobileApp` is absent, so native builds don't touch it
- The intended listener runs on the same page, and `window.location.origin` matches the page's own origin, so delivery is unchanged
- The two other places in this repo that post from injected or content-script context already scope the origin: `src/lib/adapter/client.ts:309` posts to `window.location.origin`, and `src/contentScript.ts:106-108` rejects a target origin that is missing or `'*'`

Happy to add a test asserting the target origin if that's useful.