### PR TITLE
fix(numbers): convert amounts to base units with BigNumber instead of float math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- [FIX][all] **Send, swap, and earn amounts now convert to base units exactly instead of drifting.** `stringToBigInt` parsed the user's amount with `parseFloat` and multiplied by `10 ** decimals` in double precision, which loses accuracy past ~15 significant digits: at 8 decimals `"99999999.99999999"` came out one base unit short, and at 18 decimals `"1.1"` became `1100000000000000128`. This function produces the base-unit amount that is signed and broadcast on the send, swap, and earn-deposit review screens, and the repo already defines 18-decimal bridge tokens, so the drift reached real transfers. The conversion now goes through `bignumber.js` (already imported in the file) with half-up rounding, matching the previous rounding mode.
 - [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.
 
 ## 1.15.19 (2026-08-05)

--- a/src/lib/i18n/numbers.ts
+++ b/src/lib/i18n/numbers.ts
@@ -93,17 +93,11 @@ export function formatBigInt(amount: bigint, decimals: number = MIDEN_METADATA.d
 }
 
 export function stringToBigInt(str: string, decimals: number) {
-  // Parse the string as a float
-  let num = parseFloat(str);
-
-  // Multiply by 10 to the power of the decimal count
-  num *= Math.pow(10, decimals);
-
-  // Round the number to avoid float precision issues
-  num = Math.round(num);
-
-  // Return the result as a BigInt
-  return BigInt(num);
+  // Exact base-unit conversion. `parseFloat(str) * 10 ** decimals` loses
+  // precision past ~15 significant digits — e.g. "1.1" at 18 decimals became
+  // 1100000000000000128, and "99999999.99999999" at 8 decimals lost a base
+  // unit — silently changing the amount that ends up signed and broadcast.
+  return BigInt(new BigNumber(str).shiftedBy(decimals).integerValue(BigNumber.ROUND_HALF_UP).toFixed(0));
 }
 
 export const ALEO_MICROCREDITS_TO_CREDITS = 1_000_000;


### PR DESCRIPTION
## What

`stringToBigInt` converts a user-entered amount string into base units via `parseFloat(str) * 10 ** decimals`, then `Math.round`. Doubles carry ~15-16 significant decimal digits, so the result drifts from the true value once the amount plus its decimal scale exceeds that.

Observed:

| Input | decimals | Expected | Current |
| --- | --- | --- | --- |
| `"1.1"` | 18 | 1100000000000000000 | 1100000000000000128 |
| `"99999999.99999999"` | 8 | 9999999999999999 | 9999999999999998 |
| `"12345678901.12345678"` | 8 | 1234567890112345678 | 1234567890112345600 |

## User impact

This is the only path that turns the amount a user types into the base-unit figure that gets signed and broadcast. It is called from the send review (`ReviewTransaction.tsx`, `SendManager.tsx`), the swap flow (`SwapManager.tsx`), and the earn deposit review (`EarnDepositReview.tsx`). The wallet already handles 18-decimal tokens (`BRIDGEABLE_EVM_OUTPUT_TOKEN_DECIMALS = 18`), which is where the drift is largest.

## Change

Convert through `bignumber.js` — already imported at the top of the file — using `shiftedBy(decimals)` and `ROUND_HALF_UP`, which matches the rounding the previous `Math.round` applied. Behaviour on empty input is preserved: `stringToBigInt('')` still throws, which `SwapManager.tsx:193` relies on.

## Testing

I wasn't able to run the workspace suite locally, so this is verified by evaluating the two expressions directly rather than through the test runner:

```js
for (const [s, d] of [["1.1", 18], ["99999999.99999999", 8], ["12345678901.12345678", 8]]) {
  let n = parseFloat(s); n *= Math.pow(10, d); n = Math.round(n);
  console.log(s, d, BigInt(n).toString());
}
```

That reproduces the three "Current" values in the table above exactly. The "Expected" column is the digit-shift of the same input string, which is what `BigNumber.shiftedBy` produces.

Rounding mode is preserved: the old code used `Math.round` (half away from zero for positives), and `ROUND_HALF_UP` matches it on this input domain, which is non-negative amounts.

Empty input still throws, so the guard `SwapManager.tsx` relies on is unaffected: `parseFloat('')` gave `NaN` → `BigInt(NaN)` → `RangeError`, and `new BigNumber('')` gives `NaN` → `BigInt('NaN')` → `SyntaxError`. Both throw, though the error type changes. Say the word if you'd rather I add a unit test with the table cases.