### PR TITLE
ci: stop auto-deploying feature branches to DEV (keep dev, next)

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -1,10 +1,8 @@
-name: Build Feature & Dev Branches
+name: Build Dev & Next Branches
 
 on:
   push:
     branches:
-      - 'mw-**'
-      - 'feat/**'
       - 'dev'
       - 'next'
 


### PR DESCRIPTION
## What

Drops the `feat/**` and `mw-**` wildcard patterns from `feature-branch.yml`'s push triggers, so arbitrary feature branches no longer auto-deploy to the DEV environment regardless of their base branch. Keeps the explicit `dev` and `next` branches (both continue to build → DEV).

## Why

`next` is now a first-class deploy branch (freshly reset onto `main`), and reuses the existing DEV deploy. Every random `feat/*` / `mw-*` branch triggering a DEV build+deploy on push was noise and burned CI/CD; deploys should come from the deliberate branches only.

## Note (GitHub Actions semantics)

For a `push` event, Actions runs the workflow file **as it exists on the pushed ref**. So feature branches cut *before* this merges still carry the old trigger and will keep auto-deploying until rebased onto post-merge `main`; only branches cut *after* the merge get the new behavior. No runtime/product code touched — CI trigger config only.
