### PR TITLE
Rename 'Tx ID' to 'Transaction ID' on the transaction details screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.
+- [FIX][all] Renamed the "Tx ID" field on the transaction details screen to "Transaction ID".
 
 ### Features
 

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -3390,8 +3390,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "Sende-ID",
-    "englishSource": "Tx ID"
+    "message": "Transaktions-ID",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/en/en.json
+++ b/public/_locales/en/en.json
@@ -751,7 +751,7 @@
   "network": "Network",
   "recentActivity": "Recent Activity",
   "type": "Type",
-  "txIdLabel": "Tx ID",
+  "txIdLabel": "Transaction ID",
   "notesSection": "Notes",
   "orderTracking": "Order Tracking",
   "orderStatus": "Status",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -3337,8 +3337,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "Tx ID",
-    "englishSource": "Tx ID"
+    "message": "Transaction ID",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -3391,8 +3391,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "Tx ID",
-    "englishSource": "Tx ID"
+    "message": "Transaction ID",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -3337,8 +3337,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "ID de transmisión",
-    "englishSource": "Tx ID"
+    "message": "ID de transacción",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -3389,8 +3389,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "ID d'émission",
-    "englishSource": "Tx ID"
+    "message": "ID de transaction",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -3390,8 +3390,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "送信ID",
-    "englishSource": "Tx ID"
+    "message": "トランザクションID",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -3390,8 +3390,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "전송 ID",
-    "englishSource": "Tx ID"
+    "message": "거래 ID",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -3337,8 +3337,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "Identyfikator wysyłania",
-    "englishSource": "Tx ID"
+    "message": "Identyfikator transakcji",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -3388,8 +3388,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "ID do Tx",
-    "englishSource": "Tx ID"
+    "message": "ID da transação",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "<xid=\"0\"/>",

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -3391,8 +3391,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "Идентификатор передачи",
-    "englishSource": "Tx ID"
+    "message": "Идентификатор транзакции",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -3390,8 +3390,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "Gönderim kimliği",
-    "englishSource": "Tx ID"
+    "message": "İşlem Kimliği",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -3391,8 +3391,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "Tx ID",
-    "englishSource": "Tx ID"
+    "message": "Ідентифікатор транзакції",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "Notes",

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -3390,8 +3390,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "发送 ID",
-    "englishSource": "Tx ID"
+    "message": "交易ID",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "<xid=\"0\"/>",

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -3390,8 +3390,8 @@
     "englishSource": "Type"
   },
   "txIdLabel": {
-    "message": "发送 ID",
-    "englishSource": "Tx ID"
+    "message": "交易ID",
+    "englishSource": "Transaction ID"
   },
   "notesSection": {
     "message": "<xid=\"0\"/>",


### PR DESCRIPTION
Renames the `txIdLabel` field on the transaction History Details screen from **Tx ID** to **Transaction ID** for clarity.

- `public/_locales/en/en.json`: `txIdLabel` value `Tx ID` → `Transaction ID`
- The CI `translations` job re-translates the key across the other 13 locales automatically (the generator re-translates on an `englishSource` change, not just missing keys), and commits them to this branch.
- No hardcoded strings; `HistoryDetails` renders the label only via `t('txIdLabel')`. `HistoryDetails.test.tsx` is unaffected (its `t()` mock returns the key). 45/45 tests pass; i18n lint clean.

Targets `next`.