### PR TITLE
ci(e2e): warm local-node build cache on next + raise local-e2e timeout

### DIFF
--- a/.github/workflows/pr-e2e-local.yml
+++ b/.github/workflows/pr-e2e-local.yml
@@ -28,9 +28,13 @@ jobs:
             specs: "playwright/e2e/tests/send-private.spec.ts"
     name: local-e2e (chrome)${{ matrix.name_suffix }}
     runs-on: ubuntu-latest
-    # Cold-cache runs compile miden-client-cli (~8m) + note-transport (~5m);
-    # warm-cache runs are ~20m. 45m gives the cold run headroom to seed the cache.
-    timeout-minutes: 45
+    # Cold-cache runs compile the local 0.16 node from source (~28m) + miden-client-cli
+    # (~8m) + note-transport (~5m) before any spec runs; warm-cache runs are ~20m. The
+    # node-build cache is warmed on `next` (warm-node-cache.yml) so PRs branch off a
+    # populated cache and skip the ~28m node rebuild — but keep generous headroom here so
+    # a cold cache (e.g. right after a node-rev bump) still seeds the cache without the
+    # full core suite tripping the timeout.
+    timeout-minutes: 75
     env:
       E2E_NETWORK: localhost
       MIDEN_NTX_AUTH: e2e-ntx-secret

--- a/.github/workflows/warm-node-cache.yml
+++ b/.github/workflows/warm-node-cache.yml
@@ -1,0 +1,44 @@
+name: Warm E2E node-build cache
+
+# The pr-e2e-* workflows build the local 0.16 node from source and cache it under the
+# key `local-node-build-<rev>` (see .github/actions/run-local-node). A `pull_request`
+# run only ever SAVES to that PR branch's cache scope, never to `next` — so every brand
+# new PR's first run misses the cache, recompiles the node (~28 min), and the full
+# local-e2e suite then trips its timeout before it can finish.
+#
+# Building + caching the node here on push to `next`/`main` populates the base-branch
+# cache scope that PRs restore from, so a PR branches off a WARM cache and skips the
+# cold rebuild. It only actually recompiles when the node rev (versions.env) or the
+# action changes; otherwise the action restores the existing cache and this run is a
+# fast no-op. Ongoing PR restore activity keeps the entry from evicting between bumps.
+on:
+  push:
+    branches: [next, main]
+    paths:
+      - playwright/e2e/local-stack/versions.env
+      - .github/actions/run-local-node/**
+      - .github/workflows/warm-node-cache.yml
+  workflow_dispatch: {}
+
+concurrency:
+  group: warm-node-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    name: warm-node-cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.96.1
+      # We only want the cache side effect — the action's actions/cache step saves the
+      # built node (target/test-node) as a job post-step regardless of this step's
+      # outcome. Actually starting the node is irrelevant to warming and is occasionally
+      # flaky (a service can exit during startup), so don't let it fail the warm job.
+      - name: Build + cache the local 0.16 node
+        uses: ./.github/actions/run-local-node
+        continue-on-error: true


### PR DESCRIPTION
## Problem

The pr-e2e-* workflows build the local 0.16 node from source and cache it under `local-node-build-<rev>` (`.github/actions/run-local-node`, from #521). But a `pull_request` run only saves that cache to its **own PR branch scope**, never to `next`. So **every brand-new PR's first run misses the cache**, recompiles the node (~28 min), and the full `local-e2e` suite then trips `timeout-minutes: 45` before finishing — it passes only on a re-run (cache warm). Observed on #524: `local-e2e (chrome)` canceled at 45m after passing its first 2 specs; `earn-e2e` + `local-e2e [fast blocks]` (fewer specs) squeaked in.

## Fix

1. **`warm-node-cache.yml`** — on push to `next`/`main` (when `versions.env` or the action changes) build + cache the node so it lands in the **base-branch cache scope PRs restore from**. PRs then branch off a warm cache and skip the ~28m rebuild. It's a fast no-op when the rev is unchanged; the node *start* is best-effort (`continue-on-error`) since we only want the cache side effect (the `actions/cache` save runs as a job post-step regardless).
2. **Raise `pr-e2e-local` `timeout-minutes` 45 → 75** as a safety net so a genuinely cold cache (e.g. right after a node-rev bump) still seeds without the full core suite tripping the timeout. Also corrected the stale comment, which predated the #521 node-from-source build.

Node-infra only; no product change.