### PR TITLE
feat(onboarding): dev-gated 'No guardian' account option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Features
 
 - Add hidden developer endpoint configuration (7-tap the Welcome logo during onboarding) to override RPC / prover / note-transport / faucet / explorer / guardian endpoints and network ID; read-only view with reset-to-defaults in Settings.
+- Dev-only: a "No guardian" option can be enabled from developer settings (7-tap the onboarding logo), which then shows a "No guardian" card on the Choose-your-guardian screen; selecting it creates a private single-key account with no guardian co-signer.
 
 ## 1.15.19 (2026-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [FIX][all] Renamed the "Tx ID" field on the transaction details screen to "Transaction ID".
 - [FIX][extension] **Developer endpoint settings no longer show "No response" for reachable endpoints.** The reachability probe used a `no-cors` fetch, which an MV3 extension page can never resolve — Chrome routes every extension fetch through the host_permissions/CORS path, so `no-cors` throws `Failed to fetch` and every gRPC field (RPC, prover, note-transport, faucet, explorer, guardian) reported unreachable even when the host was up. The probe now leads with a default-mode fetch (which the extension's `*.miden.io` host permissions and permissive-CORS hosts satisfy) and falls back to `no-cors` for non-extension webviews (Capacitor/Tauri).
 - [FIX][extension] Centered the Save / Reset action block at the bottom of the developer settings screen (the fixed-width buttons were left-aligned on the wide full-page view).
+- [FIX][extension] Developer-settings endpoint overrides now actually take effect. Saving an override only wrote to the frontend's cache/storage — the service worker runs in a separate JS realm with its own override cache (loaded once at boot) and a create-once Miden client singleton with endpoints baked in at creation time, so it kept hitting the build-default RPC until a full reload. Saving now nudges the service worker to reload its override cache and rebuild its Miden client, so the override takes effect immediately.
 
 ### Features
 

--- a/docs/superpowers/plans/2026-08-10-dev-no-guardian-onboarding.md
+++ b/docs/superpowers/plans/2026-08-10-dev-no-guardian-onboarding.md
@@ -1,0 +1,498 @@
+# Dev-gated "No guardian" onboarding option — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a developer-settings checkbox that, when enabled, exposes a selectable "No guardian" card in the onboarding "Choose your guardian" screen; selecting it creates a private single-key (`WalletType.OffChain`) account with no guardian co-signer.
+
+**Architecture:** UI + flow-wiring only — the non-guardian account path already exists (`Vault.spawn` else-branch → `createMidenWallet`). A new boolean `allowNoGuardian` rides on the existing `EndpointOverride` (persisted dev-settings object). The onboarding navigator reads it and passes a prop to `ChooseGuardianScreen`; selecting the card submits a sentinel id that `Welcome.tsx` routes to `WalletType.OffChain`.
+
+**Tech Stack:** React + TypeScript, Zustand, react-i18next, Jest + React Testing Library. Repo `/Users/celrisen/miden/miden-wallet-no-guardian-dev`, branch `feat/dev-no-guardian-onboarding`, base `next`.
+
+## Global Constraints
+
+- **No `any`, no `as`** — use concrete types (CLAUDE.md code style).
+- **All user-facing text via i18n** (`t('key')`); add new keys to `public/_locales/en/en.json` (flat format). `yarn lint:i18n` gates non-i18n strings.
+- **Default-off:** when the flag is off, onboarding must be byte-identical to today (no card, no behavior change).
+- **No backend/SDK/multisig-client changes.** Reuse the existing `WalletType.OffChain` create path.
+- **Sentinel value is exactly `'no-guardian'`**, exported as `NO_GUARDIAN_ID` from `src/screens/onboarding/types.ts`.
+- **No-guardian account type = `WalletType.OffChain`** (private single-key).
+- **Do not touch** `isEndpointOverride` (legacy persisted overrides lacking the new field must still load).
+- Prettier: 120 cols, single quotes, semicolons, trailing commas. Commit messages single-line, never signed / no `Co-Authored-By`. Never `git push` without explicit request. Leave the `wallet-devnet-build` worktree untouched.
+
+## Prerequisite (one-time, before Task 1)
+
+The worktree is fresh — install dependencies once. Deps are identical to the `wallet-devnet-build` worktree (same lockfile; #526/#527 changed no deps), so either is fine:
+
+```bash
+cd /Users/celrisen/miden/miden-wallet-no-guardian-dev
+# Option A (fast): borrow identical-lockfile deps
+ln -s /Users/celrisen/miden/wallet-devnet-build/node_modules node_modules
+# Option B: a clean install
+# source ~/.nvm/nvm.sh && nvm use 22 && yarn install --frozen-lockfile
+```
+
+Node ≥22 (`source ~/.nvm/nvm.sh && nvm use 22`). Test runner is `yarn test <path>` (jest). Typecheck: `npx tsc --noEmit -p tsconfig.json`. Lint: `npx eslint <files>` and `yarn lint:i18n`.
+
+## File Structure
+
+- `src/lib/miden-chain/effective-endpoints.ts` — add `allowNoGuardian` to the override type + default + getter. **(Task 1)**
+- `src/lib/miden-chain/effective-endpoints.test.ts` — getter/default/legacy tests. **(Task 1)**
+- `src/screens/onboarding/types.ts` — export `NO_GUARDIAN_ID` sentinel. **(Task 3)**
+- `src/screens/developer-settings/DeveloperSettings.tsx` — checkbox row. **(Task 2)**
+- `src/screens/developer-settings/DeveloperSettings.test.tsx` — checkbox tests. **(Task 2)**
+- `src/screens/onboarding/common/ChooseGuardian.tsx` — `showNoGuardianOption` prop + card + sentinel submit. **(Task 3)**
+- `src/screens/onboarding/common/ChooseGuardian.test.tsx` — card tests. **(Task 3)**
+- `src/screens/onboarding/navigator.tsx` — pass the prop gated on the getter. **(Task 4)**
+- `src/app/pages/Welcome.tsx` — route the sentinel to `WalletType.OffChain`. **(Task 4)**
+- `src/app/pages/Welcome.test.tsx` — no-guardian handler test. **(Task 4)**
+- `public/_locales/en/en.json` — new i18n keys. **(Tasks 2, 3)**
+- `CHANGELOG.md` — one-liner. **(Task 4)**
+
+---
+
+### Task 1: `allowNoGuardian` on the override store
+
+**Files:**
+- Modify: `src/lib/miden-chain/effective-endpoints.ts`
+- Test: `src/lib/miden-chain/effective-endpoints.test.ts`
+
+**Interfaces:**
+- Produces: `EndpointOverride.allowNoGuardian: boolean`; `getEffectiveAllowNoGuardian(): boolean`; `buildDefaultOverrideFor(...)` now includes `allowNoGuardian: false`.
+- Consumes: existing `overrideCache`, `loadEndpointOverrides`, `ENDPOINT_OVERRIDE_STORAGE_KEY`.
+
+- [ ] **Step 1: Write failing tests** — append to `src/lib/miden-chain/effective-endpoints.test.ts`. It already mocks the storage adapter via `mockKvStore` and imports the network maps from `./constants`. Add imports for the symbols under test if not already imported (`getEffectiveAllowNoGuardian`, `buildDefaultOverrideFor`, `loadEndpointOverrides`, `ENDPOINT_OVERRIDE_STORAGE_KEY`, `EndpointOverride` from `./effective-endpoints`), then add:
+
+```ts
+describe('getEffectiveAllowNoGuardian', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(mockKvStore)) delete mockKvStore[k];
+  });
+
+  it('defaults to false when no override is active', async () => {
+    await loadEndpointOverrides(); // nothing stored -> cache null
+    expect(getEffectiveAllowNoGuardian()).toBe(false);
+  });
+
+  it('reflects a stored override value', async () => {
+    mockKvStore[ENDPOINT_OVERRIDE_STORAGE_KEY] = {
+      ...buildDefaultOverrideFor(MIDEN_NETWORK_NAME.DEVNET),
+      allowNoGuardian: true
+    };
+    await loadEndpointOverrides();
+    expect(getEffectiveAllowNoGuardian()).toBe(true);
+  });
+
+  it('reads false from a legacy override that predates the field', async () => {
+    const legacy: Record<string, unknown> = { ...buildDefaultOverrideFor(MIDEN_NETWORK_NAME.DEVNET) };
+    delete legacy.allowNoGuardian;
+    mockKvStore[ENDPOINT_OVERRIDE_STORAGE_KEY] = legacy;
+    await loadEndpointOverrides();
+    expect(getEffectiveAllowNoGuardian()).toBe(false);
+  });
+
+  it('buildDefaultOverrideFor includes allowNoGuardian:false', () => {
+    expect(buildDefaultOverrideFor(MIDEN_NETWORK_NAME.DEVNET).allowNoGuardian).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `yarn test src/lib/miden-chain/effective-endpoints.test.ts`
+Expected: FAIL — `getEffectiveAllowNoGuardian is not a function` / `allowNoGuardian` undefined.
+
+- [ ] **Step 3: Implement** in `src/lib/miden-chain/effective-endpoints.ts`:
+
+Add the field to the interface (after the `guardianUrl` line):
+```ts
+  guardianUrl: string; // '' = no custom guardian
+  allowNoGuardian: boolean; // dev-only: expose a "No guardian" card in onboarding
+  networkName: MIDEN_NETWORK_NAME; // the "network id": drives NetworkId + endpoint-default seeding
+```
+
+Add the default inside `buildDefaultOverrideFor`'s returned object (after `guardianUrl`):
+```ts
+    guardianUrl: MIDEN_GUARDIAN_ENDPOINTS.get(network)?.[0] ?? '',
+    allowNoGuardian: false,
+    networkName: network,
+```
+
+Add the getter (immediately after `getEffectiveGuardianUrl`):
+```ts
+/** Dev-only: whether onboarding should offer a "No guardian" account option. */
+export function getEffectiveAllowNoGuardian(): boolean {
+  return overrideCache?.allowNoGuardian ?? false;
+}
+```
+
+**Do NOT modify `isEndpointOverride`** — it deep-checks only `rpcUrl`/`networkName`, so legacy objects still pass; requiring the new boolean would reject a user's saved override.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `yarn test src/lib/miden-chain/effective-endpoints.test.ts`
+Expected: PASS (all, including the 4 new cases).
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npx tsc --noEmit -p tsconfig.json
+git add src/lib/miden-chain/effective-endpoints.ts src/lib/miden-chain/effective-endpoints.test.ts
+git commit -m "feat(dev-endpoints): add allowNoGuardian override flag + getter"
+```
+
+---
+
+### Task 2: Dev-settings checkbox
+
+**Files:**
+- Modify: `src/screens/developer-settings/DeveloperSettings.tsx`
+- Modify: `public/_locales/en/en.json`
+- Test: `src/screens/developer-settings/DeveloperSettings.test.tsx`
+
+**Interfaces:**
+- Consumes: `EndpointOverride.allowNoGuardian` (Task 1), `Checkbox` from `components/Checkbox`.
+- Produces: a `data-testid="dev-allow-no-guardian"` row that toggles `form.allowNoGuardian` and persists it via the existing `applyEndpointOverride(form)` save path.
+
+> **Note:** `Checkbox` (`src/components/Checkbox.tsx`) has its internal `onChange` commented out, so it is display-only. Drive the toggle from the wrapping row's `onClick`, passing `value={form.allowNoGuardian}` to the `Checkbox` purely as the visual indicator.
+
+- [ ] **Step 1: Write failing tests** — in `src/screens/developer-settings/DeveloperSettings.test.tsx`:
+
+First, mock the `Checkbox` (avoids rendering the real `Icon`/SVG) — add near the other `jest.mock`s at the top:
+```ts
+jest.mock('components/Checkbox', () => ({
+  Checkbox: ({ value }: { value: boolean }) => <span data-testid="checkbox" data-checked={String(value)} />
+}));
+```
+
+Then extend the existing `buildDefaultOverrideFor` mock object (in the `jest.mock('lib/miden-chain/effective-endpoints', …)` factory) to include the new field so `form.allowNoGuardian` is defined:
+```ts
+      guardianUrl: `https://guardian.${n}`,
+      allowNoGuardian: false,
+      networkName: n,
+```
+(Match the existing object's field set; add `allowNoGuardian: false` alongside the other defaults.)
+
+Add the tests:
+```ts
+describe('DeveloperSettings — allowNoGuardian', () => {
+  beforeEach(() => {
+    applyEndpointOverride.mockClear();
+    mockUseConfirm.mockReturnValue(confirm);
+  });
+
+  it('renders the no-guardian toggle row', () => {
+    render(<DeveloperSettings />);
+    expect(screen.getByTestId('dev-allow-no-guardian')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox')).toHaveAttribute('data-checked', 'false');
+  });
+
+  it('persists allowNoGuardian=true when toggled on and saved', async () => {
+    render(<DeveloperSettings />);
+    fireEvent.click(screen.getByTestId('dev-allow-no-guardian'));
+    fireEvent.click(screen.getByTestId('dev-endpoints-save'));
+    await waitFor(() => expect(applyEndpointOverride).toHaveBeenCalled());
+    expect(applyEndpointOverride).toHaveBeenCalledWith(expect.objectContaining({ allowNoGuardian: true }));
+  });
+
+  it('disables the toggle row in read-only mode', () => {
+    render(<DeveloperSettings readOnly />);
+    expect(screen.getByTestId('dev-allow-no-guardian')).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `yarn test src/screens/developer-settings/DeveloperSettings.test.tsx`
+Expected: FAIL — `Unable to find … dev-allow-no-guardian`.
+
+- [ ] **Step 3: Implement** in `src/screens/developer-settings/DeveloperSettings.tsx`:
+
+Add the import (with the other `components/*` imports):
+```ts
+import { Checkbox } from 'components/Checkbox';
+```
+
+Insert the row inside the scrollable form, immediately **after** the Network ID `</div>` block (i.e. after the closing `</div>` of the `flex flex-col gap-2` that wraps the Network ID `TabPicker`, and before the scroll-area's closing `</div>`):
+```tsx
+        <button
+          type="button"
+          disabled={readOnly}
+          data-testid="dev-allow-no-guardian"
+          onClick={
+            readOnly
+              ? undefined
+              : () =>
+                  setForm(prev => ({
+                    ...prev,
+                    allowNoGuardian: !prev.allowNoGuardian,
+                    presetName: CUSTOM_PRESET
+                  }))
+          }
+          className="flex items-center justify-between gap-3 text-left"
+        >
+          <span className="text-sm font-medium text-heading-gray">{t('devAllowNoGuardian')}</span>
+          <Checkbox value={form.allowNoGuardian} />
+        </button>
+```
+
+- [ ] **Step 4: Add i18n key** to `public/_locales/en/en.json` (next to the other `devEndpoint*` keys, keeping valid JSON / trailing commas):
+```json
+  "devAllowNoGuardian": "Allow 'No guardian' option in onboarding",
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `yarn test src/screens/developer-settings/DeveloperSettings.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Gates + commit**
+
+```bash
+npx tsc --noEmit -p tsconfig.json
+npx eslint src/screens/developer-settings/DeveloperSettings.tsx src/screens/developer-settings/DeveloperSettings.test.tsx
+yarn lint:i18n
+git add src/screens/developer-settings/DeveloperSettings.tsx src/screens/developer-settings/DeveloperSettings.test.tsx public/_locales/en/en.json
+git commit -m "feat(dev-settings): add 'Allow No guardian' checkbox"
+```
+
+---
+
+### Task 3: "No guardian" card in ChooseGuardian
+
+**Files:**
+- Modify: `src/screens/onboarding/types.ts` (export sentinel)
+- Modify: `src/screens/onboarding/common/ChooseGuardian.tsx`
+- Modify: `public/_locales/en/en.json`
+- Test: `src/screens/onboarding/common/ChooseGuardian.test.tsx`
+
+**Interfaces:**
+- Produces: `NO_GUARDIAN_ID = 'no-guardian'` (from `types.ts`); `ChooseGuardianScreenProps.showNoGuardianOption?: boolean`. When the card is selected and Continue pressed, `onSubmit({ guardianId: NO_GUARDIAN_ID, guardianEndpoint: '' })`.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Add the sentinel** to `src/screens/onboarding/types.ts` (top-level, near the enums):
+```ts
+/** Sentinel guardianId meaning "create a no-guardian account" (dev-gated). */
+export const NO_GUARDIAN_ID = 'no-guardian';
+```
+(Placed in `types.ts` so `Welcome.tsx` can import it without pulling in `ChooseGuardian`'s module graph.)
+
+- [ ] **Step 2: Write failing tests** — in `src/screens/onboarding/common/ChooseGuardian.test.tsx` (it mocks `getGuardianOptionsForNetwork`, renders `<button data-testid="continue-button">` for `Button`, and echoes `t(key)`):
+```ts
+describe('ChooseGuardian — no-guardian option', () => {
+  const oneOption = [{ id: 'open-zeppelin', name: 'OZ', operatedBy: 'OZ', location: 'US', endpoint: 'https://g' }];
+
+  it('hides the No guardian card by default', () => {
+    mockGetGuardianOptions.mockReturnValue(oneOption);
+    render(<ChooseGuardianScreen onSubmit={jest.fn()} />);
+    expect(screen.queryByTestId('choose-no-guardian')).toBeNull();
+  });
+
+  it('shows the card and submits the sentinel when enabled', () => {
+    mockGetGuardianOptions.mockReturnValue(oneOption);
+    const onSubmit = jest.fn();
+    render(<ChooseGuardianScreen onSubmit={onSubmit} showNoGuardianOption />);
+    fireEvent.click(screen.getByTestId('choose-no-guardian'));
+    fireEvent.click(screen.getByTestId('continue-button'));
+    expect(onSubmit).toHaveBeenCalledWith({ guardianId: 'no-guardian', guardianEndpoint: '' });
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `yarn test src/screens/onboarding/common/ChooseGuardian.test.tsx`
+Expected: FAIL — `choose-no-guardian` not found.
+
+- [ ] **Step 4: Implement** in `src/screens/onboarding/common/ChooseGuardian.tsx`:
+
+Import the sentinel (with the other imports):
+```ts
+import { NO_GUARDIAN_ID } from 'screens/onboarding/types';
+```
+(If the repo's import style for this file uses a relative path, use `'../types'` to match neighbors.)
+
+Add the prop to the interface (after `allowCustomEndpoint`):
+```ts
+  // Dev-gated (onboarding only): show a selectable "No guardian" card that
+  // creates a private single-key account with no guardian co-signer.
+  showNoGuardianOption?: boolean;
+```
+Destructure it in the component signature with a default:
+```ts
+  allowCustomEndpoint = false,
+  showNoGuardianOption = false
+}) => {
+```
+
+Guard the sentinel at the **top** of `handleContinue` (before the `isCustom` branch):
+```ts
+  const handleContinue = () => {
+    if (selectedId === NO_GUARDIAN_ID) {
+      onSubmit?.({ guardianId: NO_GUARDIAN_ID, guardianEndpoint: '' });
+      return;
+    }
+    if (isCustom) {
+```
+
+Render the card immediately **after** the options grid `</div>` (the `grid grid-cols-…` block that closes at the end of `options.map`), before the `allowCustomEndpoint` block:
+```tsx
+        {showNoGuardianOption && (
+          <button
+            type="button"
+            onClick={() => handleSelect(NO_GUARDIAN_ID)}
+            data-testid="choose-no-guardian"
+            className={cn(
+              'mt-4 flex flex-col items-start rounded-[20px] border-2 p-4 text-left transition-all duration-150 shrink-0',
+              selectedId === NO_GUARDIAN_ID ? 'border-primary-500 border-4' : 'border-[#E3E3E3] dark:border-grey-800'
+            )}
+          >
+            <span className="text-base font-semibold text-heading-gray">{t('noGuardianOptionTitle')}</span>
+            <span className="mt-1 text-xs text-gray-secondary dark:text-pure-white">
+              {t('noGuardianOptionSubtitle')}
+            </span>
+          </button>
+        )}
+```
+
+- [ ] **Step 5: Add i18n keys** to `public/_locales/en/en.json` (near `chooseYourGuardian`):
+```json
+  "noGuardianOptionTitle": "No guardian",
+  "noGuardianOptionSubtitle": "Advanced — recover with your seed phrase only. No guardian co-signer.",
+```
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `yarn test src/screens/onboarding/common/ChooseGuardian.test.tsx`
+Expected: PASS (new + existing guardian tests unchanged).
+
+- [ ] **Step 7: Gates + commit**
+
+```bash
+npx tsc --noEmit -p tsconfig.json
+npx eslint src/screens/onboarding/common/ChooseGuardian.tsx src/screens/onboarding/common/ChooseGuardian.test.tsx src/screens/onboarding/types.ts
+yarn lint:i18n
+git add src/screens/onboarding/common/ChooseGuardian.tsx src/screens/onboarding/common/ChooseGuardian.test.tsx src/screens/onboarding/types.ts public/_locales/en/en.json
+git commit -m "feat(onboarding): dev-gated 'No guardian' card in ChooseGuardian"
+```
+
+---
+
+### Task 4: Wire the flow (navigator + Welcome) + CHANGELOG
+
+**Files:**
+- Modify: `src/screens/onboarding/navigator.tsx`
+- Modify: `src/app/pages/Welcome.tsx`
+- Modify: `CHANGELOG.md`
+- Test: `src/app/pages/Welcome.test.tsx`
+
+**Interfaces:**
+- Consumes: `getEffectiveAllowNoGuardian()` (Task 1), `showNoGuardianOption` prop (Task 3), `NO_GUARDIAN_ID` (Task 3), existing `WalletType.OffChain`, `putToStorage`, `GUARDIAN_URL_STORAGE_KEY`.
+
+> **No new mocks needed in `navigator.test.tsx`:** `effective-endpoints` is already in the navigator's import graph via `ChooseGuardian → constants`, and `getEffectiveAllowNoGuardian()` returns `false` with no override — so existing navigator tests render `showNoGuardianOption={false}` (no card) unchanged.
+
+- [ ] **Step 1: Write the failing Welcome test** — in `src/app/pages/Welcome.test.tsx`, inside the existing `describe('Welcome — choose-guardian-submit', …)` block. It uses `renderWelcome()`, `dispatch(action)`, `mockPutToStorage`, `mockRegisterWallet`, and `GUARDIAN_URL_STORAGE_KEY` mocked to `'guardian_url_setting'`:
+```ts
+  it('routes a No guardian selection to an OffChain wallet without storing a guardian endpoint', async () => {
+    await renderWelcome();
+    await dispatch({ id: 'setup-passcode-submit', payload: '111111' });
+    mockPutToStorage.mockClear();
+    await dispatch({ id: 'choose-guardian-submit', payload: { guardianId: 'no-guardian', guardianEndpoint: '' } });
+    // never persists a real guardian endpoint
+    expect(mockPutToStorage).not.toHaveBeenCalledWith('guardian_url_setting', expect.stringContaining('http'));
+    // driving to confirmation registers a private, no-guardian (OffChain) wallet
+    await dispatch({ id: 'confirmation' });
+    expect(mockRegisterWallet).toHaveBeenCalledWith(WalletType.OffChain, '111111', expect.any(String), false);
+  });
+```
+(Mirror the adjacent guardian test at lines ~430–437 for the passcode→confirmation sequence; if `confirmation` needs the mnemonic present, follow whatever the neighboring `registerWallet`-asserting test does to reach `register()`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `yarn test src/app/pages/Welcome.test.tsx -t "No guardian"`
+Expected: FAIL — `registerWallet` called with `Guardian`, not `OffChain` (handler not yet branching).
+
+- [ ] **Step 3: Implement navigator** — `src/screens/onboarding/navigator.tsx`:
+
+Add the import (with the other `lib/*` imports):
+```ts
+import { getEffectiveAllowNoGuardian } from 'lib/miden-chain/effective-endpoints';
+```
+Pass the prop at the `ChooseGuardian` case (currently `return <ChooseGuardianScreen onSubmit={onChooseGuardianSubmit} />;`):
+```tsx
+      case OnboardingStep.ChooseGuardian:
+        return (
+          <ChooseGuardianScreen
+            onSubmit={onChooseGuardianSubmit}
+            showNoGuardianOption={getEffectiveAllowNoGuardian()}
+          />
+        );
+```
+
+- [ ] **Step 4: Implement Welcome handler** — `src/app/pages/Welcome.tsx`:
+
+Add the sentinel import (with the `screens/onboarding/types` import already on line 22, extend it):
+```ts
+import { NO_GUARDIAN_ID, OnboardingAction, OnboardingStep, OnboardingType, WalletType } from 'screens/onboarding/types';
+```
+Replace the first two lines of the `case 'choose-guardian-submit':` block (the unconditional `putToStorage` + `setWalletType(WalletType.Guardian)`) with the branch, leaving the `if (password) … else …` tail unchanged:
+```ts
+      case 'choose-guardian-submit':
+        if (action.payload.guardianId === NO_GUARDIAN_ID) {
+          // No guardian: private single-key (OffChain) account. Clear any stale
+          // guardian endpoint; the non-guardian spawn branch ignores it anyway.
+          await putToStorage(GUARDIAN_URL_STORAGE_KEY, '');
+          setWalletType(WalletType.OffChain);
+        } else {
+          await putToStorage(GUARDIAN_URL_STORAGE_KEY, action.payload.guardianEndpoint);
+          setWalletType(WalletType.Guardian);
+        }
+        if (password) {
+          navigate('/#confirmation');
+        } else {
+          const hardwareAvailable = await checkHardwareSecurityAvailable();
+          if (hardwareAvailable) {
+            setPassword('__HARDWARE_ONLY__');
+            navigate('/#confirmation');
+          } else {
+            navigate('/#create-password');
+          }
+        }
+        break;
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `yarn test src/app/pages/Welcome.test.tsx src/screens/onboarding/navigator.test.tsx`
+Expected: PASS (new no-guardian test + all existing; navigator suite unaffected).
+
+- [ ] **Step 6: CHANGELOG** — add under the `## 1.15.20 (TBD)` section (verify it's still the unreleased heading via `gh api repos/0xMiden/wallet/releases/latest`; create a higher `(TBD)` section if 1.15.20 has shipped). Under `### Features`:
+```md
+- Dev-only: a "No guardian" option can be enabled from developer settings (7-tap the onboarding logo), which then shows a "No guardian" card on the Choose-your-guardian screen; selecting it creates a private single-key account with no guardian co-signer.
+```
+
+- [ ] **Step 7: Full gates + commit**
+
+```bash
+npx tsc --noEmit -p tsconfig.json
+npx eslint src/screens/onboarding/navigator.tsx src/app/pages/Welcome.tsx src/app/pages/Welcome.test.tsx
+yarn lint:i18n
+git add src/screens/onboarding/navigator.tsx src/app/pages/Welcome.tsx src/app/pages/Welcome.test.tsx CHANGELOG.md
+git commit -m "feat(onboarding): route 'No guardian' selection to an OffChain account"
+```
+
+---
+
+## Manual verification (after all tasks)
+
+1. Build the devnet extension in **this** worktree (not `wallet-devnet-build`):
+   `MIDEN_NETWORK=devnet yarn build:extension` — verify no errors, `dist/chrome_unpacked/manifest.json` present.
+2. Load unpacked, start onboarding, 7-tap the logo → Developer Settings → enable **Allow 'No guardian' option** → Save.
+3. Create a new wallet → on Choose-your-guardian, confirm the **No guardian** card appears; select it → Continue → finish onboarding.
+4. Confirm the account was created and Settings shows **no** guardian section (i.e. `type: OffChain`). With the dev flag **off**, confirm the card does not appear and onboarding is unchanged.
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** dev flag (Task 1), checkbox (Task 2), card + onboarding-only gating (Tasks 3–4), OffChain wiring (Task 4), scope/non-goals honored (no Settings-switch card — the reuse simply doesn't pass the prop), tests per component, CHANGELOG + manual steps. ✓
+- **Type consistency:** `allowNoGuardian` (boolean), `getEffectiveAllowNoGuardian()`, `showNoGuardianOption`, `NO_GUARDIAN_ID = 'no-guardian'`, `WalletType.OffChain` — used identically across tasks. `OnboardingAction`'s `choose-guardian-submit` payload already types `guardianId: string` (no types change needed for the read). ✓
+- **Placeholders:** none — every code step has concrete code; sentinel lives in `types.ts` to avoid import-graph breakage; `Checkbox` display-only caveat captured. ✓

--- a/docs/superpowers/specs/2026-08-10-dev-no-guardian-onboarding-design.md
+++ b/docs/superpowers/specs/2026-08-10-dev-no-guardian-onboarding-design.md
@@ -1,0 +1,105 @@
+# Dev-gated "No guardian" onboarding option — Design
+
+**Goal:** Add a developer-settings checkbox that, when enabled, exposes a "No guardian" card in the onboarding "Choose your guardian" screen. Selecting it creates a **private, single-key (`WalletType.OffChain`) account** with no guardian co-signer.
+
+**Status:** Approved design (2026-08-10). Base branch: `next`. Default-off; zero change to normal onboarding when the flag is off.
+
+## Context / findings (why this is UI-only)
+
+The wallet already fully supports non-guardian accounts; only the onboarding UI path is missing.
+
+- `WalletType` (`src/screens/onboarding/types.ts:20-24`): `OffChain` (private), `Guardian`, `OnChain` (public).
+- `Vault.spawn` (`src/lib/miden/back/vault.ts:439-475`) branches: `Guardian` → `createGuardianMidenWallet`; **else → `createMidenWallet(walletType, walletSeed, NEW_ACCOUNT_AUTH_SCHEME)`** which builds a single-key account via the SDK `accounts.create({ storage: 'private' | 'public' })` (`src/lib/miden/sdk/miden-client-interface.ts:249-266`). No multisig, no guardian keys, no `registerOnGuardian`.
+- Guardian-specific UI/logic is already gated on `account.type === WalletType.Guardian` (e.g. `Settings.tsx`, `KeysSettings.tsx`, guardian sync / hot-key rotation), so a non-guardian account cleanly skips all of it.
+- Non-guardian creation is already exercised by the E2E bypass (`Welcome.tsx:150-194`, defaults to `OffChain`) and the Import flow's OnChain option (`ImportRecoveryMethod.tsx` → `Welcome.tsx:387-393`).
+- The gap: the onboarding create flow always routes through `ChooseGuardian` and the `choose-guardian-submit` handler **unconditionally** does `setWalletType(WalletType.Guardian)` (`src/app/pages/Welcome.tsx:324-340`).
+
+Dev-settings override mechanism (PR #512):
+- `EndpointOverride` type + all read/write live in `src/lib/miden-chain/effective-endpoints.ts`. Persisted under key `endpoint_overrides` via the platform storage adapter (JSON — a boolean rides along with no adapter change). Read synchronously from a module-level `overrideCache` via `getEffective*` getters; hydrated once at startup (`front/provider.tsx`, `back/main.ts`).
+- Editor: `src/screens/developer-settings/DeveloperSettings.tsx` (form is one `EndpointOverride` in `useState`; fields are `Input`s + `TabPicker`s; `setField` marks preset `custom`). Read-only Settings variant via the `readOnly` prop.
+
+## Components & changes
+
+### 1. Dev flag (`allowNoGuardian`)
+
+`src/lib/miden-chain/effective-endpoints.ts`:
+- Add `allowNoGuardian: boolean;` to the `EndpointOverride` interface.
+- `buildDefaultOverrideFor(...)`: set `allowNoGuardian: false`.
+- `isEndpointOverride(...)`: **do NOT** add `allowNoGuardian` to the strict guard. The guard already deep-checks only `rpcUrl`/`networkName`, so an override persisted before this field existed still passes; requiring the new boolean would reject legacy objects and wipe a user's saved endpoints. Missing/invalid values are handled by the getter's `?? false` fallback.
+- Add getter:
+  ```ts
+  export function getEffectiveAllowNoGuardian(): boolean {
+    return overrideCache?.allowNoGuardian ?? false;
+  }
+  ```
+
+`src/screens/developer-settings/DeveloperSettings.tsx`:
+- Render a `Checkbox` (`src/components/Checkbox.tsx`) bound to `form.allowNoGuardian`, placed after the Network ID picker, above the footer. Label via new i18n key `devAllowNoGuardian` ("Allow 'No guardian' option in onboarding"), with a short helper line if the design has room.
+- `onChange` mirrors `setField`: `setForm(prev => ({ ...prev, allowNoGuardian: v, presetName: CUSTOM_PRESET }))`.
+- Disabled when `readOnly` (mirrors the inputs). Read-only view still reflects the saved value.
+- `initial`/`getActiveOverride()` already returns the full object, so `form.allowNoGuardian` is defined via `buildDefaultOverrideFor`.
+
+i18n: add `devAllowNoGuardian` (+ optional helper key) to `public/_locales/en/en.json`.
+
+### 2. "No guardian" card (`src/screens/onboarding/common/ChooseGuardian.tsx`)
+
+- Add prop `showNoGuardianOption?: boolean` (default `false`).
+- When true, render one extra selectable card **below** the guardian cards, styled like the others, with a sentinel id `NO_GUARDIAN_ID = 'no-guardian'`: title `t('noGuardianOptionTitle')` ("No guardian"), subtitle `t('noGuardianOptionSubtitle')` ("Advanced — recover with your seed phrase only. No guardian co-signer."). It participates in the same `selectedId` selection state and `handleSelect`.
+- `handleContinue`: check the sentinel **before** the `options.find(...) ?? options[0]` fallback:
+  ```ts
+  if (selectedId === NO_GUARDIAN_ID) {
+    onSubmit?.({ guardianId: NO_GUARDIAN_ID, guardianEndpoint: '' });
+    return;
+  }
+  ```
+- Do **not** auto-select the no-guardian card by default; the existing default (first guardian / current) is unchanged, so with the flag off behavior is byte-identical.
+- New i18n keys: `noGuardianOptionTitle`, `noGuardianOptionSubtitle`.
+
+### 3. Gating (onboarding-only)
+
+`src/screens/onboarding/navigator.tsx` (`OnboardingStep.ChooseGuardian` case, ~:201-202):
+- Pass `showNoGuardianOption={getEffectiveAllowNoGuardian()}` to `<ChooseGuardianScreen>`. Import the getter from `lib/miden-chain/effective-endpoints`.
+- The Settings guardian-switch reuse (`src/app/templates/GuardianSettings.tsx`) does **not** pass the prop → stays `false`. This combines both gates (dev-flag ON + onboarding context) in one place.
+
+### 4. Wiring (`src/app/pages/Welcome.tsx`, `choose-guardian-submit` ~:324-340)
+
+- Branch on the sentinel:
+  ```ts
+  case 'choose-guardian-submit':
+    if (action.payload.guardianId === NO_GUARDIAN_ID) {
+      await removeFromStorage(GUARDIAN_URL_STORAGE_KEY); // ensure no stale endpoint
+      setWalletType(WalletType.OffChain);
+    } else {
+      await putToStorage(GUARDIAN_URL_STORAGE_KEY, action.payload.guardianEndpoint);
+      setWalletType(WalletType.Guardian);
+    }
+    // ...unchanged: password ? navigate('/#confirmation') : biometric branch
+  ```
+  (Use the existing storage remove helper; if none exists, `putToStorage(GUARDIAN_URL_STORAGE_KEY, '')` — the non-guardian spawn branch ignores it either way.)
+- Export/share `NO_GUARDIAN_ID` from a single module (e.g. alongside `ChooseGuardian` or a small shared constant) so the screen and `Welcome` agree on the sentinel.
+- Everything after is unchanged: `register()` → `registerWallet(WalletType.OffChain, …)` → `Vault.spawn` else-branch creates the private single-key account.
+
+## Data flow
+
+Dev settings: `Checkbox` → `form.allowNoGuardian` → `applyEndpointOverride(form)` → `overrideCache` (sync) + persisted storage.
+
+Onboarding: navigator reads `getEffectiveAllowNoGuardian()` → prop → card rendered → user selects → `Continue` → `onSubmit({guardianId:'no-guardian', endpoint:''})` → `Welcome` sets `WalletType.OffChain`, skips guardian endpoint → `register()` → `Vault.spawn` else-branch → private single-key account.
+
+## Scope / non-goals
+
+- **In:** dev checkbox, onboarding "No guardian" card, create-flow wiring to `OffChain`.
+- **Out:** Import flow (already has OnChain/Guardian selector); Settings guardian-switch (must not offer no-guardian); public (`OnChain`) no-guardian variant; converting an existing guardian account to no-guardian; wiring the dead `SelectRecoveryMethod` screen. No backend/SDK/multisig-client changes.
+
+## Testing
+
+- **Unit — `effective-endpoints.test.ts`:** `getEffectiveAllowNoGuardian()` returns `false` with no override and the stored value when set; `buildDefaultOverrideFor` includes `allowNoGuardian:false`; a legacy override object lacking the field still loads (guard tolerance) and reads as `false`.
+- **Unit — `DeveloperSettings.test.tsx`:** checkbox renders, toggling updates form state + marks preset custom, value persists through `applyEndpointOverride` on save, disabled in read-only mode.
+- **Unit — `ChooseGuardian.test.tsx`:** no-guardian card absent when `showNoGuardianOption` is false/undefined; present when true; selecting it + Continue calls `onSubmit` with `{guardianId:'no-guardian', guardianEndpoint:''}`; guardian cards still behave unchanged.
+- **Unit — `Welcome`/handler (if reachable in the existing test harness):** `choose-guardian-submit` with the sentinel sets `WalletType.OffChain` and does not persist a guardian endpoint; the guardian path is unchanged.
+- **Manual/visual:** rebuild the devnet extension, enable the checkbox in dev settings, complete onboarding via "No guardian", confirm the created account has `type: OffChain` and Settings shows no guardian section.
+
+## PR logistics
+
+- Branch `feat/dev-no-guardian-onboarding` off `next` (already created). Leave `wallet-devnet-build` untouched.
+- CHANGELOG one-liner under the `1.15.20 (TBD)` section ("Fixes"/"Features" as appropriate — this is a dev-only feature).
+- Run gates locally before pushing: `eslint` (incl. `lint:i18n` for the new keys), `tsc`, and the touched jest suites.

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -1904,6 +1904,14 @@
     "message": "Erfahren Sie mehr über den Wächter",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Kein Vormund",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Erweitert – nur mit Ihrem seed phrase wiederherstellen. Kein Vormund, Mitunterzeichner.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Betrieben von:",
     "englishSource": "Operated by:"
@@ -3864,6 +3872,10 @@
   "devEndpointGuardian": {
     "message": "Benutzerdefinierte Guardian-URL",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Erlauben Sie beim Onboarding die Option „Kein Vormund“.",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Überprüfung…",

--- a/public/_locales/en/en.json
+++ b/public/_locales/en/en.json
@@ -866,6 +866,7 @@
   "devEndpointFaucetApi": "Faucet API URL",
   "devEndpointExplorer": "Explorer URL",
   "devEndpointGuardian": "Custom guardian URL",
+  "devAllowNoGuardian": "Allow 'No guardian' option in onboarding",
   "devEndpointChecking": "Checking…",
   "devEndpointReachable": "Host reachable",
   "devEndpointNoResponse": "No response",

--- a/public/_locales/en/en.json
+++ b/public/_locales/en/en.json
@@ -400,6 +400,8 @@
   "chooseYourGuardian": "Choose your Guardian",
   "chooseGuardianDescription": "Select an option below",
   "learnMoreAboutGuardian": "Learn more about the Guardian",
+  "noGuardianOptionTitle": "No guardian",
+  "noGuardianOptionSubtitle": "Advanced — recover with your seed phrase only. No guardian co-signer.",
   "guardianOperatedBy": "Operated by:",
   "guardianLocation": "Location:",
   "whatIsAGuardian": "What is a Guardian?",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1887,6 +1887,14 @@
     "message": "Learn more about the Guardian",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "No guardian",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Advanced — recover with your seed phrase only. No guardian co-signer.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Operated by:",
     "englishSource": "Operated by:"
@@ -3811,6 +3819,10 @@
   "devEndpointGuardian": {
     "message": "Custom guardian URL",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Allow 'No guardian' option in onboarding",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Checking…",

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -1904,6 +1904,14 @@
     "message": "Learn more about the Guardian",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "No guardian",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Advanced — recover with your seed phrase only. No guardian co-signer.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Operated by:",
     "englishSource": "Operated by:"
@@ -3865,6 +3873,10 @@
   "devEndpointGuardian": {
     "message": "Custom guardian URL",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Allow 'No guardian' option in onboarding",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Checking…",

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -1887,6 +1887,14 @@
     "message": "Más información sobre el guardián",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Sin tutor",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Avanzado: recupera solo con tu seed phrase. Sin tutor aval.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Operado por:",
     "englishSource": "Operated by:"
@@ -3811,6 +3819,10 @@
   "devEndpointGuardian": {
     "message": "URL de tutor personalizada",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Permitir la opción \"Sin tutor\" en la incorporación",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "De cheques…",

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -1904,6 +1904,14 @@
     "message": "En savoir plus sur le Gardien",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Pas de tuteur",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Avancé : récupérez avec votre seed phrase uniquement. Aucun tuteur cosignataire.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Exploité par :",
     "englishSource": "Operated by:"
@@ -3863,6 +3871,10 @@
   "devEndpointGuardian": {
     "message": "URL du tuteur personnalisé",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Autoriser l'option « Aucun tuteur » lors de l'intégration",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Vérification…",

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -1904,6 +1904,14 @@
     "message": "ガーディアンについて詳しく知る",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "保護者なし",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "上級 — seed phrase のみを使用して回復します。保護者の連帯保証人はいません。",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "運営者:",
     "englishSource": "Operated by:"
@@ -3864,6 +3872,10 @@
   "devEndpointGuardian": {
     "message": "カスタム ガーディアン URL",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "オンボーディングで「保護者なし」オプションを許可する",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "チェック中…",

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -1904,6 +1904,14 @@
     "message": "가디언에 대해 더 알아보기",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "보호자 없음",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "고급 — seed phrase로만 복구하세요. 보호자 공동 서명자가 없습니다.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "운영하는 사람:",
     "englishSource": "Operated by:"
@@ -3864,6 +3872,10 @@
   "devEndpointGuardian": {
     "message": "맞춤 보호자 URL",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "온보딩 시 '보호자 없음' 옵션 허용",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "확인 중…",

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -1887,6 +1887,14 @@
     "message": "Dowiedz się więcej o Guardianie",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Żadnego opiekuna",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Zaawansowane — odzyskaj tylko za pomocą seed phrase. Brak współsygnatariusza opiekuna.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Obsługiwany przez:",
     "englishSource": "Operated by:"
@@ -3811,6 +3819,10 @@
   "devEndpointGuardian": {
     "message": "Niestandardowy adres URL opiekuna",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Zezwól na opcję „Brak opiekuna” podczas wdrażania",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Kontrola…",

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -1904,6 +1904,14 @@
     "message": "Saiba mais sobre o Guardião",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Sem guardião",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Avançado — recupere apenas com seu seed phrase. Nenhum guardião fiador.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Operado por:",
     "englishSource": "Operated by:"
@@ -3862,6 +3870,10 @@
   "devEndpointGuardian": {
     "message": "URL personalizado do responsável",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Permitir a opção 'Sem responsável' na integração",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Verificando…",

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -1904,6 +1904,14 @@
     "message": "Узнайте больше о Гардиане",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Нет опекуна",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Расширенный — восстанавливайте только с помощью seed phrase. Нет со-подписавшего опекуна.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Управляется:",
     "englishSource": "Operated by:"
@@ -3865,6 +3873,10 @@
   "devEndpointGuardian": {
     "message": "Пользовательский URL-адрес опекуна",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Разрешить опцию «Нет опекуна» при регистрации",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Проверка…",

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -1904,6 +1904,14 @@
     "message": "Guardian hakkında daha fazla bilgi edinin",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Vasi yok",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Gelişmiş — yalnızca seed phrase ile kurtarın. Veli ortak imzalayan yok.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Tarafından işletilmektedir:",
     "englishSource": "Operated by:"
@@ -3864,6 +3872,10 @@
   "devEndpointGuardian": {
     "message": "Özel veli URL'si",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "İlk katılımda 'Veli yok' seçeneğine izin ver",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Kontrol ediliyor…",

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -1904,6 +1904,14 @@
     "message": "Дізнайтеся більше про Guardian",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "Без опікуна",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "Додатково — відновлюйте лише за допомогою seed phrase. Немає співпідписанта опікуна.",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "Керується:",
     "englishSource": "Operated by:"
@@ -3865,6 +3873,10 @@
   "devEndpointGuardian": {
     "message": "Спеціальна URL-адреса опікуна",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "Дозволити опцію «Без опікуна» під час реєстрації",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "Перевірка…",

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -1904,6 +1904,14 @@
     "message": "了解有关卫报的更多信息",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "无监护人",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "高级 — 仅使用 seed phrase 进行恢复。没有监护人共同签署人。",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "经营者：",
     "englishSource": "Operated by:"
@@ -3864,6 +3872,10 @@
   "devEndpointGuardian": {
     "message": "自定义监护人 URL",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "在入职时允许“无监护人”选项",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "检查…",

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -1904,6 +1904,14 @@
     "message": "了解有关卫报的更多信息",
     "englishSource": "Learn more about the Guardian"
   },
+  "noGuardianOptionTitle": {
+    "message": "无监护人",
+    "englishSource": "No guardian"
+  },
+  "noGuardianOptionSubtitle": {
+    "message": "高级 — 仅使用 seed phrase 进行恢复。没有监护人共同签署人。",
+    "englishSource": "Advanced — recover with your seed phrase only. No guardian co-signer."
+  },
   "guardianOperatedBy": {
     "message": "经营者：",
     "englishSource": "Operated by:"
@@ -3864,6 +3872,10 @@
   "devEndpointGuardian": {
     "message": "自定义监护人 URL",
     "englishSource": "Custom guardian URL"
+  },
+  "devAllowNoGuardian": {
+    "message": "在入职时允许“无监护人”选项",
+    "englishSource": "Allow 'No guardian' option in onboarding"
   },
   "devEndpointChecking": {
     "message": "检查…",

--- a/src/app/pages/Welcome.test.tsx
+++ b/src/app/pages/Welcome.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, act } from '@testing-library/react';
 
-import { OnboardingStep, OnboardingType, WalletType } from 'screens/onboarding/types';
+import { NO_GUARDIAN_ID, OnboardingStep, OnboardingType, WalletType } from 'screens/onboarding/types';
 
 import Welcome from './Welcome';
 
@@ -462,7 +462,9 @@ describe('Welcome — choose-guardian-submit', () => {
     await renderWelcome();
     await dispatch({ id: 'setup-passcode-submit', payload: '111111' });
     mockPutToStorage.mockClear();
-    await dispatch({ id: 'choose-guardian-submit', payload: { guardianId: 'no-guardian', guardianEndpoint: '' } });
+    await dispatch({ id: 'choose-guardian-submit', payload: { guardianId: NO_GUARDIAN_ID, guardianEndpoint: '' } });
+    // clears the guardian endpoint
+    expect(mockPutToStorage).toHaveBeenCalledWith('guardian_url_setting', '');
     // never persists a real guardian endpoint
     expect(mockPutToStorage).not.toHaveBeenCalledWith('guardian_url_setting', expect.stringContaining('http'));
     // driving to confirmation registers a private, no-guardian (OffChain) wallet

--- a/src/app/pages/Welcome.test.tsx
+++ b/src/app/pages/Welcome.test.tsx
@@ -457,6 +457,18 @@ describe('Welcome — choose-guardian-submit', () => {
     expect(mockFlowProps.current.password).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith('/#create-password');
   });
+
+  it('routes a No guardian selection to an OffChain wallet without storing a guardian endpoint', async () => {
+    await renderWelcome();
+    await dispatch({ id: 'setup-passcode-submit', payload: '111111' });
+    mockPutToStorage.mockClear();
+    await dispatch({ id: 'choose-guardian-submit', payload: { guardianId: 'no-guardian', guardianEndpoint: '' } });
+    // never persists a real guardian endpoint
+    expect(mockPutToStorage).not.toHaveBeenCalledWith('guardian_url_setting', expect.stringContaining('http'));
+    // driving to confirmation registers a private, no-guardian (OffChain) wallet
+    await dispatch({ id: 'confirmation' });
+    expect(mockRegisterWallet).toHaveBeenCalledWith(WalletType.OffChain, '111111', expect.any(String), false);
+  });
 });
 
 // ===========================================================================

--- a/src/app/pages/Welcome.tsx
+++ b/src/app/pages/Welcome.tsx
@@ -19,7 +19,7 @@ import { fetchStateFromBackend } from 'lib/store/hooks/useIntercomSync';
 import { seedWalletPrompt, WalletPromptType } from 'lib/wallet-prompts';
 import { navigate, useLocation } from 'lib/woozie';
 import { OnboardingFlow } from 'screens/onboarding/navigator';
-import { OnboardingAction, OnboardingStep, OnboardingType, WalletType } from 'screens/onboarding/types';
+import { NO_GUARDIAN_ID, OnboardingAction, OnboardingStep, OnboardingType, WalletType } from 'screens/onboarding/types';
 
 /**
  * Check if hardware security is available for vault key protection.
@@ -322,8 +322,15 @@ const Welcome: FC = () => {
         navigate('/#choose-guardian');
         break;
       case 'choose-guardian-submit':
-        await putToStorage(GUARDIAN_URL_STORAGE_KEY, action.payload.guardianEndpoint);
-        setWalletType(WalletType.Guardian);
+        if (action.payload.guardianId === NO_GUARDIAN_ID) {
+          // No guardian: private single-key (OffChain) account. Clear any stale
+          // guardian endpoint; the non-guardian spawn branch ignores it anyway.
+          await putToStorage(GUARDIAN_URL_STORAGE_KEY, '');
+          setWalletType(WalletType.OffChain);
+        } else {
+          await putToStorage(GUARDIAN_URL_STORAGE_KEY, action.payload.guardianEndpoint);
+          setWalletType(WalletType.Guardian);
+        }
         if (password) {
           // Passcode flow already established a password — go straight to confirmation.
           navigate('/#confirmation');

--- a/src/lib/miden-chain/effective-endpoints.test.ts
+++ b/src/lib/miden-chain/effective-endpoints.test.ts
@@ -9,6 +9,12 @@ import {
   MIDEN_GUARDIAN_ENDPOINTS,
   DEFAULT_NETWORK
 } from './constants';
+import {
+  getEffectiveAllowNoGuardian,
+  buildDefaultOverrideFor,
+  loadEndpointOverrides,
+  ENDPOINT_OVERRIDE_STORAGE_KEY
+} from './effective-endpoints';
 
 const mockKvStore: Record<string, unknown> = {};
 // Per-test toggle so a single test can simulate a storage-provider failure
@@ -224,5 +230,37 @@ describe('effective-endpoints resolver', () => {
       await m.loadEndpointOverrides();
       expect(m.getActiveOverride()).toBeNull();
     });
+  });
+});
+
+describe('getEffectiveAllowNoGuardian', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(mockKvStore)) delete mockKvStore[k];
+  });
+
+  it('defaults to false when no override is active', async () => {
+    await loadEndpointOverrides(); // nothing stored -> cache null
+    expect(getEffectiveAllowNoGuardian()).toBe(false);
+  });
+
+  it('reflects a stored override value', async () => {
+    mockKvStore[ENDPOINT_OVERRIDE_STORAGE_KEY] = {
+      ...buildDefaultOverrideFor(MIDEN_NETWORK_NAME.DEVNET),
+      allowNoGuardian: true
+    };
+    await loadEndpointOverrides();
+    expect(getEffectiveAllowNoGuardian()).toBe(true);
+  });
+
+  it('reads false from a legacy override that predates the field', async () => {
+    const legacy: Record<string, unknown> = { ...buildDefaultOverrideFor(MIDEN_NETWORK_NAME.DEVNET) };
+    delete legacy.allowNoGuardian;
+    mockKvStore[ENDPOINT_OVERRIDE_STORAGE_KEY] = legacy;
+    await loadEndpointOverrides();
+    expect(getEffectiveAllowNoGuardian()).toBe(false);
+  });
+
+  it('buildDefaultOverrideFor includes allowNoGuardian:false', () => {
+    expect(buildDefaultOverrideFor(MIDEN_NETWORK_NAME.DEVNET).allowNoGuardian).toBe(false);
   });
 });

--- a/src/lib/miden-chain/effective-endpoints.ts
+++ b/src/lib/miden-chain/effective-endpoints.ts
@@ -24,6 +24,7 @@ export interface EndpointOverride {
   faucetApiUrl: string;
   explorerUrl: string;
   guardianUrl: string; // '' = no custom guardian
+  allowNoGuardian: boolean; // dev-only: expose a "No guardian" card in onboarding
   networkName: MIDEN_NETWORK_NAME; // the "network id": drives NetworkId + endpoint-default seeding
   presetName: string; // 'testnet'|'devnet'|'localnet'|'custom' — UI dropdown seed only
 }
@@ -86,6 +87,11 @@ export function getEffectiveGuardianUrl(): string {
   return overrideCache?.guardianUrl ?? '';
 }
 
+/** Dev-only: whether onboarding should offer a "No guardian" account option. */
+export function getEffectiveAllowNoGuardian(): boolean {
+  return overrideCache?.allowNoGuardian ?? false;
+}
+
 /**
  * Effective-network default guardian endpoint (custom override first), or '' if
  * none. Non-throwing (mirrors the old `DEFAULT_GUARDIAN_ENDPOINT` const's
@@ -112,6 +118,7 @@ export function buildDefaultOverrideFor(network: MIDEN_NETWORK_NAME): EndpointOv
     faucetApiUrl: MIDEN_FAUCET_API_ENDPOINTS.get(network) ?? '',
     explorerUrl: MIDEN_EXPLORER_ENDPOINTS.get(network) ?? '',
     guardianUrl: MIDEN_GUARDIAN_ENDPOINTS.get(network)?.[0] ?? '',
+    allowNoGuardian: false,
     networkName: network,
     presetName: network
   };

--- a/src/lib/miden/back/main.test.ts
+++ b/src/lib/miden/back/main.test.ts
@@ -16,6 +16,8 @@ _g.__mainTest = {
   storeWatch: jest.fn(),
   doSync: jest.fn(),
   startTransactionProcessing: jest.fn(),
+  resetMidenClient: jest.fn(),
+  loadEndpointOverrides: jest.fn(),
   client: {
     importNoteBytes: jest.fn(),
     syncState: jest.fn(),
@@ -49,7 +51,12 @@ jest.mock('./transaction-processor', () => ({
 jest.mock('../sdk/miden-client', () => ({
   getMidenClient: async () => (globalThis as any).__mainTest.client,
   withWasmClientLock: async <T>(fn: () => Promise<T>) => fn(),
-  runWhenClientIdle: () => {}
+  runWhenClientIdle: () => {},
+  resetMidenClient: async () => (globalThis as any).__mainTest.resetMidenClient()
+}));
+
+jest.mock('lib/miden-chain/effective-endpoints', () => ({
+  loadEndpointOverrides: async () => (globalThis as any).__mainTest.loadEndpointOverrides()
 }));
 
 const mockOnRequest = _g.__mainTest.onRequest;
@@ -57,6 +64,8 @@ const mockBroadcast = _g.__mainTest.broadcast;
 const mockStoreWatch = _g.__mainTest.storeWatch;
 const mockDoSync = _g.__mainTest.doSync;
 const mockStartTransactionProcessing = _g.__mainTest.startTransactionProcessing;
+const mockResetMidenClient = _g.__mainTest.resetMidenClient;
+const mockLoadEndpointOverrides = _g.__mainTest.loadEndpointOverrides;
 const mockClient = _g.__mainTest.client;
 
 jest.mock('../sdk/helpers', () => ({
@@ -166,6 +175,16 @@ describe('processRequest', () => {
     const res = await dispatch({ type: WalletMessageType.ProcessTransactionsRequest });
     expect(res.type).toBe(WalletMessageType.ProcessTransactionsResponse);
     expect(mockStartTransactionProcessing).toHaveBeenCalled();
+  });
+
+  it('ReloadEndpointOverridesRequest re-hydrates the override cache, resets the Miden client, and acks', async () => {
+    // `start()` in beforeEach already calls loadEndpointOverrides once (see main.ts);
+    // clear that call so this assertion is scoped to the dispatched request.
+    mockLoadEndpointOverrides.mockClear();
+    const res = await dispatch({ type: WalletMessageType.ReloadEndpointOverridesRequest });
+    expect(res.type).toBe(WalletMessageType.ReloadEndpointOverridesResponse);
+    expect(mockLoadEndpointOverrides).toHaveBeenCalledTimes(1);
+    expect(mockResetMidenClient).toHaveBeenCalledTimes(1);
   });
 
   it('ImportNoteBytesRequest decodes base64, calls importNoteBytes + syncState, returns id', async () => {

--- a/src/lib/miden/back/main.ts
+++ b/src/lib/miden/back/main.ts
@@ -12,7 +12,7 @@ import { SerializedInputNoteDetail, WalletMessageType, WalletRequest, WalletResp
 
 import { NoteExportType } from '../sdk/constants';
 import { getBech32AddressFromAccountId } from '../sdk/helpers';
-import { getMidenClient, withWasmClientLock } from '../sdk/miden-client';
+import { getMidenClient, resetMidenClient, withWasmClientLock } from '../sdk/miden-client';
 import { MidenMessageType } from '../types';
 
 // frontStore is initialized lazily inside start() because with Vite's TLA stripping,
@@ -79,6 +79,13 @@ async function processRequest(req: WalletRequest, _port: Runtime.Port): Promise<
       // Fire-and-forget — start processing asynchronously
       startTransactionProcessing().catch(err => console.error('[TransactionProcessor] Error:', err));
       return { type: WalletMessageType.ProcessTransactionsResponse };
+    case WalletMessageType.ReloadEndpointOverridesRequest:
+      // Re-hydrate the override cache from storage, then dispose the Miden
+      // client singleton(s) so the next getMidenClient() rebuilds with the
+      // freshly-saved endpoints. See lib/miden-chain/effective-endpoints.ts.
+      await loadEndpointOverrides();
+      await resetMidenClient();
+      return { type: WalletMessageType.ReloadEndpointOverridesResponse };
     case WalletMessageType.ImportNoteBytesRequest: {
       const noteBytes = new Uint8Array(Buffer.from(req.noteBytes, 'base64'));
       const noteId = await withWasmClientLock(async () => {

--- a/src/lib/miden/sdk/miden-client.test.ts
+++ b/src/lib/miden/sdk/miden-client.test.ts
@@ -438,6 +438,48 @@ describe('resetMidenClient', () => {
     });
   });
 
+  it('clears an in-flight no-options creation so it cannot repopulate a stale client after the reset', async () => {
+    // Regression for: `disposeAllInstances()` used to only clear `initializingPromise`
+    // inside the `if (this.instance)` guard, so a reset that lands *while* a no-options
+    // `getInstance()` creation is still pending (instance still null) left that pending
+    // promise in place. When it later resolved, it unconditionally set `this.instance`
+    // to a client built against the pre-reset override, silently undoing the reset.
+    const free = jest.fn();
+    let resolveCreate: (client: { free: () => void }) => void = () => {};
+    const pending = new Promise<{ free: () => void }>(resolve => {
+      resolveCreate = resolve;
+    });
+    const create = jest.fn(() => pending);
+    jest.doMock('./miden-client-interface', () => ({
+      MidenClientInterface: class {
+        static create = create;
+        free = free;
+      }
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { getMidenClient, resetMidenClient } = require('./miden-client');
+
+      // Kick off a no-options creation but don't await it — it's left in flight.
+      const firstCall = getMidenClient();
+      expect(create).toHaveBeenCalledTimes(1);
+
+      // Reset while that creation is still pending: `this.instance` is still null, so
+      // the old `if (this.instance)`-guarded clear alone would have left the stale
+      // in-flight promise in place.
+      await resetMidenClient();
+
+      // A getInstance() call issued after the reset (but before the stale creation
+      // settles) must NOT rejoin the stale in-flight promise — it should start its own
+      // fresh creation instead.
+      const secondCall = getMidenClient();
+      expect(create).toHaveBeenCalledTimes(2);
+
+      resolveCreate({ free });
+      await Promise.all([firstCall, secondCall]);
+    });
+  });
+
   it('also frees an instanceWithOptions singleton, if one exists', async () => {
     const free = jest.fn();
     const create = jest.fn(async () => ({ free }));

--- a/src/lib/miden/sdk/miden-client.test.ts
+++ b/src/lib/miden/sdk/miden-client.test.ts
@@ -391,3 +391,73 @@ describe('getMidenClient singleton', () => {
     });
   });
 });
+
+describe('resetMidenClient', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('frees the no-options singleton and forces the next getMidenClient() to recreate it', async () => {
+    const free = jest.fn();
+    const create = jest.fn(async () => ({ free }));
+    jest.doMock('./miden-client-interface', () => ({
+      MidenClientInterface: class {
+        static create = create;
+        free = free;
+      }
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { getMidenClient, resetMidenClient } = require('./miden-client');
+      const first = await getMidenClient();
+      expect(create).toHaveBeenCalledTimes(1);
+
+      await resetMidenClient();
+      expect(free).toHaveBeenCalledTimes(1);
+
+      const second = await getMidenClient();
+      expect(create).toHaveBeenCalledTimes(2);
+      expect(second).not.toBe(first);
+    });
+  });
+
+  it('is a no-op when no singleton has been created yet', async () => {
+    const create = jest.fn();
+    jest.doMock('./miden-client-interface', () => ({
+      MidenClientInterface: class {
+        static create = create;
+        free() {}
+      }
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { resetMidenClient } = require('./miden-client');
+      await expect(resetMidenClient()).resolves.toBeUndefined();
+      expect(create).not.toHaveBeenCalled();
+    });
+  });
+
+  it('also frees an instanceWithOptions singleton, if one exists', async () => {
+    const free = jest.fn();
+    const create = jest.fn(async () => ({ free }));
+    jest.doMock('./miden-client-interface', () => ({
+      MidenClientInterface: class {
+        static create = create;
+        free = free;
+      }
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { getMidenClient, resetMidenClient } = require('./miden-client');
+      await getMidenClient({ seed: new Uint8Array([1]) });
+      expect(create).toHaveBeenCalledTimes(1);
+
+      await resetMidenClient();
+      expect(free).toHaveBeenCalledTimes(1);
+
+      await getMidenClient({ seed: new Uint8Array([2]) });
+      expect(create).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/lib/miden/sdk/miden-client.ts
+++ b/src/lib/miden/sdk/miden-client.ts
@@ -298,6 +298,14 @@ class MidenClientSingleton {
       this.instance.free();
       this.instance = null;
     }
+    // Null unconditionally, not just inside the `this.instance` guard above: if a
+    // no-options `getInstance()` creation is in flight, `this.instance` is still null
+    // here (the guard above never runs) but `initializingPromise` is a pending promise
+    // that a subsequent `getInstance()` call would otherwise return as-is — repopulating
+    // `this.instance` with a client built against the pre-reload override once that
+    // stale creation resolves. Clearing the slot means any `getInstance()` call issued
+    // after this reset starts its own fresh creation instead of rejoining the stale one.
+    this.initializingPromise = null;
     this.disposeInstanceWithOptions();
   }
 }

--- a/src/lib/miden/sdk/miden-client.ts
+++ b/src/lib/miden/sdk/miden-client.ts
@@ -285,6 +285,21 @@ class MidenClientSingleton {
       this.initializingPromiseWithOptions = null;
     }
   }
+
+  /**
+   * Free every live singleton (the no-options `instance` and the
+   * `instanceWithOptions`), so the next `getInstance()`/`getInstanceWithOptions()`
+   * call recreates the WASM client from scratch. Used when the effective
+   * endpoints (RPC/prover/note-transport) change underneath a long-lived
+   * singleton — see `resetMidenClient`.
+   */
+  disposeAllInstances(): void {
+    if (this.instance) {
+      this.instance.free();
+      this.instance = null;
+    }
+    this.disposeInstanceWithOptions();
+  }
 }
 
 const midenClientSingleton = new MidenClientSingleton();
@@ -300,4 +315,20 @@ export async function getMidenClient(options?: MidenClientCreateOptions): Promis
   }
   const client = await midenClientSingleton.getInstance();
   return client;
+}
+
+/**
+ * Dispose every live MidenClientInterface singleton so the next `getMidenClient()`
+ * call rebuilds one from scratch against the current effective endpoints
+ * (`lib/miden-chain/effective-endpoints`). Use this after the endpoint
+ * override changes underneath an already-created client (e.g. the SW's
+ * `RELOAD_ENDPOINT_OVERRIDES_REQUEST` handler) — the client bakes in
+ * rpcUrl/proverUrl/noteTransportUrl at `MidenClient.create()` time and never
+ * re-reads them. Runs inside `withWasmClientLock` so it can't dispose a
+ * client mid-operation.
+ */
+export async function resetMidenClient(): Promise<void> {
+  await withWasmClientLock(async () => {
+    midenClientSingleton.disposeAllInstances();
+  });
 }

--- a/src/lib/shared/types.ts
+++ b/src/lib/shared/types.ts
@@ -129,6 +129,10 @@ export enum WalletMessageType {
   // Transaction processing (popup → SW)
   ProcessTransactionsRequest = 'PROCESS_TRANSACTIONS_REQUEST',
   ProcessTransactionsResponse = 'PROCESS_TRANSACTIONS_RESPONSE',
+  // Developer endpoint overrides (popup → SW): re-hydrate the SW's override
+  // cache + rebuild its Miden client singleton(s) after a save.
+  ReloadEndpointOverridesRequest = 'RELOAD_ENDPOINT_OVERRIDES_REQUEST',
+  ReloadEndpointOverridesResponse = 'RELOAD_ENDPOINT_OVERRIDES_RESPONSE',
   // Note operations (popup → SW)
   ImportNoteBytesRequest = 'IMPORT_NOTE_BYTES_REQUEST',
   ImportNoteBytesResponse = 'IMPORT_NOTE_BYTES_RESPONSE',
@@ -238,6 +242,26 @@ export interface ProcessTransactionsRequest extends WalletMessageBase {
 
 export interface ProcessTransactionsResponse extends WalletMessageBase {
   type: WalletMessageType.ProcessTransactionsResponse;
+}
+
+/**
+ * Tell the SW to re-hydrate `lib/miden-chain/effective-endpoints`'s
+ * module-level override cache from storage and dispose its Miden client
+ * singleton(s), so the next `getMidenClient()` rebuilds against the
+ * freshly-saved endpoints. Fire-and-forget from the caller's perspective
+ * (the response payload carries no data) — mirrors `ProcessTransactionsRequest`.
+ * Still pairs with a Response type: `IntercomServer.processMessage` treats a
+ * handler returning `undefined` as "Not Found" and errors the round trip, so
+ * every case in `processRequest` must resolve to a typed response, even ones
+ * with nothing to report. Extension-only: mobile/desktop share the frontend's
+ * JS realm, so `applyEndpointOverride` alone already takes effect there.
+ */
+export interface ReloadEndpointOverridesRequest extends WalletMessageBase {
+  type: WalletMessageType.ReloadEndpointOverridesRequest;
+}
+
+export interface ReloadEndpointOverridesResponse extends WalletMessageBase {
+  type: WalletMessageType.ReloadEndpointOverridesResponse;
 }
 
 export interface ImportNoteBytesRequest extends WalletMessageBase {
@@ -1009,6 +1033,7 @@ export type WalletRequest =
   | SyncRequest
   | NoteClaimStarted
   | ProcessTransactionsRequest
+  | ReloadEndpointOverridesRequest
   | ImportNoteBytesRequest
   | ExportNoteRequest
   | GetInputNoteDetailsRequest
@@ -1071,6 +1096,7 @@ export type WalletResponse =
   | SyncResponse
   | NoteClaimStartedResponse
   | ProcessTransactionsResponse
+  | ReloadEndpointOverridesResponse
   | ImportNoteBytesResponse
   | ExportNoteResponse
   | GetInputNoteDetailsResponse

--- a/src/lib/store/index.test.ts
+++ b/src/lib/store/index.test.ts
@@ -4,7 +4,14 @@ import { MidenMessageType } from 'lib/miden/types';
 import { WalletMessageType, WalletStatus } from 'lib/shared/types';
 import { WalletType } from 'screens/onboarding/types';
 
-import { useWalletStore, selectIsReady, selectIsLocked, selectIsIdle, getIntercom } from './index';
+import {
+  useWalletStore,
+  selectIsReady,
+  selectIsLocked,
+  selectIsIdle,
+  getIntercom,
+  reloadEndpointOverridesInSW
+} from './index';
 
 // Mock the intercom module
 const mockRequest = jest.fn();
@@ -849,6 +856,26 @@ describe('useWalletStore', () => {
       const client1 = getIntercom();
       const client2 = getIntercom();
       expect(client1).toBe(client2);
+    });
+  });
+
+  describe('reloadEndpointOverridesInSW', () => {
+    it('sends a ReloadEndpointOverridesRequest and resolves on completion', async () => {
+      mockRequest.mockResolvedValueOnce({ type: WalletMessageType.ReloadEndpointOverridesResponse });
+      await expect(reloadEndpointOverridesInSW()).resolves.toBeUndefined();
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ type: WalletMessageType.ReloadEndpointOverridesRequest })
+      );
+    });
+
+    it('swallows a failed request instead of rejecting', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockRequest.mockRejectedValueOnce(new Error('port disconnected'));
+
+      await expect(reloadEndpointOverridesInSW()).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith('[reloadEndpointOverridesInSW] failed to nudge SW:', expect.any(Error));
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/lib/store/index.test.ts
+++ b/src/lib/store/index.test.ts
@@ -877,6 +877,26 @@ describe('useWalletStore', () => {
 
       warnSpy.mockRestore();
     });
+
+    it('resolves after a bounded timeout instead of hanging forever when the request never settles (e.g. the SW port disconnects mid-request, which IntercomClient does not surface as a rejection)', async () => {
+      jest.useFakeTimers();
+      try {
+        mockRequest.mockImplementationOnce(() => new Promise(() => {})); // never settles
+
+        const settled = jest.fn();
+        reloadEndpointOverridesInSW().then(settled);
+
+        // Still pending well before the timeout — proves this isn't just a same-tick resolve.
+        await Promise.resolve();
+        expect(settled).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(4000);
+        expect(settled).toHaveBeenCalledTimes(1);
+        expect(settled).toHaveBeenCalledWith(undefined);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   // ── Additional coverage for action methods ────────────────────────

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -764,6 +764,24 @@ export const useWalletStore = create<WalletStore>()(
 // Export the intercom getter for use in sync hook
 export { getIntercom };
 
+/**
+ * Tell the service worker to reload its endpoint-override cache and dispose
+ * its Miden client singleton(s), so the next `getMidenClient()` call there
+ * rebuilds against the just-saved override. No-op on mobile/desktop, which
+ * share the frontend's JS realm — `applyEndpointOverride` alone already
+ * takes effect there. Awaitable so callers (Developer Settings' handleSave)
+ * can order navigation after the SW has re-hydrated; best-effort otherwise —
+ * a failed nudge just means the override applies after the next SW restart.
+ */
+export function reloadEndpointOverridesInSW(): Promise<void> {
+  return getIntercom()
+    .request({ type: WalletMessageType.ReloadEndpointOverridesRequest })
+    .then(() => {})
+    .catch(err => {
+      console.warn('[reloadEndpointOverridesInSW] failed to nudge SW:', err);
+    });
+}
+
 // Derived selectors for common patterns
 export const selectIsReady = (state: WalletStore) => state.status === WalletStatus.Ready;
 export const selectIsLocked = (state: WalletStore) => state.status === WalletStatus.Locked;

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -764,6 +764,10 @@ export const useWalletStore = create<WalletStore>()(
 // Export the intercom getter for use in sync hook
 export { getIntercom };
 
+// `reloadEndpointOverridesInSW`'s request must always settle so it can't wedge a caller
+// that awaits it before navigating (e.g. Developer Settings' handleSave) — see below.
+const RELOAD_ENDPOINT_OVERRIDES_SW_TIMEOUT_MS = 4000;
+
 /**
  * Tell the service worker to reload its endpoint-override cache and dispose
  * its Miden client singleton(s), so the next `getMidenClient()` call there
@@ -772,14 +776,26 @@ export { getIntercom };
  * takes effect there. Awaitable so callers (Developer Settings' handleSave)
  * can order navigation after the SW has re-hydrated; best-effort otherwise —
  * a failed nudge just means the override applies after the next SW restart.
+ *
+ * Bounded to `RELOAD_ENDPOINT_OVERRIDES_SW_TIMEOUT_MS`: `IntercomClient.request`
+ * never rejects if the SW port disconnects mid-request, so an un-bounded await
+ * here could hang forever and wedge a caller's UI (e.g. leave `saving` stuck).
+ * The underlying request keeps running and its own `.catch` still swallows a
+ * late failure — this just stops the caller from waiting on it past the timeout.
  */
 export function reloadEndpointOverridesInSW(): Promise<void> {
-  return getIntercom()
+  const request = getIntercom()
     .request({ type: WalletMessageType.ReloadEndpointOverridesRequest })
     .then(() => {})
     .catch(err => {
       console.warn('[reloadEndpointOverridesInSW] failed to nudge SW:', err);
     });
+
+  const timeout = new Promise<void>(resolve => {
+    setTimeout(resolve, RELOAD_ENDPOINT_OVERRIDES_SW_TIMEOUT_MS);
+  });
+
+  return Promise.race([request, timeout]);
 }
 
 // Derived selectors for common patterns

--- a/src/screens/developer-settings/DeveloperSettings.test.tsx
+++ b/src/screens/developer-settings/DeveloperSettings.test.tsx
@@ -70,11 +70,16 @@ jest.mock('lib/miden-chain/effective-endpoints', () => {
       faucetApiUrl: `https://faucet-api.${n}`,
       explorerUrl: `https://scan.${n}`,
       guardianUrl: `https://guardian.${n}`,
+      allowNoGuardian: false,
       networkName: n,
       presetName: n
     })
   };
 });
+
+jest.mock('components/Checkbox', () => ({
+  Checkbox: ({ value }: { value: boolean }) => <span data-testid="checkbox" data-checked={String(value)} />
+}));
 
 type HealthStatus = 'idle' | 'pending' | 'reachable' | 'error';
 const mockHealthStatus: { value: HealthStatus } = { value: 'idle' };
@@ -358,6 +363,32 @@ describe('DeveloperSettings', () => {
     expect(screen.queryByText('devEndpointChecking')).not.toBeInTheDocument();
     expect(screen.queryByText('devEndpointReachable')).not.toBeInTheDocument();
     expect(screen.queryByText('devEndpointNoResponse')).not.toBeInTheDocument();
+  });
+});
+
+describe('DeveloperSettings — allowNoGuardian', () => {
+  beforeEach(() => {
+    applyEndpointOverride.mockClear();
+    mockUseConfirm.mockReturnValue(confirm);
+  });
+
+  it('renders the no-guardian toggle row', () => {
+    render(<DeveloperSettings />);
+    expect(screen.getByTestId('dev-allow-no-guardian')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox')).toHaveAttribute('data-checked', 'false');
+  });
+
+  it('persists allowNoGuardian=true when toggled on and saved', async () => {
+    render(<DeveloperSettings />);
+    fireEvent.click(screen.getByTestId('dev-allow-no-guardian'));
+    fireEvent.click(screen.getByTestId('dev-endpoints-save'));
+    await waitFor(() => expect(applyEndpointOverride).toHaveBeenCalled());
+    expect(applyEndpointOverride).toHaveBeenCalledWith(expect.objectContaining({ allowNoGuardian: true }));
+  });
+
+  it('disables the toggle row in read-only mode', () => {
+    render(<DeveloperSettings readOnly />);
+    expect(screen.getByTestId('dev-allow-no-guardian')).toBeDisabled();
   });
 });
 

--- a/src/screens/developer-settings/DeveloperSettings.test.tsx
+++ b/src/screens/developer-settings/DeveloperSettings.test.tsx
@@ -92,6 +92,14 @@ jest.mock('lib/miden/reset', () => ({
   resetStorageDestructive: () => resetStorageDestructive()
 }));
 
+// `reloadEndpointOverridesInSW` nudges the service worker on the extension
+// (separate JS realm); handleSave's gating on `isExtension()` is asserted
+// against this spy below.
+const reloadEndpointOverridesInSW = jest.fn().mockResolvedValue(undefined);
+jest.mock('lib/store', () => ({
+  reloadEndpointOverridesInSW: () => reloadEndpointOverridesInSW()
+}));
+
 // House components — replace with lightweight stand-ins that forward the
 // props DeveloperSettings actually passes, so testids/values stay assertable
 // without pulling in framer-motion / icon assets.
@@ -200,6 +208,24 @@ describe('DeveloperSettings', () => {
     fireEvent.click(screen.getByTestId('dev-endpoints-save'));
     await waitFor(() => expect(applyEndpointOverride).toHaveBeenCalledTimes(1));
     expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('nudges the service worker to reload endpoint overrides on save when running as an extension', async () => {
+    mockIsExtension.value = true;
+    render(<DeveloperSettings />);
+    fireEvent.click(screen.getByTestId('dev-endpoints-save'));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
+    expect(reloadEndpointOverridesInSW).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not nudge the service worker on save outside the extension (mobile/desktop share the realm)', async () => {
+    mockIsExtension.value = false;
+    render(<DeveloperSettings />);
+    fireEvent.click(screen.getByTestId('dev-endpoints-save'));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
+    expect(reloadEndpointOverridesInSW).not.toHaveBeenCalled();
   });
 
   it('read-only mode disables inputs and shows the reset action', () => {

--- a/src/screens/developer-settings/DeveloperSettings.test.tsx
+++ b/src/screens/developer-settings/DeveloperSettings.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
+import { WalletStatus } from 'lib/shared/types';
 import { useConfirm } from 'lib/ui/dialog';
 
 import DeveloperSettings from './DeveloperSettings';
@@ -96,9 +97,21 @@ jest.mock('lib/miden/reset', () => ({
 // (separate JS realm); handleSave's gating on `isExtension()` is asserted
 // against this spy below.
 const reloadEndpointOverridesInSW = jest.fn().mockResolvedValue(undefined);
-jest.mock('lib/store', () => ({
-  reloadEndpointOverridesInSW: () => reloadEndpointOverridesInSW()
-}));
+// `useWalletStore(selectIsIdle)` gates the SW nudge to pre-wallet (onboarding) —
+// `/developer-settings` is also reachable read-write from a live wallet (gated on
+// `!locked`, not `!ready`), so the nudge must not fire once a wallet exists. Default
+// to idle (no wallet) so the existing extension/non-extension save tests, which predate
+// this gate, keep exercising the "onboarding" case unchanged; a dedicated test below
+// flips it to Ready.
+const mockWalletState: { status: number } = { status: 0 };
+jest.mock('lib/store', () => {
+  const { WalletStatus } = jest.requireActual('lib/shared/types');
+  return {
+    reloadEndpointOverridesInSW: () => reloadEndpointOverridesInSW(),
+    useWalletStore: (selector: (s: typeof mockWalletState) => unknown) => selector(mockWalletState),
+    selectIsIdle: (s: typeof mockWalletState) => s.status === WalletStatus.Idle
+  };
+});
 
 // House components — replace with lightweight stand-ins that forward the
 // props DeveloperSettings actually passes, so testids/values stay assertable
@@ -192,6 +205,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockHealthStatus.value = 'idle';
   mockIsExtension.value = false;
+  mockWalletState.status = WalletStatus.Idle;
   confirm.mockResolvedValue(true);
   mockUseConfirm.mockReturnValue(confirm);
 });
@@ -210,8 +224,9 @@ describe('DeveloperSettings', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
-  it('nudges the service worker to reload endpoint overrides on save when running as an extension', async () => {
+  it('nudges the service worker to reload endpoint overrides on save when running as an extension with no wallet yet (onboarding)', async () => {
     mockIsExtension.value = true;
+    mockWalletState.status = WalletStatus.Idle;
     render(<DeveloperSettings />);
     fireEvent.click(screen.getByTestId('dev-endpoints-save'));
 
@@ -221,6 +236,17 @@ describe('DeveloperSettings', () => {
 
   it('does not nudge the service worker on save outside the extension (mobile/desktop share the realm)', async () => {
     mockIsExtension.value = false;
+    mockWalletState.status = WalletStatus.Idle;
+    render(<DeveloperSettings />);
+    fireEvent.click(screen.getByTestId('dev-endpoints-save'));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'));
+    expect(reloadEndpointOverridesInSW).not.toHaveBeenCalled();
+  });
+
+  it('does not nudge the service worker on save when a wallet already exists (live/unlocked, reachable via /developer-settings without onlyReady), even on the extension', async () => {
+    mockIsExtension.value = true;
+    mockWalletState.status = WalletStatus.Ready;
     render(<DeveloperSettings />);
     fireEvent.click(screen.getByTestId('dev-endpoints-save'));
 

--- a/src/screens/developer-settings/DeveloperSettings.tsx
+++ b/src/screens/developer-settings/DeveloperSettings.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button, ButtonVariant } from 'components/Button';
+import { Checkbox } from 'components/Checkbox';
 import { Input } from 'components/Input';
 import { ScreenHeader } from 'components/ScreenHeader';
 import { TabPicker } from 'components/TabPicker';
@@ -224,6 +225,26 @@ const DeveloperSettings: React.FC<DeveloperSettingsProps> = ({ readOnly = false 
             }
           />
         </div>
+
+        <button
+          type="button"
+          disabled={readOnly}
+          data-testid="dev-allow-no-guardian"
+          onClick={
+            readOnly
+              ? undefined
+              : () =>
+                  setForm(prev => ({
+                    ...prev,
+                    allowNoGuardian: !prev.allowNoGuardian,
+                    presetName: CUSTOM_PRESET
+                  }))
+          }
+          className="flex items-center justify-between gap-3 text-left"
+        >
+          <span className="text-sm font-medium text-heading-gray">{t('devAllowNoGuardian')}</span>
+          <Checkbox value={form.allowNoGuardian} />
+        </button>
       </div>
 
       <div className="px-4 pb-8 pt-4 mt-auto flex flex-col items-center gap-3">

--- a/src/screens/developer-settings/DeveloperSettings.tsx
+++ b/src/screens/developer-settings/DeveloperSettings.tsx
@@ -19,6 +19,7 @@ import {
 import { EndpointHealthKind, useEndpointHealth } from 'lib/miden-chain/endpoint-health';
 import { hapticMedium } from 'lib/mobile/haptics';
 import { isExtension } from 'lib/platform';
+import { reloadEndpointOverridesInSW } from 'lib/store';
 import { useConfirm } from 'lib/ui/dialog';
 import { goBack, navigate } from 'lib/woozie';
 
@@ -125,6 +126,12 @@ const DeveloperSettings: React.FC<DeveloperSettingsProps> = ({ readOnly = false 
   const handleSave = async () => {
     setSaving(true);
     await applyEndpointOverride(form);
+    // On the extension, the service worker is a separate JS realm with its own
+    // module-level override cache and a create-once Miden client singleton, so
+    // applyEndpointOverride's write doesn't reach it — nudge it to re-hydrate
+    // and rebuild before navigating away. Mobile/desktop share this realm, so
+    // the override above already took effect and this is a no-op.
+    if (isExtension()) await reloadEndpointOverridesInSW();
     setSaving(false);
     navigate('/');
   };

--- a/src/screens/developer-settings/DeveloperSettings.tsx
+++ b/src/screens/developer-settings/DeveloperSettings.tsx
@@ -19,7 +19,7 @@ import {
 import { EndpointHealthKind, useEndpointHealth } from 'lib/miden-chain/endpoint-health';
 import { hapticMedium } from 'lib/mobile/haptics';
 import { isExtension } from 'lib/platform';
-import { reloadEndpointOverridesInSW } from 'lib/store';
+import { reloadEndpointOverridesInSW, selectIsIdle, useWalletStore } from 'lib/store';
 import { useConfirm } from 'lib/ui/dialog';
 import { goBack, navigate } from 'lib/woozie';
 
@@ -99,6 +99,9 @@ const DeveloperSettings: React.FC<DeveloperSettingsProps> = ({ readOnly = false 
   );
   const [form, setForm] = useState<EndpointOverride>(initial);
   const [saving, setSaving] = useState(false);
+  // No wallet registered yet, i.e. this screen is reachable but we're still pre-onboarding.
+  // `handleSave`'s SW nudge is only safe to send in this state — see its comment.
+  const noWalletYet = useWalletStore(selectIsIdle);
 
   const presetTabs = useMemo(
     () =>
@@ -131,7 +134,13 @@ const DeveloperSettings: React.FC<DeveloperSettingsProps> = ({ readOnly = false 
     // applyEndpointOverride's write doesn't reach it — nudge it to re-hydrate
     // and rebuild before navigating away. Mobile/desktop share this realm, so
     // the override above already took effect and this is a no-op.
-    if (isExtension()) await reloadEndpointOverridesInSW();
+    // Only nudge pre-wallet (onboarding): this screen is also reachable read-write
+    // from a live, unlocked wallet (it's gated on `!locked`, not `!ready` — see
+    // PageRouter), and disposing the SW's Miden client mid-session would tear down
+    // an in-progress sync/tx. Once a wallet exists, an override change here still
+    // applies to this realm but requires an explicit reload to reach the SW,
+    // unchanged from before this nudge existed.
+    if (isExtension() && noWalletYet) await reloadEndpointOverridesInSW();
     setSaving(false);
     navigate('/');
   };

--- a/src/screens/onboarding/common/ChooseGuardian.test.tsx
+++ b/src/screens/onboarding/common/ChooseGuardian.test.tsx
@@ -445,3 +445,22 @@ describe('ChooseGuardianScreen — custom endpoint keyboard (regression)', () =>
     expect(document.activeElement).not.toBe(input);
   });
 });
+
+describe('ChooseGuardian — no-guardian option', () => {
+  const oneOption = [{ id: 'open-zeppelin', name: 'OZ', operatedBy: 'OZ', location: 'US', endpoint: 'https://g' }];
+
+  it('hides the No guardian card by default', () => {
+    mockGetGuardianOptions.mockReturnValue(oneOption);
+    render(<ChooseGuardianScreen onSubmit={jest.fn()} />);
+    expect(screen.queryByTestId('choose-no-guardian')).toBeNull();
+  });
+
+  it('shows the card and submits the sentinel when enabled', () => {
+    mockGetGuardianOptions.mockReturnValue(oneOption);
+    const onSubmit = jest.fn();
+    render(<ChooseGuardianScreen onSubmit={onSubmit} showNoGuardianOption />);
+    fireEvent.click(screen.getByTestId('choose-no-guardian'));
+    fireEvent.click(screen.getByTestId('continue-button'));
+    expect(onSubmit).toHaveBeenCalledWith({ guardianId: 'no-guardian', guardianEndpoint: '' });
+  });
+});

--- a/src/screens/onboarding/common/ChooseGuardian.tsx
+++ b/src/screens/onboarding/common/ChooseGuardian.tsx
@@ -12,6 +12,7 @@ import { hapticLight } from 'lib/mobile/haptics';
 import { isValidGuardianUrl, sanitizeGuardianUrl } from 'lib/settings/helpers';
 import type { GuardianOption } from 'lib/shared/types';
 import { cn } from 'lib/ui/util';
+import { NO_GUARDIAN_ID } from 'screens/onboarding/types';
 
 import { GuardianInfoDrawer } from './GuardianInfoDrawer';
 
@@ -30,6 +31,9 @@ export interface ChooseGuardianScreenProps {
   hideHeader?: boolean;
   // When true, show a "custom Guardian URL" field below the provider grid.
   allowCustomEndpoint?: boolean;
+  // Dev-gated (onboarding only): show a selectable "No guardian" card that
+  // creates a private single-key account with no guardian co-signer.
+  showNoGuardianOption?: boolean;
 }
 
 export const ChooseGuardianScreen: React.FC<ChooseGuardianScreenProps> = ({
@@ -39,7 +43,8 @@ export const ChooseGuardianScreen: React.FC<ChooseGuardianScreenProps> = ({
   description,
   submitLabel,
   hideHeader = false,
-  allowCustomEndpoint = false
+  allowCustomEndpoint = false,
+  showNoGuardianOption = false
 }) => {
   const { t } = useTranslation();
   const [isInfoOpen, setIsInfoOpen] = useState(false);
@@ -80,6 +85,10 @@ export const ChooseGuardianScreen: React.FC<ChooseGuardianScreenProps> = ({
   };
 
   const handleContinue = () => {
+    if (selectedId === NO_GUARDIAN_ID) {
+      onSubmit?.({ guardianId: NO_GUARDIAN_ID, guardianEndpoint: '' });
+      return;
+    }
     if (isCustom) {
       const sanitized = sanitizeGuardianUrl(customUrl);
       if (!isValidGuardianUrl(sanitized)) {
@@ -177,6 +186,23 @@ export const ChooseGuardianScreen: React.FC<ChooseGuardianScreenProps> = ({
             );
           })}
         </div>
+
+        {showNoGuardianOption && (
+          <button
+            type="button"
+            onClick={() => handleSelect(NO_GUARDIAN_ID)}
+            data-testid="choose-no-guardian"
+            className={cn(
+              'mt-4 flex flex-col items-start rounded-[20px] border-2 p-4 text-left transition-all duration-150 shrink-0',
+              selectedId === NO_GUARDIAN_ID ? 'border-primary-500 border-4' : 'border-[#E3E3E3] dark:border-grey-800'
+            )}
+          >
+            <span className="text-base font-semibold text-heading-gray">{t('noGuardianOptionTitle')}</span>
+            <span className="mt-1 text-xs text-gray-secondary dark:text-pure-white">
+              {t('noGuardianOptionSubtitle')}
+            </span>
+          </button>
+        )}
 
         {allowCustomEndpoint && (
           <div className="mt-4 flex flex-col gap-2 shrink-0">

--- a/src/screens/onboarding/navigator.test.tsx
+++ b/src/screens/onboarding/navigator.test.tsx
@@ -63,6 +63,13 @@ jest.mock('lib/platform', () => ({
   isMobile: () => mockPlatform.isMobile
 }));
 
+// Dev-gated "No guardian" onboarding flag — reads the shared toggle so a test
+// can drive whether ChooseGuardianScreen is told to show the option.
+let mockAllowNoGuardian = false;
+jest.mock('lib/miden-chain/effective-endpoints', () => ({
+  getEffectiveAllowNoGuardian: () => mockAllowNoGuardian
+}));
+
 // `Button` (bottom "back" nav) — surface title, variant and the onClick wiring.
 jest.mock('components/Button', () => ({
   Button: ({ title, onClick, variant, className }: any) =>
@@ -134,6 +141,7 @@ const progress = () => screen.queryByTestId('progress');
 beforeEach(() => {
   mockPlatform.isMobile = false;
   mockReduceMotion = false;
+  mockAllowNoGuardian = false;
   for (const k of Object.keys(mockCaptured)) delete mockCaptured[k];
 });
 
@@ -256,6 +264,18 @@ describe('OnboardingFlow — action wiring per screen', () => {
     const payload = { guardianId: 'g1', guardianEndpoint: 'https://guardian.example' };
     act(() => mockCaptured['choose-guardian'].onSubmit(payload));
     expect(onAction).toHaveBeenLastCalledWith({ id: 'choose-guardian-submit', payload });
+  });
+
+  it('ChooseGuardian: forwards the dev-gated allow-no-guardian flag as showNoGuardianOption', () => {
+    mockAllowNoGuardian = true;
+    renderFlow({ step: OnboardingStep.ChooseGuardian });
+    expect(mockCaptured['choose-guardian'].showNoGuardianOption).toBe(true);
+  });
+
+  it('ChooseGuardian: hides the no-guardian option when the dev flag is off', () => {
+    mockAllowNoGuardian = false;
+    renderFlow({ step: OnboardingStep.ChooseGuardian });
+    expect(mockCaptured['choose-guardian'].showNoGuardianOption).toBe(false);
   });
 
   it('BackupSeedPhrase: passes the seed phrase through and submits verify', () => {

--- a/src/screens/onboarding/navigator.tsx
+++ b/src/screens/onboarding/navigator.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Button, ButtonVariant } from 'components/Button';
 import { ProgressIndicator } from 'components/ProgressIndicator';
+import { getEffectiveAllowNoGuardian } from 'lib/miden-chain/effective-endpoints';
 import { isMobile } from 'lib/platform';
 
 import { ChooseGuardianScreen } from './common/ChooseGuardian';
@@ -199,7 +200,12 @@ export const OnboardingFlow: FC<OnboardingFlowProps> = ({
           <SetupBiometricScreen onContinue={onSetupBiometricSubmit} onSwitchToPasscode={onBiometricSwitchToPasscode} />
         );
       case OnboardingStep.ChooseGuardian:
-        return <ChooseGuardianScreen onSubmit={onChooseGuardianSubmit} />;
+        return (
+          <ChooseGuardianScreen
+            onSubmit={onChooseGuardianSubmit}
+            showNoGuardianOption={getEffectiveAllowNoGuardian()}
+          />
+        );
       case OnboardingStep.BackupSeedPhrase:
         return <BackUpSeedPhraseScreen seedPhrase={seedPhrase || []} onSubmit={onBackupSeedPhraseSubmit} />;
       case OnboardingStep.VerifySeedPhrase:

--- a/src/screens/onboarding/types.ts
+++ b/src/screens/onboarding/types.ts
@@ -12,6 +12,9 @@ export type GuardianProbeState =
   | { status: 'done'; result: GuardianDiscoveryResult }
   | { status: 'error'; message: string };
 
+/** Sentinel guardianId meaning "create a no-guardian account" (dev-gated). */
+export const NO_GUARDIAN_ID = 'no-guardian';
+
 export enum OnboardingType {
   Create = 'create',
   Import = 'import'


### PR DESCRIPTION
## What

Adds a **developer-settings checkbox** that, when enabled, exposes a **"No guardian" card** on the onboarding "Choose your guardian" screen. Selecting it creates a **private single-key account** (`WalletType.OffChain`) with no guardian co-signer — recovery is seed-phrase only.

Default-off: with the flag disabled, onboarding is byte-identical to today (no card, no behavior change).

## Why

Useful for development/testing of the non-guardian account experience without needing a guardian operator. The non-guardian create path already exists in the backend (`Vault.spawn` else-branch → `createMidenWallet` → SDK single-key `accounts.create`); the only thing missing was an onboarding UI path, since the create flow previously hard-coded `WalletType.Guardian`.

**No backend / SDK / multisig-client changes** — this is UI + flow wiring only.

## How it works

- `allowNoGuardian: boolean` rides on the existing persisted `EndpointOverride` object (`effective-endpoints.ts`), read via a synchronous `getEffectiveAllowNoGuardian()` getter. `isEndpointOverride` is deliberately left unchanged so overrides persisted before this field still load.
- Developer Settings renders a `Checkbox`-in-clickable-row bound to the flag (the shared `Checkbox` is display-only, so the row's `onClick` drives it).
- The onboarding navigator passes `showNoGuardianOption={getEffectiveAllowNoGuardian()}` to `ChooseGuardianScreen`. The Settings guardian-switch reuse (`RotateGuardian`) does **not** pass it, so the card is onboarding-only and can never convert an existing guardian account.
- Selecting the card + Continue submits the sentinel `NO_GUARDIAN_ID` (`screens/onboarding/types.ts`); `Welcome.tsx` routes it to `WalletType.OffChain` and clears the guardian endpoint. All guardian-gated UI (Settings, key rotation, guardian sync) already no-ops for non-guardian account types.

## Scope

- **In:** dev checkbox, onboarding "No guardian" card, create-flow wiring to `OffChain`.
- **Out:** Import flow (already has its own selector), Settings guardian-switch, public (`OnChain`) variant, converting an existing account. No backend changes.

## Testing

- 189/189 across the five touched suites (`effective-endpoints`, `DeveloperSettings`, `ChooseGuardian`, `navigator`, `Welcome`); `tsc`, `eslint`, `lint:i18n` clean.
- Unit coverage: getter default/stored/legacy-tolerance; checkbox renders + persists + read-only-disabled; card hidden-by-default / shown-when-enabled / submits the sentinel; navigator passes the getter's value (both true/false); `Welcome` routes the sentinel to `OffChain` and clears the endpoint.
- Built the devnet extension and verified end-to-end: enable the flag → the card appears → creating via it yields a non-guardian account; with the flag off the card is absent.

Design + plan: `docs/superpowers/specs/2026-08-10-dev-no-guardian-onboarding-design.md`, `docs/superpowers/plans/2026-08-10-dev-no-guardian-onboarding.md`.

---

## Also bundled: endpoint-override → service-worker fix

**Bug:** On the browser extension, developer-settings endpoint overrides never reached the wallet's real RPC — the wallet kept syncing against the build-default `rpc.devnet.miden.io` even after saving a custom override (confirmed via the SW Network tab). Root cause: the service worker is a separate JS realm that (a) loads the override cache once at boot and never re-hydrates it, and (b) builds its Miden client as a create-once, never-disposed singleton with endpoints baked in at `create()`. `handleSave` only mutated the frontend realm's cache + storage and never told the SW.

**Fix:** A new `ReloadEndpointOverridesRequest` intercom message. On the extension, `handleSave` sends it (awaited, 4s-bounded so it can't wedge onboarding) after persisting; the SW handler re-hydrates its override cache (`loadEndpointOverrides()`) and disposes its Miden client singletons (`resetMidenClient()`) so the next `getMidenClient()` rebuilds with the new endpoints. Mobile/desktop share the frontend realm, so it's a no-op there (gated to `isExtension()`).

**Safety:** The nudge is gated to `selectIsIdle` (no wallet yet). The editable `/developer-settings` is reachable read-write from a live wallet (it's gated on `!locked`, not `!ready`), so disposing the SW client there would tear down an in-progress sync/tx — the gate prevents that. Consequence: the override applies when set **during onboarding** (fresh wallet); changing endpoints on an existing wallet still requires an explicit extension reload (unchanged, and intentionally so — it's a network switch).

**Verification:** unit tests for the handler round-trip, the three gating cases (extension+idle → nudge; extension+ready → no nudge; non-extension → no nudge), the timeout, and the dispose; adversarial review (which caught the live-wallet gating hazard, now fixed); compiles + bundles; live smoke — a dev-settings Save during onboarding round-trips through the SW in ~80ms with no error. Not run: a full onboarding→wallet→sync E2E proving the RPC host actually switches (needs a reachable distinct node).
