### PR TITLE
ci: self-heal recurring SwiftPM cache corruption in iOS E2E builds

### DIFF
--- a/.github/workflows/e2e-blockchain.yml
+++ b/.github/workflows/e2e-blockchain.yml
@@ -562,7 +562,17 @@ jobs:
       # reaches them via simctl by UDID, independent of xcodebuild.
 
       - name: Build iOS app
-        run: yarn test:e2e:mobile:build
+        # Self-heal the recurring GitHub macOS-runner SwiftPM cache
+        # corruption ("xcodebuild: error: Could not resolve package
+        # dependencies: ... org.swift.swiftpm/repositories/<pkg> ... No
+        # such file or directory"): on a failed build, wipe the corrupt
+        # SwiftPM cache + derived data and retry once before failing.
+        run: |
+          yarn test:e2e:mobile:build || {
+            echo "::warning::iOS build failed; clearing SwiftPM cache (runner cache corruption) and retrying once"
+            rm -rf "$HOME/Library/Caches/org.swift.swiftpm" ios/App/build
+            yarn test:e2e:mobile:build
+          }
 
       - name: Run blockchain E2E (mobile, devnet)
         id: e2e
@@ -735,7 +745,17 @@ jobs:
       # reaches them via simctl by UDID, independent of xcodebuild.
 
       - name: Build iOS app
-        run: yarn test:e2e:mobile:build
+        # Self-heal the recurring GitHub macOS-runner SwiftPM cache
+        # corruption ("xcodebuild: error: Could not resolve package
+        # dependencies: ... org.swift.swiftpm/repositories/<pkg> ... No
+        # such file or directory"): on a failed build, wipe the corrupt
+        # SwiftPM cache + derived data and retry once before failing.
+        run: |
+          yarn test:e2e:mobile:build || {
+            echo "::warning::iOS build failed; clearing SwiftPM cache (runner cache corruption) and retrying once"
+            rm -rf "$HOME/Library/Caches/org.swift.swiftpm" ios/App/build
+            yarn test:e2e:mobile:build
+          }
 
       - name: Run blockchain E2E (mobile, testnet)
         # --retries=2 absorbs flaky CDP "no pages found" errors and degraded-
@@ -945,7 +965,17 @@ jobs:
       # reaches them via simctl by UDID, independent of xcodebuild.
 
       - name: Build iOS app
-        run: yarn test:e2e:mobile:build
+        # Self-heal the recurring GitHub macOS-runner SwiftPM cache
+        # corruption ("xcodebuild: error: Could not resolve package
+        # dependencies: ... org.swift.swiftpm/repositories/<pkg> ... No
+        # such file or directory"): on a failed build, wipe the corrupt
+        # SwiftPM cache + derived data and retry once before failing.
+        run: |
+          yarn test:e2e:mobile:build || {
+            echo "::warning::iOS build failed; clearing SwiftPM cache (runner cache corruption) and retrying once"
+            rm -rf "$HOME/Library/Caches/org.swift.swiftpm" ios/App/build
+            yarn test:e2e:mobile:build
+          }
 
       - name: Run Guardian E2E (mobile, devnet)
         id: e2e
@@ -1116,7 +1146,17 @@ jobs:
       # reaches them via simctl by UDID, independent of xcodebuild.
 
       - name: Build iOS app
-        run: yarn test:e2e:mobile:build
+        # Self-heal the recurring GitHub macOS-runner SwiftPM cache
+        # corruption ("xcodebuild: error: Could not resolve package
+        # dependencies: ... org.swift.swiftpm/repositories/<pkg> ... No
+        # such file or directory"): on a failed build, wipe the corrupt
+        # SwiftPM cache + derived data and retry once before failing.
+        run: |
+          yarn test:e2e:mobile:build || {
+            echo "::warning::iOS build failed; clearing SwiftPM cache (runner cache corruption) and retrying once"
+            rm -rf "$HOME/Library/Caches/org.swift.swiftpm" ios/App/build
+            yarn test:e2e:mobile:build
+          }
 
       - name: Run Guardian E2E (mobile, testnet)
         # --retries=2 absorbs the residual onboarding flake + flaky CDP on macos-26

--- a/.github/workflows/e2e-bridge-in.yml
+++ b/.github/workflows/e2e-bridge-in.yml
@@ -182,7 +182,17 @@ jobs:
       # Built for a GENERIC simulator destination (see test:e2e:mobile:build), so
       # it doesn't need a concrete booted device. E2E_EVM_RPC_URL is baked here.
       - name: Build iOS app
-        run: yarn test:e2e:mobile:build
+        # Self-heal the recurring GitHub macOS-runner SwiftPM cache
+        # corruption ("xcodebuild: error: Could not resolve package
+        # dependencies: ... org.swift.swiftpm/repositories/<pkg> ... No
+        # such file or directory"): on a failed build, wipe the corrupt
+        # SwiftPM cache + derived data and retry once before failing.
+        run: |
+          yarn test:e2e:mobile:build || {
+            echo "::warning::iOS build failed; clearing SwiftPM cache (runner cache corruption) and retrying once"
+            rm -rf "$HOME/Library/Caches/org.swift.swiftpm" ios/App/build
+            yarn test:e2e:mobile:build
+          }
 
       - name: Run bridge-IN deposit E2E (mobile, testnet + local Anvil)
         id: e2e


### PR DESCRIPTION
## Problem

The iOS `Build iOS app` step in the E2E workflows intermittently fails at SwiftPM package resolution with a corrupted **runner-side** SwiftPM cache:

```
xcodebuild: error: Could not resolve package dependencies:
  Git command 'git -C ~/Library/Caches/org.swift.swiftpm/repositories/<pkg> config --get remote.origin.url'
  failed: fatal: cannot change to '.../<pkg>': No such file or directory
```

It has recurred on different packages on different days — `CryptoSwift` (2026-08-05, blocking the 1.15.19 push) and `SwiftImageReadWrite` (2026-08-09, #520). Each time the job was green on the neighbouring commit and the change was unrelated to iOS, so it's pure GitHub macOS-runner cache corruption, not a code regression. Today it's the only red check on `origin/main`.

## Fix

Wrap the build so it **self-heals**: run `yarn test:e2e:mobile:build` as before; only on failure, wipe the corrupt SwiftPM cache (`~/Library/Caches/org.swift.swiftpm`) + derived data and retry once.

- **No happy-path cost** — the first attempt is unchanged; the clear+retry only runs when the build fails.
- Also absorbs the occasional transient build/sim flake, not just SPM corruption.
- Applied to all 5 `Build iOS app` steps across `e2e-bridge-in.yml` (1) and `e2e-blockchain.yml` (4).

## Notes / follow-up

- `build-mobile.yml`'s release iOS build uses a different (direct `xcodebuild`) step and hasn't been observed flaking; left out to keep this focused. Same wrapper could be applied there if it ever surfaces.
- CI-only change (no user-facing behavior) → `no changelog`.