### PR TITLE
fix(build): classic SVGR JSX runtime so minified production builds don't crash on undefined React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- [FIX][all] **Production (minified) builds no longer crash on load with "React is not defined."** The SVG→React (SVGR) transform in the vite configs generated components with the automatic JSX runtime (importing nothing from `react`), but the bundler recompiles those `moduleType: 'jsx'` modules with the *classic* runtime (tsconfig `jsx: "react"`, which neither the `esbuild` nor `oxc` JSX options override in rolldown-vite) — emitting `React.createElement` calls against an undefined `React`. Harmless in unminified dev builds (a stray `React` leaked into the chunk) but every minified production build crashed on first render. SVGR now emits the classic runtime so each generated component imports `React`, matching the compile. Applied to the extension, mobile, and desktop configs.
+
 - [FIX][all] **Private-note delivery no longer silently fails on fast chains.** The wallet relayed a private note's transport hint *after* waiting for the transaction to commit, so the hint (the client's sync height) could already be at or past the note's commitment block — the recipient scans forward from the hint and would never find the note. The note is now relayed *before* the commit wait (the SDK's prompt-relay flow), so the hint stays below the commitment block and the recipient picks the note up when it lands; the commit wait is preserved so `Completed` status still requires on-chain confirmation. Latent on testnet (slow blocks kept the sync height ≈ the commitment block at relay time); reproduced deterministically on a fast devnet.
 
 ### Features

--- a/vite.desktop.config.ts
+++ b/vite.desktop.config.ts
@@ -36,7 +36,11 @@ export default defineConfig({
             plugins: ['@svgr/plugin-jsx'],
             exportType: 'named',
             namedExport: 'ReactComponent',
-            jsxRuntime: 'automatic'
+            // Classic runtime so SVGR imports React into each generated component,
+            // matching the bundler's classic JSX compile (see vite.extension.config.ts
+            // for the full rationale) — automatic emits `React.createElement` with an
+            // undefined `React`, crashing minified production builds.
+            jsxRuntime: 'classic'
           },
           { filePath }
         );

--- a/vite.extension.config.ts
+++ b/vite.extension.config.ts
@@ -264,7 +264,17 @@ export default defineConfig({
             plugins: ['@svgr/plugin-jsx'],
             exportType: 'named',
             namedExport: 'ReactComponent',
-            jsxRuntime: 'automatic',
+            // Classic runtime so SVGR emits `import * as React from "react"` into
+            // each generated component. The output is returned as `moduleType: 'jsx'`
+            // and recompiled by the bundler with the CLASSIC runtime (tsconfig
+            // `jsx: "react"`, which rolldown-vite honors for these modules and which
+            // neither `esbuild` nor `oxc` JSX options override) → `React.createElement`.
+            // With the automatic runtime SVGR imports nothing from 'react', so those
+            // `React.createElement` calls reference an undefined `React` — harmless in
+            // unminified dev builds (a stray React leaks into the chunk) but crashing
+            // minified production builds ("React is not defined"). Classic keeps the
+            // import and the reference matched.
+            jsxRuntime: 'classic',
             prettier: false,
             svgo: false,
             titleProp: true,

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -97,7 +97,11 @@ export default defineConfig({
             plugins: ['@svgr/plugin-jsx'],
             exportType: 'named',
             namedExport: 'ReactComponent',
-            jsxRuntime: 'automatic'
+            // Classic runtime so SVGR imports React into each generated component,
+            // matching the bundler's classic JSX compile (see vite.extension.config.ts
+            // for the full rationale) — automatic emits `React.createElement` with an
+            // undefined `React`, crashing minified production builds.
+            jsxRuntime: 'classic'
           },
           { filePath }
         );


### PR DESCRIPTION
Same fix as #531 (which targets `next`), opened against `main` too because `main` and `next` have diverged (main is not an ancestor of next) and `main` carries the identical bug.

## Problem

Minified **production** builds (`MODE_ENV=production yarn build:extension`) crash on first render with `Uncaught ReferenceError: React is not defined` (blank UI). Unminified dev builds are fine, so local dev and the E2E harness never hit it (nothing sets `MODE_ENV=production`).

## Root cause

The custom SVG→React (SVGR) transform in the vite configs is `jsxRuntime: 'automatic'`, so SVGR imports **nothing** from `react`. It returns `moduleType: 'jsx'`, and the bundler recompiles those modules with the **classic** runtime (tsconfig `jsx: "react"`), emitting `React.createElement(...)` against a `React` that was never imported. Unminified builds leak a stray `React` into the chunk (works); minified builds tree-shake it away → crash. Note: rolldown-vite (Vite 8) transforms with **oxc, not esbuild**, and neither an `esbuild` nor `oxc` JSX-runtime override changes these `moduleType: 'jsx'` modules — so the fix has to be at the SVGR transform.

## Fix

`jsxRuntime: 'classic'` — classic SVGR emits `import * as React from "react"` into each generated component, matching the bundler's classic compile. Applied to `vite.{extension,mobile,desktop}.config.ts`.

## Verification

Done on the identical change in #531: production extension build's Dialogs chunk went from **370 free `React.createElement` → 0** (React now imported/minifier-renamed), and the **minified** build loaded in a real Chromium renders ("Welcome to Bread!") with **zero JS errors**. eslint clean.