### PR TITLE
ci: welcome external contributors with an airdrop-policy notice

### DIFF
--- a/.github/workflows/welcome-external-contributors.yml
+++ b/.github/workflows/welcome-external-contributors.yml
@@ -4,6 +4,15 @@ name: Welcome external contributors
 # opened by an EXTERNAL contributor (someone without write access — i.e. a
 # fork PR from a non-member).
 #
+# Two entry points:
+#   • pull_request_target (opened/reopened/ready_for_review) — the automatic
+#     path for new external PRs.
+#   • workflow_dispatch (pr_number) — a manual backfill / re-post tool for a
+#     specific PR (e.g. external PRs that were already open when this workflow
+#     first landed, which the event triggers can't reach retroactively). The
+#     external-contributor gate is re-applied to the dispatched PR, so a manual
+#     run can't welcome an insider by mistake.
+#
 # ── Why `pull_request_target` (NOT `pull_request`) ───────────────────────────
 # A PR from a fork gets a READ-ONLY GITHUB_TOKEN on `pull_request` events
 # (GitHub's security default for untrusted forks), regardless of the
@@ -16,67 +25,67 @@ name: Welcome external contributors
 # the default; it does not merely cap it).
 #
 # ── Safety ───────────────────────────────────────────────────────────────────
-# `pull_request_target` is only dangerous when the workflow EXECUTES
-# PR-supplied code (it runs with the base repo's secrets/token). This workflow
-# does NOT check out or run any PR code, install dependencies, or read any
-# secret beyond the default token — it only reads event metadata and posts a
-# comment. There is no injection surface: the one piece of PR-supplied text
-# used (the author's login) is read from the event payload INSIDE the script at
-# runtime via `context.payload` — never interpolated into the workflow YAML or
-# a shell — and a login is constrained to `[A-Za-z0-9-]` regardless.
+# `pull_request_target` (and `workflow_dispatch`) run with the base repo's
+# token, so they're only dangerous when the workflow EXECUTES PR-supplied code.
+# This workflow does NOT check out or run any PR code, install dependencies, or
+# read any secret beyond the default token — it only reads PR metadata and
+# posts a comment. There is no injection surface: the one piece of PR-supplied
+# text used (the author's login) is read from the API/event at runtime INSIDE
+# the script — never interpolated into the workflow YAML or a shell — and a
+# login is constrained to `[A-Za-z0-9-]` regardless.
 #
 # ── Robustness (so we never revisit for edge cases) ──────────────────────────
 #   • Fork PRs         → handled by `pull_request_target` (write token).
 #   • Insiders/bots    → filtered out by `author_association`, a fork check,
-#                        and `user.type`.
+#                        and `user.type` — enforced for BOTH entry points.
 #   • Duplicate posts  → the script upserts a single comment keyed by a hidden
 #                        HTML-comment marker, so a re-run / `reopened` /
-#                        `ready_for_review` updates in place, never dupes.
+#                        `ready_for_review` / repeat dispatch updates in place.
 #   • Transient errors → each API call retries (rate limit / 5xx / blip).
 #   • Hard failure     → NOT swallowed. If all retries fail the step fails
 #                        (red ✗, re-runnable) instead of silently posting
-#                        nothing — a dropped welcome must be visible, since
-#                        `opened` only fires once. (This workflow is not a
-#                        required check, so a red ✗ never blocks the PR.)
-#   • Event races      → `concurrency` serializes runs per PR (the upsert's
-#                        list-then-write is not atomic; the concurrency group
-#                        is what guarantees exactly-one — keep it).
-#   • No PAT/secret    → unlike the translation-push workflow (which needs a
-#                        PAT so its *pushed commit* re-triggers CI), a *comment*
-#                        has no such constraint; the default token suffices.
+#                        nothing. (This workflow is not a required check, so a
+#                        red ✗ never blocks the PR.)
+#   • Event races      → `concurrency` serializes runs per PR.
+#   • No PAT/secret    → a *comment* re-triggers nothing, so unlike the
+#                        translation-push workflow the default token suffices.
 
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to post/refresh the welcome comment on (manual backfill; the external-contributor gate still applies)."
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
 
 concurrency:
-  group: welcome-contributor-${{ github.event.pull_request.number }}
+  group: welcome-contributor-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
   welcome:
     name: Post welcome + airdrop notice
     runs-on: ubuntu-latest
-    # EXTERNAL contributors only:
+    # Fast-skip insiders on the automatic path (don't spin a runner for them);
+    # always run for a manual dispatch (the script re-checks the target PR).
     #   • author_association is OWNER / MEMBER / COLLABORATOR for people with
-    #     access; anyone else (CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR /
-    #     FIRST_TIMER / NONE / MANNEQUIN — or a future value) falls through to
-    #     "welcomed", so we never MISS a real external contributor.
-    #   • the fork check (`head.repo.full_name != <this repo>`) additionally
-    #     skips insiders who push a branch to the base repo — including a
-    #     private org member who surfaces as `author_association == NONE`.
-    #     External contributors can only ever open from a fork, so this never
-    #     skips a real one.
-    #   • skip bots (Dependabot / Renovate etc.).
+    #     access; anyone else falls through to "welcomed", so we never MISS a
+    #     real external contributor even if GitHub adds a new association value.
+    #   • the fork check additionally skips insiders (incl. private members who
+    #     surface as NONE) who push a branch to the base repo; external
+    #     contributors can only ever open from a fork, so this never skips one.
     if: >-
-      github.event.pull_request.author_association != 'OWNER' &&
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'COLLABORATOR' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      github.event.pull_request.user.type != 'Bot'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.author_association != 'OWNER' &&
+       github.event.pull_request.author_association != 'MEMBER' &&
+       github.event.pull_request.author_association != 'COLLABORATOR' &&
+       github.event.pull_request.head.repo.full_name != github.repository &&
+       github.event.pull_request.user.type != 'Bot')
     steps:
       - name: Post welcome + airdrop policy comment
         uses: actions/github-script@v7
@@ -84,9 +93,56 @@ jobs:
           script: |
             const MARKER = '<!-- external-contributor-welcome -->';
             const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
+
+            // Retry transient failures (secondary rate limits, 5xx, blips) so a
+            // single hiccup doesn't silently drop the welcome. Throws (fails the
+            // step, visibly) if every attempt fails.
+            const retry = async (label, fn) => {
+              let lastErr;
+              for (let attempt = 1; attempt <= 4; attempt++) {
+                try {
+                  return await fn();
+                } catch (err) {
+                  lastErr = err;
+                  core.warning(`${label} failed (attempt ${attempt}/4): ${err.message}`);
+                  if (attempt < 4) await new Promise(r => setTimeout(r, 3000 * attempt));
+                }
+              }
+              throw lastErr;
+            };
+
+            // Resolve the target PR from either entry point.
+            let pr;
+            if (context.eventName === 'workflow_dispatch') {
+              const pull_number = Number(context.payload.inputs.pr_number);
+              if (!Number.isInteger(pull_number) || pull_number <= 0) {
+                core.setFailed(`Invalid pr_number input: ${context.payload.inputs.pr_number}`);
+                return;
+              }
+              ({ data: pr } = await retry('get PR', () =>
+                github.rest.pulls.get({ owner, repo, pull_number })
+              ));
+            } else {
+              pr = context.payload.pull_request;
+            }
+
             const issue_number = pr.number;
             const login = pr.user.login;
+
+            // External-contributor gate — applied for BOTH paths so a manual
+            // dispatch can't welcome an insider. (The job `if` already skips
+            // insiders on the automatic path; this is the authoritative check
+            // for dispatch and a cheap defense-in-depth otherwise.)
+            const assoc = pr.author_association;
+            const isFork = pr.head.repo.full_name !== `${owner}/${repo}`;
+            const isBot = pr.user.type === 'Bot';
+            if (assoc === 'OWNER' || assoc === 'MEMBER' || assoc === 'COLLABORATOR' || !isFork || isBot) {
+              core.notice(
+                `PR #${issue_number} by @${login} (association=${assoc}, fork=${isFork}, bot=${isBot}) ` +
+                `is not an external contributor — skipping welcome.`
+              );
+              return;
+            }
 
             const body = [
               MARKER,
@@ -108,23 +164,6 @@ jobs:
               '',
               "Thanks again for being part of the community — we're glad you chose to contribute. 🚀"
             ].join('\n');
-
-            // Retry transient failures (secondary rate limits, 5xx, blips) so a
-            // single hiccup on the once-firing `opened` event doesn't silently
-            // drop the welcome. Throws (fails the step, visibly) if all attempts fail.
-            const retry = async (label, fn) => {
-              let lastErr;
-              for (let attempt = 1; attempt <= 4; attempt++) {
-                try {
-                  return await fn();
-                } catch (err) {
-                  lastErr = err;
-                  core.warning(`${label} failed (attempt ${attempt}/4): ${err.message}`);
-                  if (attempt < 4) await new Promise(r => setTimeout(r, 3000 * attempt));
-                }
-              }
-              throw lastErr;
-            };
 
             // Idempotent upsert: find our prior comment by the hidden marker,
             // update it in place if present, otherwise create it.

--- a/.github/workflows/welcome-external-contributors.yml
+++ b/.github/workflows/welcome-external-contributors.yml
@@ -104,10 +104,7 @@ jobs:
               '',
               '**One thing we want to be transparent about up front:** contributing to this',
               'repository will **not** make you eligible for any token airdrop, allocation, or',
-              'other reward — **not now, and not at any point in the future.** Please contribute',
-              "because you're interested in the technology and the project, not in expectation of",
-              'an airdrop. Anyone claiming that pull requests will be rewarded with tokens is not',
-              'speaking for the Miden team.',
+              'other reward — **not now, and not at any point in the future.**',
               '',
               "Thanks again for being part of the community — we're glad you chose to contribute. 🚀"
             ].join('\n');

--- a/.github/workflows/welcome-external-contributors.yml
+++ b/.github/workflows/welcome-external-contributors.yml
@@ -10,33 +10,44 @@ name: Welcome external contributors
 # `permissions:` block below — so the comment API call would 403 on exactly
 # the PRs we care about (external ones). `pull_request_target` runs in the
 # BASE repo's context with a write-capable token, which is what "comment on a
-# fork PR" requires. Same reasoning as `check-linked-web-sdk-pr.yml`.
+# fork PR" requires. Same reasoning as `check-linked-web-sdk-pr.yml`. The
+# explicit `permissions:` block grants `pull-requests: write` even when the
+# repo/org default token permission is read-only (an explicit block overrides
+# the default; it does not merely cap it).
 #
 # ── Safety ───────────────────────────────────────────────────────────────────
 # `pull_request_target` is only dangerous when the workflow EXECUTES
 # PR-supplied code (it runs with the base repo's secrets/token). This workflow
 # does NOT check out or run any PR code, install dependencies, or read any
 # secret beyond the default token — it only reads event metadata and posts a
-# sticky comment. There is no injection surface: the one piece of PR-supplied
-# text used is the author's login (`user.login`, a GitHub handle: constrained
-# to `[A-Za-z0-9-]`), interpolated into the comment body via the Actions
-# expression engine (never into a shell). No PR title/body/branch is used.
+# comment. There is no injection surface: the one piece of PR-supplied text
+# used (the author's login) is read from the event payload INSIDE the script at
+# runtime via `context.payload` — never interpolated into the workflow YAML or
+# a shell — and a login is constrained to `[A-Za-z0-9-]` regardless.
 #
 # ── Robustness (so we never revisit for edge cases) ──────────────────────────
 #   • Fork PRs         → handled by `pull_request_target` (write token).
-#   • Insiders/bots    → filtered out by `author_association` + `user.type`.
-#   • Duplicate posts  → the sticky `header` upserts one comment, so a re-run
-#                        or a `reopened` event updates in place, never dupes.
-#   • Comment failure  → `continue-on-error` (the comment is never a blocker).
-#   • Event races      → `concurrency` serializes runs per PR.
-#   • Permissions      → explicit `pull-requests: write`, the only scope needed.
-#   • No PAT/secret    → unlike the translation-push workflow (which needs a PAT
-#                        so its *pushed commit* re-triggers CI), a *comment* has
-#                        no such constraint; the default token suffices.
+#   • Insiders/bots    → filtered out by `author_association`, a fork check,
+#                        and `user.type`.
+#   • Duplicate posts  → the script upserts a single comment keyed by a hidden
+#                        HTML-comment marker, so a re-run / `reopened` /
+#                        `ready_for_review` updates in place, never dupes.
+#   • Transient errors → each API call retries (rate limit / 5xx / blip).
+#   • Hard failure     → NOT swallowed. If all retries fail the step fails
+#                        (red ✗, re-runnable) instead of silently posting
+#                        nothing — a dropped welcome must be visible, since
+#                        `opened` only fires once. (This workflow is not a
+#                        required check, so a red ✗ never blocks the PR.)
+#   • Event races      → `concurrency` serializes runs per PR (the upsert's
+#                        list-then-write is not atomic; the concurrency group
+#                        is what guarantees exactly-one — keep it).
+#   • No PAT/secret    → unlike the translation-push workflow (which needs a
+#                        PAT so its *pushed commit* re-triggers CI), a *comment*
+#                        has no such constraint; the default token suffices.
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   pull-requests: write
@@ -49,40 +60,90 @@ jobs:
   welcome:
     name: Post welcome + airdrop notice
     runs-on: ubuntu-latest
-    # EXTERNAL contributors only. `author_association` is OWNER / MEMBER /
-    # COLLABORATOR for people with access; anyone else (CONTRIBUTOR /
-    # FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / NONE / MANNEQUIN) is external.
-    # Also skip bots (Dependabot etc.) — they aren't contributors to welcome.
+    # EXTERNAL contributors only:
+    #   • author_association is OWNER / MEMBER / COLLABORATOR for people with
+    #     access; anyone else (CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR /
+    #     FIRST_TIMER / NONE / MANNEQUIN — or a future value) falls through to
+    #     "welcomed", so we never MISS a real external contributor.
+    #   • the fork check (`head.repo.full_name != <this repo>`) additionally
+    #     skips insiders who push a branch to the base repo — including a
+    #     private org member who surfaces as `author_association == NONE`.
+    #     External contributors can only ever open from a fork, so this never
+    #     skips a real one.
+    #   • skip bots (Dependabot / Renovate etc.).
     if: >-
       github.event.pull_request.author_association != 'OWNER' &&
       github.event.pull_request.author_association != 'MEMBER' &&
       github.event.pull_request.author_association != 'COLLABORATOR' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
       github.event.pull_request.user.type != 'Bot'
     steps:
       - name: Post welcome + airdrop policy comment
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.4
+        uses: actions/github-script@v7
         with:
-          header: external-contributor-welcome
-          number: ${{ github.event.pull_request.number }}
-          message: |
-            ### 👋 Thanks for contributing to Miden, @${{ github.event.pull_request.user.login }}!
+          script: |
+            const MARKER = '<!-- external-contributor-welcome -->';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const issue_number = pr.number;
+            const login = pr.user.login;
 
-            We really appreciate you taking the time to open this pull request. Miden is
-            building an edge-first, zero-knowledge blockchain, and thoughtful contributions
-            from the community are a big part of how it gets better. A maintainer will review
-            your changes as soon as they can — in the meantime, please make sure the CI checks
-            are green and that your change follows the repository's contribution guidelines.
+            const body = [
+              MARKER,
+              `### 👋 Thanks for contributing to Miden, @${login}!`,
+              '',
+              'We really appreciate you taking the time to open this pull request. Miden is',
+              'building an edge-first, zero-knowledge blockchain, and thoughtful contributions',
+              'from the community are a big part of how it gets better. A maintainer will review',
+              'your changes as soon as they can — in the meantime, please make sure the CI checks',
+              "are green and that your change follows the repository's contribution guidelines.",
+              '',
+              "We're genuinely excited to have you here. 🧡",
+              '',
+              '---',
+              '',
+              '**One thing we want to be transparent about up front:** contributing to this',
+              'repository will **not** make you eligible for any token airdrop, allocation, or',
+              'other reward — **not now, and not at any point in the future.** Please contribute',
+              "because you're interested in the technology and the project, not in expectation of",
+              'an airdrop. Anyone claiming that pull requests will be rewarded with tokens is not',
+              'speaking for the Miden team.',
+              '',
+              "Thanks again for being part of the community — we're glad you chose to contribute. 🚀"
+            ].join('\n');
 
-            We're genuinely excited to have you here. 🧡
+            // Retry transient failures (secondary rate limits, 5xx, blips) so a
+            // single hiccup on the once-firing `opened` event doesn't silently
+            // drop the welcome. Throws (fails the step, visibly) if all attempts fail.
+            const retry = async (label, fn) => {
+              let lastErr;
+              for (let attempt = 1; attempt <= 4; attempt++) {
+                try {
+                  return await fn();
+                } catch (err) {
+                  lastErr = err;
+                  core.warning(`${label} failed (attempt ${attempt}/4): ${err.message}`);
+                  if (attempt < 4) await new Promise(r => setTimeout(r, 3000 * attempt));
+                }
+              }
+              throw lastErr;
+            };
 
-            ---
+            // Idempotent upsert: find our prior comment by the hidden marker,
+            // update it in place if present, otherwise create it.
+            const comments = await retry('list comments', () =>
+              github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 })
+            );
+            const existing = comments.find(c => (c.body || '').includes(MARKER));
 
-            **One thing we want to be transparent about up front:** contributing to this
-            repository will **not** make you eligible for any token airdrop, allocation, or
-            other reward — **not now, and not at any point in the future.** Please contribute
-            because you're interested in the technology and the project, not in expectation of
-            an airdrop. Anyone claiming that pull requests will be rewarded with tokens is not
-            speaking for the Miden team.
-
-            Thanks again for being part of the community — we're glad you chose to contribute. 🚀
+            if (existing) {
+              await retry('update comment', () =>
+                github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+              );
+              core.info(`Updated existing welcome comment ${existing.id} on PR #${issue_number}.`);
+            } else {
+              await retry('create comment', () =>
+                github.rest.issues.createComment({ owner, repo, issue_number, body })
+              );
+              core.info(`Posted welcome comment on PR #${issue_number}.`);
+            }

--- a/.github/workflows/welcome-external-contributors.yml
+++ b/.github/workflows/welcome-external-contributors.yml
@@ -1,0 +1,88 @@
+name: Welcome external contributors
+
+# Posts a one-time, idempotent welcome + airdrop-policy comment on every PR
+# opened by an EXTERNAL contributor (someone without write access — i.e. a
+# fork PR from a non-member).
+#
+# ── Why `pull_request_target` (NOT `pull_request`) ───────────────────────────
+# A PR from a fork gets a READ-ONLY GITHUB_TOKEN on `pull_request` events
+# (GitHub's security default for untrusted forks), regardless of the
+# `permissions:` block below — so the comment API call would 403 on exactly
+# the PRs we care about (external ones). `pull_request_target` runs in the
+# BASE repo's context with a write-capable token, which is what "comment on a
+# fork PR" requires. Same reasoning as `check-linked-web-sdk-pr.yml`.
+#
+# ── Safety ───────────────────────────────────────────────────────────────────
+# `pull_request_target` is only dangerous when the workflow EXECUTES
+# PR-supplied code (it runs with the base repo's secrets/token). This workflow
+# does NOT check out or run any PR code, install dependencies, or read any
+# secret beyond the default token — it only reads event metadata and posts a
+# sticky comment. There is no injection surface: the one piece of PR-supplied
+# text used is the author's login (`user.login`, a GitHub handle: constrained
+# to `[A-Za-z0-9-]`), interpolated into the comment body via the Actions
+# expression engine (never into a shell). No PR title/body/branch is used.
+#
+# ── Robustness (so we never revisit for edge cases) ──────────────────────────
+#   • Fork PRs         → handled by `pull_request_target` (write token).
+#   • Insiders/bots    → filtered out by `author_association` + `user.type`.
+#   • Duplicate posts  → the sticky `header` upserts one comment, so a re-run
+#                        or a `reopened` event updates in place, never dupes.
+#   • Comment failure  → `continue-on-error` (the comment is never a blocker).
+#   • Event races      → `concurrency` serializes runs per PR.
+#   • Permissions      → explicit `pull-requests: write`, the only scope needed.
+#   • No PAT/secret    → unlike the translation-push workflow (which needs a PAT
+#                        so its *pushed commit* re-triggers CI), a *comment* has
+#                        no such constraint; the default token suffices.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: welcome-contributor-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  welcome:
+    name: Post welcome + airdrop notice
+    runs-on: ubuntu-latest
+    # EXTERNAL contributors only. `author_association` is OWNER / MEMBER /
+    # COLLABORATOR for people with access; anyone else (CONTRIBUTOR /
+    # FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / NONE / MANNEQUIN) is external.
+    # Also skip bots (Dependabot etc.) — they aren't contributors to welcome.
+    if: >-
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
+      github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: Post welcome + airdrop policy comment
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.4
+        with:
+          header: external-contributor-welcome
+          number: ${{ github.event.pull_request.number }}
+          message: |
+            ### 👋 Thanks for contributing to Miden, @${{ github.event.pull_request.user.login }}!
+
+            We really appreciate you taking the time to open this pull request. Miden is
+            building an edge-first, zero-knowledge blockchain, and thoughtful contributions
+            from the community are a big part of how it gets better. A maintainer will review
+            your changes as soon as they can — in the meantime, please make sure the CI checks
+            are green and that your change follows the repository's contribution guidelines.
+
+            We're genuinely excited to have you here. 🧡
+
+            ---
+
+            **One thing we want to be transparent about up front:** contributing to this
+            repository will **not** make you eligible for any token airdrop, allocation, or
+            other reward — **not now, and not at any point in the future.** Please contribute
+            because you're interested in the technology and the project, not in expectation of
+            an airdrop. Anyone claiming that pull requests will be rewarded with tokens is not
+            speaking for the Miden team.
+
+            Thanks again for being part of the community — we're glad you chose to contribute. 🚀

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -2275,6 +2275,22 @@
     "message": "Anbieter",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Endpunkt",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Region",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Letzte Synchronisierung",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "Online",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Überprüfungsrotation",
     "englishSource": "Review rotation"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -2227,6 +2227,34 @@
     "message": "Provider",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Endpoint",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Region",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Last sync",
+    "englishSource": "Last sync"
+  },
+  "guardianProviderRegion": {
+    "message": "$provider$ · $region$",
+    "englishSource": "$provider$ · $region$",
+    "placeholders": {
+      "provider": {
+        "content": "$1"
+      },
+      "region": {
+        "content": "$2"
+      }
+    }
+  },
+  "online": {
+    "message": "Online",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Review rotation",
     "englishSource": "Review rotation"

--- a/public/_locales/en_GB/messages.json
+++ b/public/_locales/en_GB/messages.json
@@ -2276,6 +2276,34 @@
     "message": "Provider",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Endpoint",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Region",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Last sync",
+    "englishSource": "Last sync"
+  },
+  "guardianProviderRegion": {
+    "message": "$provider$ · $region$",
+    "englishSource": "$provider$ · $region$",
+    "placeholders": {
+      "provider": {
+        "content": "$1"
+      },
+      "region": {
+        "content": "$2"
+      }
+    }
+  },
+  "online": {
+    "message": "Online",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Review rotation",
     "englishSource": "Review rotation"

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -2227,6 +2227,22 @@
     "message": "Proveedor",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Punto final",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Región",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Última sincronización",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "En línea",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Rotación de revisión",
     "englishSource": "Review rotation"

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -2274,6 +2274,22 @@
     "message": "Fournisseur",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Point de terminaison",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Région",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Dernière synchronisation",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "En ligne",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Rotation des révisions",
     "englishSource": "Review rotation"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -2275,6 +2275,22 @@
     "message": "プロバイダー",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "終点",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "地域",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "最終同期",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "オンライン",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "ローテーションの見直し",
     "englishSource": "Review rotation"

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -2275,6 +2275,22 @@
     "message": "공급자",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "엔드포인트",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "지역",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "마지막 동기화",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "온라인",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "순환 검토",
     "englishSource": "Review rotation"

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -2227,6 +2227,22 @@
     "message": "Dostawca",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Punkt końcowy",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Region",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Ostatnia synchronizacja",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "W Internecie",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Przejrzyj rotację",
     "englishSource": "Review rotation"

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -2273,6 +2273,22 @@
     "message": "Provedor",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Ponto final",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Região",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Última sincronização",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "On-line",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Revise a rotação",
     "englishSource": "Review rotation"

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -2276,6 +2276,22 @@
     "message": "Поставщик",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Конечная точка",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Область",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Последняя синхронизация",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "Онлайн",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Обзор ротации",
     "englishSource": "Review rotation"

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -2275,6 +2275,22 @@
     "message": "sağlayıcı",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Uç nokta",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Bölge",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Son senkronizasyon",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "Çevrimiçi",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Rotasyonu inceleyin",
     "englishSource": "Review rotation"

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -2276,6 +2276,34 @@
     "message": "Провайдер",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "Кінцева точка",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "Регіон",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "Остання синхронізація",
+    "englishSource": "Last sync"
+  },
+  "guardianProviderRegion": {
+    "message": "$provider$ · $region$",
+    "englishSource": "$provider$ · $region$",
+    "placeholders": {
+      "provider": {
+        "content": "$1"
+      },
+      "region": {
+        "content": "$2"
+      }
+    }
+  },
+  "online": {
+    "message": "Онлайн",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "Оглядова ротація",
     "englishSource": "Review rotation"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -2275,6 +2275,22 @@
     "message": "提供者",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "端点",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "地区",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "上次同步",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "在线的",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "审查轮换",
     "englishSource": "Review rotation"

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -2275,6 +2275,22 @@
     "message": "提供者",
     "englishSource": "Provider"
   },
+  "guardianEndpointLabel": {
+    "message": "端点",
+    "englishSource": "Endpoint"
+  },
+  "guardianRegion": {
+    "message": "地区",
+    "englishSource": "Region"
+  },
+  "guardianLastSync": {
+    "message": "上次同步",
+    "englishSource": "Last sync"
+  },
+  "online": {
+    "message": "在线的",
+    "englishSource": "Online"
+  },
   "reviewRotation": {
     "message": "审查轮换",
     "englishSource": "Review rotation"


### PR DESCRIPTION
Automatically posts a welcome + airdrop-policy comment on every PR opened by an **external contributor** (a fork PR from a non-member).

The comment (1) thanks them and conveys genuine excitement about Miden, and (2) states clearly that contributing will **not** make anyone eligible for a token airdrop/allocation/reward — now or in the future — so expectations are set up front and consistently.

### Mechanism (and the edge cases it handles)
Built on the same proven pattern as `check-linked-web-sdk-pr.yml`, hardened after an adversarial review:

- **`pull_request_target` (not `pull_request`)** — a fork PR gets a read-only `GITHUB_TOKEN` on `pull_request`, so a comment would 403 on exactly the external PRs we care about. `pull_request_target` runs in the base-repo context with a write-capable token. Explicit `permissions: pull-requests: write` grants the scope even when the org default token permission is read-only.
- **Safe** — no fork code is checked out or executed; the only PR-supplied value used (the author login) is read from `context` at runtime, never interpolated into YAML/shell. First-party `actions/github-script` only.
- **Idempotent** — upserts a single comment keyed by a hidden marker, so re-runs / `reopened` / `ready_for_review` update in place, never duplicate.
- **Never silently drops a welcome** — each API call retries (4× backoff for rate-limit/5xx/blips); if it ultimately fails the step fails **visibly** (re-runnable) rather than going green with no comment. This workflow is not a required check, so a red ✗ never blocks a PR.
- **Targets external contributors only** — denylist on `author_association` (so an unknown/new association still gets welcomed — we never miss a real external), plus a fork check (skips insiders / private org members pushing base-repo branches) and `user.type != 'Bot'`.
- **Concurrency** group serializes runs per PR (the list-then-upsert isn't atomic on its own).

Activates only after merge to `main` (`pull_request_target` loads the workflow from the base ref), so it won't self-trigger on this PR.

_No CHANGELOG entry: CI-only workflow, no user-facing wallet change (`no changelog` label applied)._
