### PR TITLE
ci: fix welcome-comment line wrapping

### DIFF
--- a/.github/workflows/welcome-external-contributors.yml
+++ b/.github/workflows/welcome-external-contributors.yml
@@ -144,26 +144,22 @@ jobs:
               return;
             }
 
+            // Each paragraph is a SINGLE continuous line; paragraphs are joined
+            // by a blank line ('\n\n'). GitHub renders a lone newline inside a
+            // paragraph as a <br>, so pre-wrapping the prose (one array entry
+            // per ~80 chars) produced hard breaks that stopped short of the
+            // comment width. Keeping each paragraph on one line lets GitHub
+            // soft-wrap it to the full box width. The blank line around '---'
+            // is required for it to render as a horizontal rule.
             const body = [
               MARKER,
               `### 👋 Thanks for contributing to Miden, @${login}!`,
-              '',
-              'We really appreciate you taking the time to open this pull request. Miden is',
-              'building an edge-first, zero-knowledge blockchain, and thoughtful contributions',
-              'from the community are a big part of how it gets better. A maintainer will review',
-              'your changes as soon as they can — in the meantime, please make sure the CI checks',
-              "are green and that your change follows the repository's contribution guidelines.",
-              '',
+              "We really appreciate you taking the time to open this pull request. Miden is building an edge-first, zero-knowledge blockchain, and thoughtful contributions from the community are a big part of how it gets better. A maintainer will review your changes as soon as they can — in the meantime, please make sure the CI checks are green and that your change follows the repository's contribution guidelines.",
               "We're genuinely excited to have you here. 🧡",
-              '',
               '---',
-              '',
-              '**One thing we want to be transparent about up front:** contributing to this',
-              'repository will **not** make you eligible for any token airdrop, allocation, or',
-              'other reward — **not now, and not at any point in the future.**',
-              '',
+              "**One thing we want to be transparent about up front:** contributing to this repository will **not** make you eligible for any token airdrop, allocation, or other reward — **not now, and not at any point in the future.**",
               "Thanks again for being part of the community — we're glad you chose to contribute. 🚀"
-            ].join('\n');
+            ].join('\n\n');
 
             // Idempotent upsert: find our prior comment by the hidden marker,
             // update it in place if present, otherwise create it.


### PR DESCRIPTION
Follow-up to #538. The welcome-comment body was built from an array of pre-wrapped ~80-char lines joined with `\n`. GitHub renders a lone newline inside a paragraph as a `<br>`, so each wrap showed as a hard break that stopped short of the comment width.

Fix: each paragraph is now a single continuous line; paragraphs are joined by a blank line (`\n\n`) so GitHub soft-wraps them to full width. The blank line around `---` keeps it rendering as a horizontal rule. No copy changes.

The three already-posted welcome comments (#517/#518/#519) were edited in place to this same body (still github-actions[bot]-authored).