### PR TITLE
chore: add CODEOWNERS to auto-request review on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Auto-request @WiktorStarczewski to review every PR into this branch.
+#
+# GitHub reads CODEOWNERS from the PR's base branch, so this file is kept on
+# `main` and `next` to scope the auto-request to those two branches (PRs into
+# other branches don't trigger it). This only REQUESTS a review — it does not
+# block merging unless "Require review from Code Owners" is enabled in this
+# branch's protection rules. GitHub never requests the PR's own author, so this
+# adds the reviewer on everyone else's PRs, not your own.
+* @WiktorStarczewski


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @WiktorStarczewski` so every PR into this branch automatically requests @WiktorStarczewski as a reviewer.

GitHub reads CODEOWNERS from the PR's **base branch**, so a companion PR adds the same file to `next` — together they scope the auto-request to **main + next** only.

Notes:
- This **requests** a review; it does not block merging unless "Require review from Code Owners" is enabled in branch protection.
- GitHub never requests the PR author, so this adds the reviewer on others' PRs, not your own.