### PR TITLE
chore: add CODEOWNERS to auto-request review on all PRs (next)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Auto-request @WiktorStarczewski to review every PR into this branch.
+#
+# GitHub reads CODEOWNERS from the PR's base branch, so this file is kept on
+# `main` and `next` to scope the auto-request to those two branches (PRs into
+# other branches don't trigger it). This only REQUESTS a review — it does not
+# block merging unless "Require review from Code Owners" is enabled in this
+# branch's protection rules. GitHub never requests the PR's own author, so this
+# adds the reviewer on everyone else's PRs, not your own.
+* @WiktorStarczewski


### PR DESCRIPTION
Companion to the `main` CODEOWNERS PR — adds `.github/CODEOWNERS` (`* @WiktorStarczewski`) to `next` so PRs targeting `next` also auto-request @WiktorStarczewski. GitHub reads CODEOWNERS from the PR's base branch, so it must live on `next` too. Non-blocking (requests only) unless "Require review from Code Owners" is enabled; the author is never auto-requested on their own PRs.