### PR TITLE
docs: prefer shared wallet buttons in frontend skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- [CHANGE][all] **Frontend skill guidance now defaults standard actions to the shared wallet button.** The shared frontend skill directs standard wallet actions to `components/Button`, reserving native buttons for compact, icon-only, or inline controls that the full CTA cannot represent.
 - [CHANGE][all] **Frontend implementation guidance is now shared across supported coding agents.** The repository now carries one vendor-neutral Miden Wallet frontend skill for component reuse, semantic styling, motion, accessibility, haptics, and cross-platform verification, with matching concise rules in the repository instructions.
 
 ### Fixes

--- a/skills/miden-wallet-frontend/references/motion-and-interaction.md
+++ b/skills/miden-wallet-frontend/references/motion-and-interaction.md
@@ -29,7 +29,7 @@ An indeterminate progress runner, icon flip, and hero state pop are all owned by
 
 ## Interaction Requirements
 
-Use a native `button` for an action and an `a` for navigation whenever possible. Icon-only controls need an accessible name. Status or asynchronous completion needs the right `role` or live-region behavior. Keyboard users must receive the same action with Enter and Space when a custom control is unavoidable.
+Use `components/Button` for standard wallet actions. Use a native `button` only for compact, icon-only, or inline controls that the full CTA component cannot represent; use an `a` for navigation. Never replace a suitable button with a `div`. Icon-only controls need an accessible name. Status or asynchronous completion needs the right `role` or live-region behavior. Keyboard users must receive the same action with Enter and Space when a custom control is unavoidable.
 
 Mobile feedback follows intent:
 


### PR DESCRIPTION
## Summary

Refines the shared frontend skill after review feedback on #515. Standard wallet actions now default to `components/Button`; bare native buttons are reserved for compact, icon-only, or inline controls that the full CTA cannot represent.

## Validation

- `quick_validate.py` passes for `skills/miden-wallet-frontend`.
- `git diff --check` and post-commit `git show --check` pass.

## Out of scope

- Runtime UI component changes
- Replacing existing controls across the application
- Dependency or lockfile changes