### PR TITLE
fix(guardian): standardize provider display names via a canonical brand mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.15.20 (TBD)
 
+### Fixes
+
+- [FIX][all] **Guardian provider names are spelled consistently across the wallet.** Onboarding, Settings, Activity and recovery now read each operator's display name from one canonical source, so "OpenZeppelin" and "LambdaClass" render the same everywhere (previously a mix of "Open-Zeppelin"/"Lambda Class"). (#464)
+
 ### Changes
 
 - [CHANGE][all] **Frontend implementation guidance is now shared across supported coding agents.** The repository now carries one vendor-neutral Miden Wallet frontend skill for component reuse, semantic styling, motion, accessibility, haptics, and cross-platform verification, with matching concise rules in the repository instructions.

--- a/src/components/GuardianTransitionHero.test.tsx
+++ b/src/components/GuardianTransitionHero.test.tsx
@@ -34,7 +34,7 @@ it('renders provider names and a custom endpoint hostname between the supplied l
 
   expect(screen.getByTestId('guardian-transition-hero')).toHaveClass('history-hero');
   expect(screen.getByText('Current')).toBeInTheDocument();
-  expect(screen.getByText('Lambda Class')).toBeInTheDocument();
+  expect(screen.getByText('LambdaClass')).toBeInTheDocument();
   expect(screen.getByTestId('transition-icon')).toHaveTextContent('ArrowDown');
   expect(screen.getByText('New')).toBeInTheDocument();
   expect(screen.getByText('custom.guardian.example')).toBeInTheDocument();
@@ -62,6 +62,6 @@ it('emphasizes the destination and keeps review labels readable in dark mode', (
   expect(screen.getByText('Current')).toHaveClass('text-heading-gray');
   expect(screen.getByText('EU-WEST')).toHaveClass('text-text-muted');
   expect(screen.getByText('New')).toHaveClass('text-primary-500');
-  expect(screen.getByText('Open-Zeppelin · US-EAST')).toHaveClass('text-pure-white');
-  expect(screen.getByText('Open-Zeppelin', { selector: 'h2' })).toHaveClass('text-pure-white');
+  expect(screen.getByText('OpenZeppelin · US-EAST')).toHaveClass('text-pure-white');
+  expect(screen.getByText('OpenZeppelin', { selector: 'h2' })).toHaveClass('text-pure-white');
 });

--- a/src/lib/miden-chain/constants.test.ts
+++ b/src/lib/miden-chain/constants.test.ts
@@ -71,8 +71,8 @@ describe('miden-chain/constants', () => {
         expect(getGuardianOptionsForNetwork(MIDEN_NETWORK_NAME.DEVNET)).toEqual([
           {
             id: 'open-zeppelin',
-            name: 'Open-Zeppelin',
-            operatedBy: 'Open-Zeppelin',
+            name: 'OpenZeppelin',
+            operatedBy: 'OpenZeppelin',
             location: 'US-EAST',
             endpoint: 'https://guardian-stg.openzeppelin.com'
           }

--- a/src/lib/miden-chain/constants.test.ts
+++ b/src/lib/miden-chain/constants.test.ts
@@ -99,6 +99,10 @@ describe('miden-chain/constants', () => {
           const { getGuardianOptionsForNetwork, MIDEN_NETWORK_NAME } = require('./constants');
           const opts = getGuardianOptionsForNetwork(MIDEN_NETWORK_NAME.LOCALNET);
           expect(opts.map((o: { endpoint: string }) => o.endpoint)).toContain('http://localhost:3001');
+          // The E2E-only operator must use the canonical brand spelling too (#464).
+          const ozB = opts.find((o: { endpoint: string }) => o.endpoint === 'http://localhost:3001');
+          expect(ozB?.name).toBe('OpenZeppelin B');
+          expect(ozB?.operatedBy).toBe('OpenZeppelin');
         });
       });
 

--- a/src/lib/miden-chain/constants.ts
+++ b/src/lib/miden-chain/constants.ts
@@ -8,6 +8,7 @@ import {
 } from 'lib/miden-chain/effective-endpoints';
 import {
   DEFAULT_NETWORK,
+  GUARDIAN_BRAND_NAME,
   GUARDIAN_OPTIONS,
   MIDEN_EXPLORER_ENDPOINTS,
   MIDEN_GUARDIAN_ENDPOINTS,
@@ -61,7 +62,7 @@ export function getGuardianOptionsForNetwork(
     options.push({
       id: 'open-zeppelin-b',
       name: 'OpenZeppelin B',
-      operatedBy: 'Open-Zeppelin',
+      operatedBy: GUARDIAN_BRAND_NAME.openZeppelin,
       location: 'US-EAST',
       endpoint: 'http://localhost:3001'
     });

--- a/src/lib/miden-chain/constants.ts
+++ b/src/lib/miden-chain/constants.ts
@@ -61,7 +61,7 @@ export function getGuardianOptionsForNetwork(
   if (network === MIDEN_NETWORK_NAME.LOCALNET && process.env.MIDEN_E2E_TEST === 'true') {
     options.push({
       id: 'open-zeppelin-b',
-      name: 'OpenZeppelin B',
+      name: `${GUARDIAN_BRAND_NAME.openZeppelin} B`,
       operatedBy: GUARDIAN_BRAND_NAME.openZeppelin,
       location: 'US-EAST',
       endpoint: 'http://localhost:3001'

--- a/src/lib/miden-chain/networks-config.test.ts
+++ b/src/lib/miden-chain/networks-config.test.ts
@@ -1,4 +1,4 @@
-import { GUARDIAN_OPTIONS } from './networks-config';
+import { GUARDIAN_BRAND_NAME, GUARDIAN_OPTIONS } from './networks-config';
 
 /**
  * #464 — Guardian provider display names must be spelled canonically and come
@@ -26,6 +26,10 @@ describe('GUARDIAN_OPTIONS canonical provider names (#464)', () => {
 
   it('keeps Gateway as the canonical operator brand', () => {
     expect(byId('gateway').operatedBy).toBe('Gateway');
+  });
+
+  it('derives descriptive names from the canonical brand (no drifting literal)', () => {
+    expect(byId('gateway').name).toBe(`${GUARDIAN_BRAND_NAME.gateway} Operator`);
   });
 
   it('never uses a non-canonical spelling for any provider', () => {

--- a/src/lib/miden-chain/networks-config.test.ts
+++ b/src/lib/miden-chain/networks-config.test.ts
@@ -1,0 +1,40 @@
+import { GUARDIAN_OPTIONS } from './networks-config';
+
+/**
+ * #464 — Guardian provider display names must be spelled canonically and come
+ * from the single GUARDIAN_OPTIONS source, so onboarding, Settings, Activity,
+ * recovery and success/error copy all render the same brand name.
+ */
+describe('GUARDIAN_OPTIONS canonical provider names (#464)', () => {
+  const byId = (id: string) => {
+    const option = GUARDIAN_OPTIONS.find(o => o.id === id);
+    if (!option) throw new Error(`no guardian option with id "${id}"`);
+    return option;
+  };
+
+  it('spells OpenZeppelin as one word', () => {
+    const oz = byId('open-zeppelin');
+    expect(oz.name).toBe('OpenZeppelin');
+    expect(oz.operatedBy).toBe('OpenZeppelin');
+  });
+
+  it('spells LambdaClass as one word', () => {
+    const lc = byId('lambda-class');
+    expect(lc.name).toBe('LambdaClass');
+    expect(lc.operatedBy).toBe('LambdaClass');
+  });
+
+  it('keeps Gateway as the canonical operator brand', () => {
+    expect(byId('gateway').operatedBy).toBe('Gateway');
+  });
+
+  it('never uses a non-canonical spelling for any provider', () => {
+    const forbidden = ['Open Zeppelin', 'Open-Zeppelin', 'Lambda Class'];
+    for (const option of GUARDIAN_OPTIONS) {
+      for (const bad of forbidden) {
+        expect(option.name).not.toContain(bad);
+        expect(option.operatedBy).not.toContain(bad);
+      }
+    }
+  });
+});

--- a/src/lib/miden-chain/networks-config.ts
+++ b/src/lib/miden-chain/networks-config.ts
@@ -123,7 +123,7 @@ export const GUARDIAN_OPTIONS: GuardianOption[] = [
   },
   {
     id: 'gateway',
-    name: 'Gateway Operator',
+    name: `${GUARDIAN_BRAND_NAME.gateway} Operator`,
     operatedBy: GUARDIAN_BRAND_NAME.gateway,
     location: 'EU-NORTH',
     endpoint: new Map<MIDEN_NETWORK_NAME, string>([

--- a/src/lib/miden-chain/networks-config.ts
+++ b/src/lib/miden-chain/networks-config.ts
@@ -91,6 +91,18 @@ export const MIDEN_NETWORKS: MidenNetwork[] = [
 ];
 
 /**
+ * Canonical Guardian provider brand names — the single source of truth for how
+ * each operator is spelled in the UI (onboarding, Settings, Activity, recovery,
+ * and success/error copy). Keeps spellings consistent (#464): "OpenZeppelin",
+ * not "Open Zeppelin"/"Open-Zeppelin"; "LambdaClass", not "Lambda Class"/"Lambda".
+ */
+export const GUARDIAN_BRAND_NAME = {
+  openZeppelin: 'OpenZeppelin',
+  gateway: 'Gateway',
+  lambdaClass: 'LambdaClass'
+} as const;
+
+/**
  * The Guardian providers a user can choose from during onboarding or when
  * switching their Guardian. Each provider maps the networks it supports to its
  * endpoint on that network (OpenZeppelin runs on both testnet and devnet; the
@@ -99,8 +111,8 @@ export const MIDEN_NETWORKS: MidenNetwork[] = [
 export const GUARDIAN_OPTIONS: GuardianOption[] = [
   {
     id: 'open-zeppelin',
-    name: 'Open-Zeppelin',
-    operatedBy: 'Open-Zeppelin',
+    name: GUARDIAN_BRAND_NAME.openZeppelin,
+    operatedBy: GUARDIAN_BRAND_NAME.openZeppelin,
     location: 'US-EAST',
     endpoint: new Map<MIDEN_NETWORK_NAME, string>([
       [MIDEN_NETWORK_NAME.TESTNET, 'https://guardian.openzeppelin.com'],
@@ -112,7 +124,7 @@ export const GUARDIAN_OPTIONS: GuardianOption[] = [
   {
     id: 'gateway',
     name: 'Gateway Operator',
-    operatedBy: 'Gateway',
+    operatedBy: GUARDIAN_BRAND_NAME.gateway,
     location: 'EU-NORTH',
     endpoint: new Map<MIDEN_NETWORK_NAME, string>([
       [MIDEN_NETWORK_NAME.TESTNET, 'https://miden-guardian.dev.eu-north-3.gateway.fm']
@@ -120,8 +132,8 @@ export const GUARDIAN_OPTIONS: GuardianOption[] = [
   },
   {
     id: 'lambda-class',
-    name: 'Lambda Class',
-    operatedBy: 'Lambda Class',
+    name: GUARDIAN_BRAND_NAME.lambdaClass,
+    operatedBy: GUARDIAN_BRAND_NAME.lambdaClass,
     location: 'EU-WEST',
     endpoint: new Map<MIDEN_NETWORK_NAME, string>([
       [MIDEN_NETWORK_NAME.TESTNET, 'https://miden-guardian.lambdaclass.com']

--- a/src/lib/miden/guardian/account.test.ts
+++ b/src/lib/miden/guardian/account.test.ts
@@ -285,7 +285,7 @@ describe('getGuardianCommitmentFromAccount', () => {
 });
 
 describe('guardianProviderFromEndpoint', () => {
-  it('maps a known Open-Zeppelin endpoint to its provider id', () => {
+  it('maps a known OpenZeppelin endpoint to its provider id', () => {
     expect(guardianProviderFromEndpoint('https://guardian.openzeppelin.com')).toBe('open-zeppelin');
   });
 
@@ -293,7 +293,7 @@ describe('guardianProviderFromEndpoint', () => {
     expect(guardianProviderFromEndpoint('https://miden-guardian.dev.eu-north-3.gateway.fm')).toBe('gateway');
   });
 
-  it('maps a known Lambda Class endpoint to its provider id', () => {
+  it('maps a known LambdaClass endpoint to its provider id', () => {
     expect(guardianProviderFromEndpoint('https://miden-guardian.lambdaclass.com')).toBe('lambda-class');
   });
 

--- a/src/screens/onboarding/common/ChooseGuardian.test.tsx
+++ b/src/screens/onboarding/common/ChooseGuardian.test.tsx
@@ -108,8 +108,8 @@ const GATEWAY = {
 };
 const LAMBDA = {
   id: 'lambda-class',
-  name: 'Lambda Class',
-  operatedBy: 'Lambda Class',
+  name: 'LambdaClass',
+  operatedBy: 'LambdaClass',
   location: 'EU-WEST',
   endpoint: 'https://lc.example.com'
 };

--- a/src/screens/onboarding/import-wallet-flow/ImportRecoveryMethod.test.tsx
+++ b/src/screens/onboarding/import-wallet-flow/ImportRecoveryMethod.test.tsx
@@ -73,7 +73,7 @@ const renderScreen = (overrides: Partial<React.ComponentProps<typeof ImportRecov
 
 const continueButton = () => screen.getByTestId('continue-button') as HTMLButtonElement;
 const guardianInput = () => screen.getByTestId('guardian-input') as HTMLInputElement;
-const ozPreset = () => screen.getByRole('button', { name: /Open-Zeppelin/ });
+const ozPreset = () => screen.getByRole('button', { name: /OpenZeppelin/ });
 const gatewayPreset = () => screen.getByRole('button', { name: /Gateway Operator/ });
 const customToggle = () => screen.getByRole('button', { name: /useDifferentGuardian/ });
 const selectGuardian = () => fireEvent.click(screen.getByText('importViaGuardian'));
@@ -109,7 +109,7 @@ describe('ImportRecoveryMethodScreen', () => {
     // All testnet Guardian providers are offered as presets.
     expect(ozPreset()).toBeInTheDocument();
     expect(gatewayPreset()).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Lambda Class/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /LambdaClass/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Koda/ })).toBeInTheDocument();
 
     // The seeded OpenZeppelin preset is active; the others are not.
@@ -236,7 +236,7 @@ describe('ImportRecoveryMethodScreen', () => {
 
     // Guardian-only UI is gone.
     expect(screen.queryByText('guardianEndpoint')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Open-Zeppelin/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /OpenZeppelin/ })).not.toBeInTheDocument();
 
     // On-chain never needs an endpoint, so Continue is enabled.
     expect(continueButton()).toBeEnabled();
@@ -304,7 +304,7 @@ describe('ImportRecoveryMethodScreen — guardian auto-detection', () => {
     expect(continueButton()).toBeDisabled();
 
     // No picker while we're still deciding what to preselect.
-    expect(screen.queryByRole('button', { name: /Open-Zeppelin/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /OpenZeppelin/ })).not.toBeInTheDocument();
     expect(screen.queryByTestId('guardian-input')).not.toBeInTheDocument();
   });
 
@@ -330,7 +330,7 @@ describe('ImportRecoveryMethodScreen — guardian auto-detection', () => {
       });
 
       fireEvent.click(customToggleAfterDetection());
-      expect(screen.getByRole('button', { name: /Open-Zeppelin/ })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /OpenZeppelin/ })).toBeInTheDocument();
       expect(screen.getByTestId('guardian-input')).toBeInTheDocument();
     } finally {
       jest.useRealTimers();
@@ -355,7 +355,7 @@ describe('ImportRecoveryMethodScreen — guardian auto-detection', () => {
       expect(continueButton()).toBeEnabled();
 
       // A preset pick still works and wins over the in-flight probe.
-      fireEvent.click(screen.getByRole('button', { name: /Open-Zeppelin/ }));
+      fireEvent.click(screen.getByRole('button', { name: /OpenZeppelin/ }));
       fireEvent.click(continueButton());
       expect(onSubmit).toHaveBeenCalledWith({
         walletType: WalletType.Guardian,
@@ -429,11 +429,11 @@ describe('ImportRecoveryMethodScreen — guardian auto-detection', () => {
   it('keeps the preset grid behind a disclosure once a guardian is detected', () => {
     renderScreen({ probe: detected() });
 
-    expect(screen.queryByRole('button', { name: /Open-Zeppelin/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /OpenZeppelin/ })).not.toBeInTheDocument();
 
     fireEvent.click(customToggleAfterDetection());
 
-    expect(screen.getByRole('button', { name: /Open-Zeppelin/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /OpenZeppelin/ })).toBeInTheDocument();
     expect(screen.getByTestId('guardian-input')).toBeInTheDocument();
   });
 
@@ -473,7 +473,7 @@ describe('ImportRecoveryMethodScreen — guardian auto-detection', () => {
     expect(screen.getByTestId('guardian-not-detected')).toBeInTheDocument();
     expect(screen.getByText('guardianNotDetected')).toBeInTheDocument();
     // Exactly today's screen underneath.
-    expect(screen.getByRole('button', { name: /Open-Zeppelin/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /OpenZeppelin/ })).toBeInTheDocument();
     expect(screen.getByText('guardianEndpoint')).toBeInTheDocument();
     expect(continueButton()).toBeEnabled();
 
@@ -505,7 +505,7 @@ describe('ImportRecoveryMethodScreen — guardian auto-detection', () => {
     renderScreen({ probe: { status: 'error', message: 'network down' } });
 
     expect(screen.getByTestId('guardian-not-detected')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Open-Zeppelin/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /OpenZeppelin/ })).toBeInTheDocument();
     expect(continueButton()).toBeEnabled();
   });
 


### PR DESCRIPTION
Closes #464

## Problem

Guardian provider names were spelled inconsistently across the wallet — "Open-Zeppelin"/"Open Zeppelin" vs "OpenZeppelin", "Lambda Class"/"Lambda" vs "LambdaClass" — and the E2E operator hardcoded its own spelling separate from the config, which is how the drift reached production.

## Fix

Introduce a single canonical `GUARDIAN_BRAND_NAME` mapping in `networks-config.ts` and source every provider display field from it:
- `GUARDIAN_OPTIONS` (open-zeppelin, gateway, lambda-class) — `name`/`operatedBy`.
- The E2E-only `open-zeppelin-b` operator in `constants.ts`.
- Gateway's descriptive name derives too (`${brand.gateway} Operator`) so it can't drift.

Components already read display names from `GUARDIAN_OPTIONS` (single source), so fixing the config fixes onboarding, Settings, Activity, recovery and success/error copy. Slug IDs (`open-zeppelin`, `lambda-class`) are keys and left unchanged; Koda is untouched (already canonical).

## Tests

- New `networks-config.test.ts` pins the canonical spellings and adds a negative denylist guard against the known bad spellings.
- `constants.test.ts` now also asserts the E2E operator's canonical name.
- Updated the existing suites that asserted the old spellings. All affected suites green (93 tests); broad guardian/onboarding sweep green (610 tests).

Built test-first (TDD). Reviewed over 4 loops; nothing keys off the display strings at runtime, so no behavior change beyond the corrected text.