### PR TITLE
fix(ios): keep Payment Sent screen until user action

### DIFF
--- a/src/screens/generating-transaction/GeneratingTransaction.test.tsx
+++ b/src/screens/generating-transaction/GeneratingTransaction.test.tsx
@@ -332,7 +332,7 @@ describe('GeneratingTransactionPage container effects', () => {
     act(() => root.unmount());
   });
 
-  it('auto-closes (navigate home) when the row reaches a terminal state and auto-close is enabled', async () => {
+  it('auto-closes (navigate home) when the row fails and auto-close is enabled', async () => {
     isAutoCloseEnabledMock.mockReturnValue(true);
     navigateMock.mockClear();
     window.location.hash = '#/generating-transaction/tx-1';
@@ -340,8 +340,8 @@ describe('GeneratingTransactionPage container effects', () => {
 
     const { root } = await mount(<GeneratingTransactionPage txId="tx-1" />);
 
-    // Row transitions to Completed → schedules auto-close.
-    mockRowState = { row: makeTx({ status: 2, transactionId: '0xhash' }), loaded: true };
+    // Row transitions to Failed → schedules auto-close.
+    mockRowState = { row: makeTx({ status: 3, transactionId: '0xhash' }), loaded: true };
     await act(async () => {
       root.render(<GeneratingTransactionPage txId="tx-1" />);
     });
@@ -353,6 +353,30 @@ describe('GeneratingTransactionPage container effects', () => {
     await flush();
 
     expect(navigateMock).toHaveBeenCalledWith('/');
+    isAutoCloseEnabledMock.mockReturnValue(false);
+    act(() => root.unmount());
+  });
+
+  it('does not auto-close after a successful completion when auto-close is enabled', async () => {
+    isAutoCloseEnabledMock.mockReturnValue(true);
+    navigateMock.mockClear();
+    window.location.hash = '#/generating-transaction/tx-1';
+    mockRowState = { row: makeTx({ stage: 'submitting' }), loaded: true };
+
+    const { root } = await mount(<GeneratingTransactionPage txId="tx-1" />);
+
+    mockRowState = { row: makeTx({ status: 2, transactionId: '0xhash' }), loaded: true };
+    await act(async () => {
+      root.render(<GeneratingTransactionPage txId="tx-1" />);
+    });
+    await flush();
+
+    await act(async () => {
+      jest.advanceTimersByTime(10_000);
+    });
+    await flush();
+
+    expect(navigateMock).not.toHaveBeenCalled();
     isAutoCloseEnabledMock.mockReturnValue(false);
     act(() => root.unmount());
   });

--- a/src/screens/generating-transaction/GeneratingTransaction.tsx
+++ b/src/screens/generating-transaction/GeneratingTransaction.tsx
@@ -136,12 +136,11 @@ export const GeneratingTransactionPage: FC<GeneratingTransactionPageProps> = ({ 
     }
   }, [status, active?.transactionId]);
 
-  // Auto-close once the tx reaches a terminal state (mirrors the old
-  // "left flight" transition, now derived from status rather than the tx
-  // dropping out of the uncompleted list).
+  // Auto-close once the tx reaches a terminal state, but keep the success receipt
+  // visible until the user chooses Done or View in activities (#472).
   const prevTransactionComplete = useRef(false);
   useEffect(() => {
-    if (transactionComplete && !prevTransactionComplete.current) {
+    if (transactionComplete && !prevTransactionComplete.current && hasErrors) {
       new Promise(res => setTimeout(res, AUTO_CLOSE_DELAY_MS)).then(async () => {
         await trackEvent('GeneratingTransaction Page Closed Automatically');
         isAutoCloseEnabled() && onClose();
@@ -149,7 +148,7 @@ export const GeneratingTransactionPage: FC<GeneratingTransactionPageProps> = ({ 
     }
 
     prevTransactionComplete.current = transactionComplete;
-  }, [transactionComplete, trackEvent, onClose]);
+  }, [transactionComplete, hasErrors, trackEvent, onClose]);
 
   const lastCompletedTxHash = useWalletStore(state => state.lastCompletedTxHash);
   const receiptTxHash = lastCompletedTxHash ?? active?.transactionId ?? null;


### PR DESCRIPTION
## Summary

Successful transactions auto-closed the Payment Sent screen after a short delay. Keep the receipt until the user taps Done or View in activities. Failed transactions still auto-close when enabled.

## Testing

- `yarn test GeneratingTransaction --watchAll=false` — 32 passed

Closes #472