### PR TITLE
fix(history): reconcile swap order status with confirmed settlement (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [FIX][all] **A settled swap's order status no longer sticks on "Active" with a flickering spinner.** The order-tracking row reconciles the on-chain order lineage with the settlement this wallet has already observed: once the settlement (or reclaim) consume notes are seen locally, the status shows "Filled"/"Reclaimed" immediately, even if the lineage poll still lags behind reporting the order as active. The polling indicator is now tied to whether the order is genuinely still resolving rather than to each individual in-flight poll, so it no longer blinks off and on every couple of seconds while an order is active (most visible on iOS).
 - [FIX][all] **Token metadata fetched during sync is now persisted immediately.** Subsequent syncs reuse the existing metadata cache instead of repeatedly requesting the same faucet account from the node.
 - [FIX][all] **A mistyped recipient address is rejected in the Send screen instead of failing after guardian approval.** Miden addresses are now validated with the SDK's full bech32 decode (`Address.fromBech32`) as you type, scan, or pick a contact — previously only the `mtst1`/`mm1`/`mdev1` prefix was checked, so a typo'd address sailed through to the transaction pipeline and surfaced as a bech32 error in Activity. A well-formed address for a different Miden network (e.g. a mainnet `mm1…` address on a testnet build) gets its own "different Miden network" message.
 ### Changes

--- a/src/app/templates/history/HistoryDetails.test.tsx
+++ b/src/app/templates/history/HistoryDetails.test.tsx
@@ -575,7 +575,7 @@ describe('HistoryDetails', () => {
       expect(screen.queryByTestId('swap-order-status')).not.toBeInTheDocument();
     });
 
-    it('shows a polling indicator while refreshing an active order', async () => {
+    it('shows a steady tracking indicator while the order is active', async () => {
       let resolveRefresh!: (tracking: {
         orderId: string;
         state: string;
@@ -601,13 +601,15 @@ describe('HistoryDetails', () => {
       );
       await renderAndLoad();
 
-      expect(screen.queryByTestId('swap-order-polling')).not.toBeInTheDocument();
+      // The order is active, so the tracking indicator shows steadily — not only
+      // while a poll is momentarily in flight (that per-poll flicker was #486).
+      expect(screen.getByTestId('swap-order-status')).toHaveTextContent('orderStatusActive');
+      expect(screen.getByTestId('swap-order-polling')).toHaveTextContent('loading');
 
+      // It stays put across the next background poll rather than blinking off/on.
       await act(async () => {
         jest.advanceTimersByTime(2000);
       });
-
-      expect(screen.getByTestId('swap-order-status')).toHaveTextContent('orderStatusActive');
       expect(screen.getByTestId('swap-order-polling')).toHaveTextContent('loading');
 
       await act(async () => {
@@ -623,6 +625,50 @@ describe('HistoryDetails', () => {
 
       expect(screen.queryByTestId('swap-order-polling')).not.toBeInTheDocument();
       expect(screen.getByTestId('swap-order-status')).toHaveTextContent('orderStatusFilled');
+    });
+
+    it('reconciles to Filled once settlement notes are seen locally, even if the lineage still reports active (#486)', async () => {
+      mockGetSwapTokenByFaucetId.mockReturnValue({ symbol: 'ETH', decimals: 8 });
+      // The on-chain lineage lags — it keeps reporting the order as still active...
+      mockTrackOrderId.mockResolvedValue({
+        orderId: '10',
+        state: 'active',
+        currentDepth: 1,
+        remainingOffered: 0n,
+        remainingRequested: 700n
+      });
+      // ...but this wallet has already observed the settlement consume note.
+      mockGetSwapSettlementNotes.mockResolvedValue({ settled: ['note-x'], reclaimed: [] });
+      mockGetTransactionById.mockResolvedValue(
+        swapTx({ orderId: 10n, requestedFaucetId: 'req-faucet', requestedAmount: 1000n })
+      );
+
+      await renderAndLoad();
+
+      // Local settlement is the source of truth: show Filled and drop the spinner
+      // instead of sitting on "Active" with a flickering loader.
+      expect(screen.getByTestId('swap-order-status')).toHaveTextContent('orderStatusFilled');
+      expect(screen.queryByTestId('swap-order-polling')).not.toBeInTheDocument();
+    });
+
+    it('reconciles to Reclaimed when the local settlement is a reclaim (#486)', async () => {
+      mockGetSwapTokenByFaucetId.mockReturnValue({ symbol: 'ETH', decimals: 8 });
+      mockTrackOrderId.mockResolvedValue({
+        orderId: '11',
+        state: 'active',
+        currentDepth: 1,
+        remainingOffered: 0n,
+        remainingRequested: 700n
+      });
+      mockGetSwapSettlementNotes.mockResolvedValue({ settled: [], reclaimed: ['note-r'] });
+      mockGetTransactionById.mockResolvedValue(
+        swapTx({ orderId: 11n, requestedFaucetId: 'req-faucet', requestedAmount: 1000n })
+      );
+
+      await renderAndLoad();
+
+      expect(screen.getByTestId('swap-order-status')).toHaveTextContent('orderStatusReclaimed');
+      expect(screen.queryByTestId('swap-order-polling')).not.toBeInTheDocument();
     });
 
     it('backs off on unresolved polls and gives up after the cap', async () => {

--- a/src/app/templates/history/HistoryDetails.test.tsx
+++ b/src/app/templates/history/HistoryDetails.test.tsx
@@ -671,6 +671,29 @@ describe('HistoryDetails', () => {
       expect(screen.queryByTestId('swap-order-polling')).not.toBeInTheDocument();
     });
 
+    it('treats a mixed settle+reclaim order as Filled — a settle consume outranks a reclaim (#486)', async () => {
+      mockGetSwapTokenByFaucetId.mockReturnValue({ symbol: 'ETH', decimals: 8 });
+      mockTrackOrderId.mockResolvedValue({
+        orderId: '12',
+        state: 'active',
+        currentDepth: 1,
+        remainingOffered: 0n,
+        remainingRequested: 700n
+      });
+      // Paybacks settled in one consume tick, the tip reclaimed in another — both
+      // buckets are non-empty. The swap-row chip stamps "Settled" (funds received),
+      // so this row must agree rather than showing "Reclaimed".
+      mockGetSwapSettlementNotes.mockResolvedValue({ settled: ['note-s'], reclaimed: ['note-r'] });
+      mockGetTransactionById.mockResolvedValue(
+        swapTx({ orderId: 12n, requestedFaucetId: 'req-faucet', requestedAmount: 1000n })
+      );
+
+      await renderAndLoad();
+
+      expect(screen.getByTestId('swap-order-status')).toHaveTextContent('orderStatusFilled');
+      expect(screen.queryByTestId('swap-order-polling')).not.toBeInTheDocument();
+    });
+
     it('backs off on unresolved polls and gives up after the cap', async () => {
       mockGetSwapTokenByFaucetId.mockReturnValue({ symbol: 'ETH', decimals: 8 });
       mockTrackOrderId.mockResolvedValue(null); // never resolves the order

--- a/src/app/templates/history/HistoryDetails.tsx
+++ b/src/app/templates/history/HistoryDetails.tsx
@@ -625,6 +625,19 @@ export const HistoryDetails: FC<HistoryDetailsProps> = ({ transactionId }) => {
     }
   };
 
+  // Reconcile the (potentially lagging) on-chain order lineage with settlement
+  // this wallet has already observed: once the settlement/reclaim consume notes
+  // are seen locally, the order is terminal regardless of what the lineage poll
+  // still reports. Otherwise the status sits on "Active" with a per-poll
+  // flickering spinner after the swap has actually settled (#486).
+  const settledOrderState: SwapOrderState | null = settlementFound
+    ? settlementNotes && settlementNotes.reclaimed.length > 0
+      ? 'reclaimed'
+      : 'filled'
+    : null;
+  const displayOrderState: SwapOrderState | null = settledOrderState ?? swapTracking?.state ?? null;
+  const orderStillResolving = displayOrderState === 'active';
+
   // How much of the requested amount has been filled so far, derived from the
   // original requested amount and the lineage's still-outstanding remainder.
   const filledRequested =
@@ -1073,12 +1086,12 @@ export const HistoryDetails: FC<HistoryDetailsProps> = ({ transactionId }) => {
                 <div className="mt-5">
                   <DetailCard title={t('orderTracking')}>
                     <DetailRow label={t('orderStatus')} isLast={!swapTracking}>
-                      {swapTracking ? (
+                      {displayOrderState ? (
                         <div className="flex items-center gap-2">
                           <span data-testid="swap-order-status" className="text-sm text-heading-gray font-medium">
-                            {orderStatusLabel(swapTracking.state)}
+                            {orderStatusLabel(displayOrderState)}
                           </span>
-                          {trackingLoading && (
+                          {orderStillResolving && (
                             <span
                               data-testid="swap-order-polling"
                               className="flex items-center gap-1.5 text-xs font-medium text-text-muted"

--- a/src/app/templates/history/HistoryDetails.tsx
+++ b/src/app/templates/history/HistoryDetails.tsx
@@ -630,10 +630,14 @@ export const HistoryDetails: FC<HistoryDetailsProps> = ({ transactionId }) => {
   // are seen locally, the order is terminal regardless of what the lineage poll
   // still reports. Otherwise the status sits on "Active" with a per-poll
   // flickering spinner after the swap has actually settled (#486).
+  // A settle consume outranks a reclaim one — funds were received — matching
+  // `repairSettlementStamp`'s precedence so this row agrees with the swap-row
+  // chip when an order carries both kinds (e.g. paybacks settled one tick, tip
+  // reclaimed another).
   const settledOrderState: SwapOrderState | null = settlementFound
-    ? settlementNotes && settlementNotes.reclaimed.length > 0
-      ? 'reclaimed'
-      : 'filled'
+    ? settlementNotes && settlementNotes.settled.length > 0
+      ? 'filled'
+      : 'reclaimed'
     : null;
   const displayOrderState: SwapOrderState | null = settledOrderState ?? swapTracking?.state ?? null;
   const orderStillResolving = displayOrderState === 'active';


### PR DESCRIPTION
Closes #486

## Problem

On iOS, a swap's **order status** on the transaction-details page keeps showing a loading/glitching state even after the swap has actually settled on-chain — the status can sit on "Active" with a spinner that flickers on and off every ~2 seconds, and never reconciles to the final status without navigating away, refreshing, or relaunching.

## Root cause

`HistoryDetails.tsx` derived the order-status row entirely from the on-chain order-**lineage** poll (`trackOrderId`):

- **Status label** came from `swapTracking.state`. That lineage poll can lag behind the settlement this wallet has *already observed locally* (the completed consume note), so after the swap settles the label stays "Active" until the lineage catches up.
- **The spinner** was gated on `trackingLoading` — a flag set true at the *start of each individual poll* and false in its `finally`. Because the poll reschedules every 2s while the lineage reports `active`, the indicator blinked off/on with every poll.

## Fix

Reconcile the (possibly lagging) lineage state with locally-observed settlement, and tie the spinner to whether the order is *genuinely* still resolving rather than to each in-flight poll:

```ts
const settledOrderState = settlementFound
  ? (settlementNotes && settlementNotes.settled.length > 0 ? 'filled' : 'reclaimed')
  : null;
const displayOrderState = settledOrderState ?? swapTracking?.state ?? null;
const orderStillResolving = displayOrderState === 'active';
```

- Once the settlement/reclaim consume notes are seen locally, the status shows **Filled**/**Reclaimed** immediately, regardless of what the lineage still reports.
- `settledAt`-style precedence is preserved: **a settle consume outranks a reclaim** ("funds were received"), matching `repairSettlementStamp` and the swap-row chip, so a mixed settle+reclaim order shows "Filled" consistently in both places.
- The spinner shows steadily while the order is genuinely active and disappears once terminal — no more per-poll flicker.
- Local settlement is only ever observed for a *terminal or expired* order (`settlement.ts` skips active-unexpired orders), so an in-progress partial fill still correctly falls through to the lineage's "Active".

The order-tracking card is gated on `swap + orderId` (not on the lineage), so it renders and reconciles even when the lineage poll never resolves.

## Tests

`HistoryDetails.test.tsx`:
- Reworked the polling-indicator test to assert the indicator is **steady** across a background poll (not blinking off between polls).
- New: reconciles to **Filled** when settlement is seen locally but the lineage still reports active.
- New: reconciles to **Reclaimed** for a local reclaim settlement.
- New: a mixed settle+reclaim order shows **Filled** (settle outranks reclaim), agreeing with the swap-row chip.

All 50 tests in the file pass; `tsc` and `eslint` clean. Each new test was confirmed RED against the unpatched derivation before the fix.